### PR TITLE
chore: fix anvil tests

### DIFF
--- a/packages/sdk/tests/setup/anvil.ts
+++ b/packages/sdk/tests/setup/anvil.ts
@@ -2,7 +2,7 @@ import { execa, type ExecaChildProcess } from "execa";
 import { Writable } from "node:stream";
 
 export interface AnvilOptions {
-  portNumber: number;
+  port: number;
   forkUrl?: string | undefined;
   forkBlockNumber?: number | bigint | undefined;
   startUpTimeout?: number;
@@ -43,14 +43,14 @@ export class Anvil {
     const controller = new AbortController();
     const recorder = new LogRecorder((message) => {
       // We know that anvil has started up when it prints this message.
-      if (message.includes(`Listening on 127.0.0.1:${opts.portNumber}`)) {
+      if (message.includes(`Listening on 127.0.0.1:${opts.port}`)) {
         resolve(instance);
       }
     });
 
     // TODO: We could expose a lot more options here. We could also extract this into a dedicated command builder.
     const args = Object.entries({
-      "--port": `${opts.portNumber}`,
+      "--port": `${opts.port}`,
       ...(opts.forkUrl ? { "--fork-url": opts.forkUrl } : {}),
       ...(opts.forkBlockNumber ? { "--fork-block-number": `${Number(opts.forkBlockNumber)}` } : {}),
     }).flatMap(([key, value]) => [key, value]);
@@ -94,7 +94,7 @@ export class Anvil {
   }
 
   public get port() {
-    return this.options.portNumber;
+    return this.options.port;
   }
 
   public get logs() {

--- a/packages/sdk/tests/setup/globalSetup.ts
+++ b/packages/sdk/tests/setup/globalSetup.ts
@@ -7,7 +7,7 @@ export default async function () {
     proxyPort: 8545,
     proxyHostname: "::",
     anvilOptions: {
-      portRange: portNumbers(8546, 8645),
+      portRange: portNumbers(8546, 8546 + 100),
       forkBlockNumber: FORK_BLOCK_NUMBER,
       forkUrl: FORK_URL,
     },

--- a/packages/sdk/tests/setup/globalSetup.ts
+++ b/packages/sdk/tests/setup/globalSetup.ts
@@ -1,88 +1,12 @@
-import { Server, createServer } from "node:http";
-import { createProxyServer } from "http-proxy";
-import { Anvil } from "./anvil.js";
-import getPort from "get-port";
-import { FORK_BLOCK_NUMBER, FORK_URL } from "../constants.js";
-
-const instances = new Map<number, Promise<Anvil>>();
-
-async function getOrCreateAnvil(id: number) {
-  let anvil = instances.get(id);
-
-  if (anvil === undefined) {
-    // rome-ignore lint/suspicious/noAsyncPromiseExecutor: we are using try/catch here correctly
-    anvil = new Promise(async (resolve, reject) => {
-      try {
-        resolve(
-          Anvil.start({
-            portNumber: await getPort(),
-            forkUrl: FORK_URL,
-            forkBlockNumber: FORK_BLOCK_NUMBER,
-            startUpTimeout: 10000,
-          }),
-        );
-      } catch (error) {
-        reject(error);
-      }
-    });
-
-    instances.set(id, anvil);
-
-    return anvil;
-  }
-
-  return anvil;
-}
-
-function getIdFromUrl(url?: string) {
-  const path = url ? new RegExp("^[0-9]+$").exec(url.slice(1))?.[0] : undefined;
-  const id = path ? Number(path) : undefined;
-
-  return id;
-}
+import { stopAnvilInstances, createAnvilProxy } from "./proxy.js";
 
 export default async function () {
-  const server = await new Promise<Server>((resolve, reject) => {
-    const proxy = createProxyServer({
-      ignorePath: true,
-      ws: true,
-    });
-
-    const server = createServer(async (req, res) => {
-      const id = getIdFromUrl(req.url);
-      if (id === undefined) {
-        res.writeHead(404).end("Missing worker id in request");
-      } else {
-        const anvil = await getOrCreateAnvil(id);
-        proxy.web(req, res, {
-          target: `http://localhost:${anvil.port}`,
-        });
-      }
-    });
-
-    server.on("upgrade", async (req, socket, head) => {
-      const id = getIdFromUrl(req.url);
-      if (id === undefined) {
-        socket.destroy(new Error("Missing worker id in request"));
-      } else {
-        const anvil = await getOrCreateAnvil(id);
-        proxy.ws(req, socket, head, {
-          target: `ws://localhost:${anvil.port}`,
-        });
-      }
-    });
-
-    server.on("listening", () => resolve(server));
-    server.on("error", (error) => reject(error));
-
-    server.listen("8545");
-  });
+  const server = await createAnvilProxy();
 
   return async () => {
     // Clean up all anvil instances and the anvil pool manager itself.
-    const anvils = Array.from(instances.values());
     await Promise.allSettled([
-      ...anvils.map(async (anvil) => (await anvil).exit()),
+      stopAnvilInstances(),
       new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));
       }),

--- a/packages/sdk/tests/setup/globalSetup.ts
+++ b/packages/sdk/tests/setup/globalSetup.ts
@@ -1,7 +1,17 @@
+import { portNumbers } from "get-port";
 import { stopAnvilInstances, createAnvilProxy } from "./proxy.js";
+import { FORK_BLOCK_NUMBER, FORK_URL } from "../constants.js";
 
 export default async function () {
-  const server = await createAnvilProxy();
+  const server = await createAnvilProxy({
+    proxyPort: 8545,
+    proxyHostname: "::",
+    anvilOptions: {
+      portRange: portNumbers(8546, 8645),
+      forkBlockNumber: FORK_BLOCK_NUMBER,
+      forkUrl: FORK_URL,
+    },
+  });
 
   return async () => {
     // Clean up all anvil instances and the anvil pool manager itself.

--- a/packages/sdk/tests/setup/proxy.ts
+++ b/packages/sdk/tests/setup/proxy.ts
@@ -33,7 +33,7 @@ export function createAnvilProxy({
         });
         const anvil = await getOrCreateAnvilInstance(id, { ...anvilOptions, port });
         proxy.web(req, res, {
-          target: `http://localhost:${anvil.port}`,
+          target: `http://127.0.0.1:${anvil.port}`,
         });
       }
     });
@@ -48,7 +48,7 @@ export function createAnvilProxy({
         });
         const anvil = await getOrCreateAnvilInstance(id, { ...anvilOptions, port });
         proxy.ws(req, socket, head, {
-          target: `ws://localhost:${anvil.port}`,
+          target: `ws://127.0.0.1:${anvil.port}`,
         });
       }
     });

--- a/packages/sdk/tests/setup/proxy.ts
+++ b/packages/sdk/tests/setup/proxy.ts
@@ -1,0 +1,91 @@
+import { Server, createServer } from "node:http";
+import { createProxyServer } from "http-proxy";
+import { Anvil } from "./anvil.js";
+import getPort from "get-port";
+import { FORK_BLOCK_NUMBER, FORK_URL } from "../constants.js";
+
+export interface AnvilProxyOptions {
+  port?: number;
+  hostname?: string;
+}
+
+export function createAnvilProxy({ port = 8545, hostname = "::" }: AnvilProxyOptions = {}) {
+  // rome-ignore lint/suspicious/noAsyncPromiseExecutor: this is fine ...
+  return new Promise<Server>(async (resolve, reject) => {
+    const proxy = createProxyServer({
+      ignorePath: true,
+      ws: true,
+    });
+
+    const server = createServer(async (req, res) => {
+      const id = getIdFromUrl(req.url);
+      if (id === undefined) {
+        res.writeHead(404).end("Missing worker id in request");
+      } else {
+        const anvil = await getOrCreateAnvilInstance(id);
+        proxy.web(req, res, {
+          target: `http://localhost:${anvil.port}`,
+        });
+      }
+    });
+
+    server.on("upgrade", async (req, socket, head) => {
+      const id = getIdFromUrl(req.url);
+      if (id === undefined) {
+        socket.destroy(new Error("Missing worker id in request"));
+      } else {
+        const anvil = await getOrCreateAnvilInstance(id);
+        proxy.ws(req, socket, head, {
+          target: `ws://localhost:${anvil.port}`,
+        });
+      }
+    });
+
+    server.on("listening", () => resolve(server));
+    server.on("error", (error) => reject(error));
+
+    server.listen(port, hostname);
+  });
+}
+
+const instances = new Map<number, Promise<Anvil>>();
+
+export async function stopAnvilInstances() {
+  const anvils = Array.from(instances.values());
+  await Promise.allSettled(anvils.map(async (anvil) => (await anvil).exit()));
+}
+
+async function getOrCreateAnvilInstance(id: number) {
+  let anvil = instances.get(id);
+
+  if (anvil === undefined) {
+    // rome-ignore lint/suspicious/noAsyncPromiseExecutor: we need this to be synchronous
+    anvil = new Promise(async (resolve, reject) => {
+      try {
+        resolve(
+          Anvil.start({
+            portNumber: await getPort(),
+            forkUrl: FORK_URL,
+            forkBlockNumber: FORK_BLOCK_NUMBER,
+            startUpTimeout: 10000,
+          }),
+        );
+      } catch (error) {
+        reject(error);
+      }
+    });
+
+    instances.set(id, anvil);
+
+    return anvil;
+  }
+
+  return anvil;
+}
+
+function getIdFromUrl(url?: string) {
+  const path = url ? new RegExp("^[0-9]+$").exec(url.slice(1))?.[0] : undefined;
+  const id = path ? Number(path) : undefined;
+
+  return id;
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR replaces `get-port` with `port-numbers` and updates the `Anvil` class to use `port` instead of `portNumber`. It also refactors `globalSetup` and `proxy` modules to use the updated `Anvil` class.

### Detailed summary
- Replace `get-port` with `port-numbers`
- Update `Anvil` class to use `port` instead of `portNumber`
- Refactor `globalSetup` module to use updated `Anvil` class
- Refactor `proxy` module to use updated `Anvil` class and `port-numbers`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->