### PR TITLE
docs: document all the things

### DIFF
--- a/packages/sdk/src/actions/addAssetManagers.ts
+++ b/packages/sdk/src/actions/addAssetManagers.ts
@@ -3,12 +3,12 @@ import { prepareFunctionParams } from "../utils/viem.js";
 import { decodeFunctionData, getAbiItem, type Address } from "viem";
 import type { Hex } from "viem";
 
-export interface AddAssetManagersParams {
+export type AddAssetManagersParams = {
   /**
    * The addresses of the asset managers to add.
    */
   managers: readonly Address[];
-}
+};
 
 /**
  * Prepares the parameters for the `addAssetManagers` function.

--- a/packages/sdk/src/actions/buyBackProtocolFeeShares.ts
+++ b/packages/sdk/src/actions/buyBackProtocolFeeShares.ts
@@ -3,12 +3,12 @@ import { prepareFunctionParams } from "../utils/viem.js";
 import { decodeFunctionData, getAbiItem } from "viem";
 import type { Hex } from "viem";
 
-export interface BuyBackProtocolFeeSharesParams {
+export type BuyBackProtocolFeeSharesParams = {
   /**
    * The amount of shares to buy back.
    */
   sharesAmount: bigint;
-}
+};
 
 /**
  * Prepares the parameters for the `buyBackProtocolFeeShares` function call.

--- a/packages/sdk/src/actions/buyShares.ts
+++ b/packages/sdk/src/actions/buyShares.ts
@@ -64,16 +64,18 @@ export type GetExpectedShareQuantityParams = Omit<BuySharesParams, "minSharesQua
  *
  * @returns The expected number of shares to receive.
  * @params client The public client to use to get the expected number of shares to receive.
- * @param params The parameters to use to get the expected number of shares to receive.
  */
-export async function getExpectedShareQuantity(client: PublicClient, params: GetExpectedShareQuantityParams) {
+export async function getExpectedShareQuantity(
+  client: PublicClient,
+  { comptrollerProxy, investmentAmount, sharesBuyer }: GetExpectedShareQuantityParams,
+) {
   const { result } = await simulateContract(client, {
     ...prepareBuySharesParams({
-      investmentAmount: params.investmentAmount,
+      investmentAmount: investmentAmount,
       minSharesQuantity: 1n,
     }),
-    account: params.sharesBuyer,
-    address: params.comptrollerProxy,
+    account: sharesBuyer,
+    address: comptrollerProxy,
   });
 
   return result;

--- a/packages/sdk/src/actions/callOnExtension.ts
+++ b/packages/sdk/src/actions/callOnExtension.ts
@@ -3,12 +3,26 @@ import { prepareFunctionParams } from "../utils/viem.js";
 import { decodeFunctionData, getAbiItem, type Address } from "viem";
 import type { Hex } from "viem";
 
-export interface CallOnExtensionParams {
+export type CallOnExtensionParams = {
+  /**
+   * The address of the extension to call.
+   */
   extension: Address;
+  /**
+   * The action ID of the extension to call.
+   */
   actionId: bigint;
+  /**
+   * The encoded arguments to pass to the extension.
+   */
   callArgs: Hex;
-}
+};
 
+/**
+ * Prepare the parameters for the `callOnExtension` function.
+ *
+ * @returns The prepared parameters to be encoded.
+ */
 export function prepareCallOnExtensionParams({ extension, actionId, callArgs }: CallOnExtensionParams) {
   return prepareFunctionParams({
     abi: getAbiItem({ abi: IComptroller, name: "callOnExtension" }),
@@ -16,6 +30,12 @@ export function prepareCallOnExtensionParams({ extension, actionId, callArgs }: 
   });
 }
 
+/**
+ * Decodes the parameters for the `callOnExtension` function.
+ *
+ * @param params The encoded parameters.
+ * @returns The decoded parameters.
+ */
 export function decodeCallOnExtensionParams(params: Hex): CallOnExtensionParams {
   const abi = getAbiItem({ abi: IComptroller, name: "callOnExtension" });
   const decoded = decodeFunctionData({

--- a/packages/sdk/src/actions/claimOwnership.ts
+++ b/packages/sdk/src/actions/claimOwnership.ts
@@ -2,6 +2,11 @@ import { IVault } from "@enzymefinance/abis/IVault";
 import { prepareFunctionParams } from "../../src/utils/viem.js";
 import { getAbiItem } from "viem";
 
+/**
+ * Prepare the parameters for the `claimOwnership` function.
+ *
+ * @returns The prepared parameters to be encoded.
+ */
 export function prepareClaimOwnershipParams() {
   return prepareFunctionParams({
     abi: getAbiItem({ abi: IVault, name: "claimOwnership" }),

--- a/packages/sdk/src/actions/getSharesActionTimelock.ts
+++ b/packages/sdk/src/actions/getSharesActionTimelock.ts
@@ -1,14 +1,22 @@
 import type { Address, PublicClient } from "viem";
 import { IComptroller } from "@enzymefinance/abis/IComptroller";
+import { readContract } from "viem/contract";
 
-export function getSharesActionTimelock({
-  publicClient,
-  comptrollerProxy,
-}: {
-  publicClient: PublicClient;
+export type GetSharesActionTimelockParams = {
+  /**
+   * The address of the `ComptrollerProxy` contract of the vault.
+   */
   comptrollerProxy: Address;
-}) {
-  return publicClient.readContract({
+};
+
+/**
+ * Get the shares action timelock.
+ *
+ * @param client The public client to use to read the contract.
+ * @returns The shares action timelock in seconds.
+ */
+export function getSharesActionTimelock(client: PublicClient, { comptrollerProxy }: GetSharesActionTimelockParams) {
+  return readContract(client, {
     abi: IComptroller,
     address: comptrollerProxy,
     functionName: "getSharesActionTimelock",

--- a/packages/sdk/src/actions/prepareAdapterTrade.ts
+++ b/packages/sdk/src/actions/prepareAdapterTrade.ts
@@ -9,10 +9,23 @@ import { Integration } from "../enums.js";
 
 export type PrepareTradeParams = AaveV2LendTrade | AaveV2RedeemTrade;
 
-export function prepareAdapterTrade({
-  trade,
-  integrationManager,
-}: { trade: PrepareTradeParams; integrationManager: Address }) {
+export type PrepareAdapterTradeParams = {
+  /**
+   * The address of the `IntegrationManager` contract.
+   */
+  integrationManager: Address;
+  /**
+   * The trade to prepare.
+   */
+  trade: PrepareTradeParams;
+};
+
+/**
+ * Prepare a trade to be executed via an integration adapter.
+ *
+ * @returns The prepared arguments to pass to the `callOnExtension` action.
+ */
+export function prepareAdapterTrade({ trade, integrationManager }: PrepareAdapterTradeParams) {
   switch (trade.type) {
     case Integration.AaveV2Lend:
       return prepareCallOnAaveV2LendParams({ integrationManager, callArgs: trade.callArgs });

--- a/packages/sdk/src/actions/redeemSharesForSpecificAssets.ts
+++ b/packages/sdk/src/actions/redeemSharesForSpecificAssets.ts
@@ -3,13 +3,32 @@ import { prepareFunctionParams } from "../utils/viem.js";
 import { decodeFunctionData, getAbiItem, type Address } from "viem";
 import type { Hex } from "viem";
 
-export interface RedeemSharesForSpecificAssetsParams {
-  withdrawalRecipient: Address;
-  sharesQuantity: bigint;
-  payoutAssets: readonly Address[];
-  payoutAssetPercentages: readonly bigint[];
-}
+// TODO: The payout assets & payout asset percentages should be a map instead of two arrays.
 
+export type RedeemSharesForSpecificAssetsParams = {
+  /**
+   * The address to send the redeemed assets to.
+   */
+  withdrawalRecipient: Address;
+  /**
+   * The quantity of shares to redeem.
+   */
+  sharesQuantity: bigint;
+  /**
+   * The list of specific assets to redeem.
+   */
+  payoutAssets: readonly Address[];
+  /**
+   * The list of percentages of the shares to redeem for each asset.
+   */
+  payoutAssetPercentages: readonly bigint[];
+};
+
+/**
+ * Prepare the parameters for the `redeemSharesForSpecificAssets` function.
+ *
+ * @returns The prepared parameters to be encoded.
+ */
 export function prepareRedeemSharesForSpecificAssetsParams({
   withdrawalRecipient,
   sharesQuantity,

--- a/packages/sdk/src/actions/redeemSharesInKind.ts
+++ b/packages/sdk/src/actions/redeemSharesInKind.ts
@@ -3,13 +3,46 @@ import { prepareFunctionParams } from "../utils/viem.js";
 import { decodeFunctionData, getAbiItem, type Address } from "viem";
 import type { Hex } from "viem";
 
-export interface RedeemSharesInKindParams {
+export type RedeemSharesInKindParams = {
+  /**
+   * The address to send the withdrawn assets to.
+   */
   withdrawalReceipient: Address;
+  /**
+   * The quantity of shares to redeem.
+   */
   sharesQuantity: bigint;
+  /**
+   * The list of additional assets to withdraw.
+   *
+   * @remarks
+   *
+   * This is useful for when the user wants to withdraw additional assets that are currently not
+   * tracked by the vault. For example, if the vault received an airdrop but the vault manager
+   * has not yet added the asset to the vault, the user can still withdraw the asset by adding
+   * it to this list.
+   */
   additionalAssets: readonly Address[];
+  /**
+   * The list of assets to skip withdrawal for.
+   *
+   * @remarks
+   *
+   * This is useful for when the user wants to withdraw all assets except for a few. In some
+   * rare cases, transferal of certain assets may be restricted or dysfunctional, so this allows
+   * the user to skip those.
+   *
+   * Note that this essentially means that the user would be redeeming shares for a subset of the
+   * underlying assets they are owed, essentially leaving a portion of their owed assets behind.
+   */
   assetsToSkip: readonly Address[];
-}
+};
 
+/**
+ * Prepare the parameters for the `redeemSharesInKind` function.
+ *
+ * @returns The prepared parameters to be encoded.
+ */
 export function prepareRedeemSharesInKindParams({
   withdrawalReceipient,
   sharesQuantity,

--- a/packages/sdk/src/actions/removeAssetManagers.ts
+++ b/packages/sdk/src/actions/removeAssetManagers.ts
@@ -3,10 +3,21 @@ import { prepareFunctionParams } from "../utils/viem.js";
 import { decodeFunctionData, getAbiItem, type Address } from "viem";
 import type { Hex } from "viem";
 
-export interface RemoveAssetManagersParams {
+/**
+ * The parameters for the `removeAssetManagers` function call.
+ */
+export type RemoveAssetManagersParams = {
+  /**
+   * The addresses of the asset managers to be removed.
+   */
   managers: readonly Address[];
-}
+};
 
+/**
+ * Prepares the parameters for the `removeAssetManagers` function call.
+ *
+ * @returns The prepared parameters to be encoded.
+ */
 export function prepareRemoveAssetManagersParams({ managers }: RemoveAssetManagersParams) {
   return prepareFunctionParams({
     abi: getAbiItem({ abi: IVault, name: "removeAssetManagers" }),
@@ -14,6 +25,11 @@ export function prepareRemoveAssetManagersParams({ managers }: RemoveAssetManage
   });
 }
 
+/**
+ * Decodes the parameters for the `removeAssetManagers` function call.
+ *
+ * @returns The decoded parameters.
+ */
 export function decodeRemoveAssetManagersParams(params: Hex): RemoveAssetManagersParams {
   const abi = getAbiItem({ abi: IVault, name: "removeAssetManagers" });
   const decoded = decodeFunctionData({

--- a/packages/sdk/src/actions/removeNominatedOwner.ts
+++ b/packages/sdk/src/actions/removeNominatedOwner.ts
@@ -2,6 +2,11 @@ import { IVault } from "@enzymefinance/abis/IVault";
 import { prepareFunctionParams } from "../../src/utils/viem.js";
 import { getAbiItem } from "viem";
 
+/**
+ * Prepares the parameters for the `removeNominatedOwner` function call.
+ *
+ * @returns The prepared parameters to be encoded.
+ */
 export function prepareRemoveNominatedOwnerParams() {
   return prepareFunctionParams({
     abi: getAbiItem({ abi: IVault, name: "removeNominatedOwner" }),

--- a/packages/sdk/src/actions/setAutoProtocolFeeSharesBuyback.test.ts
+++ b/packages/sdk/src/actions/setAutoProtocolFeeSharesBuyback.test.ts
@@ -15,7 +15,7 @@ test("setAutoProtocolFeeSharesBuyback should work correctly", async () => {
 
   const { request: setAutoProtocolFeeSharesBuybackTrue } = await publicClient.simulateContract({
     ...prepareSetAutoProtocolFeeSharesBuybackParams({
-      nextAutoProtocolFeeSharesBuyback: true,
+      enabled: true,
     }),
     account: ALICE,
     address: comptrollerProxy,
@@ -39,7 +39,7 @@ test("setAutoProtocolFeeSharesBuyback should work correctly", async () => {
 
   const { request: setAutoProtocolFeeSharesBuybackFalse } = await publicClient.simulateContract({
     ...prepareSetAutoProtocolFeeSharesBuybackParams({
-      nextAutoProtocolFeeSharesBuyback: false,
+      enabled: false,
     }),
     account: ALICE,
     address: comptrollerProxy,
@@ -59,7 +59,7 @@ test("setAutoProtocolFeeSharesBuyback should work correctly", async () => {
 test("should prepare params correctly", () => {
   expect(
     prepareSetAutoProtocolFeeSharesBuybackParams({
-      nextAutoProtocolFeeSharesBuyback: true,
+      enabled: true,
     }),
   ).toMatchInlineSnapshot(`
     {
@@ -68,7 +68,7 @@ test("should prepare params correctly", () => {
           "inputs": [
             {
               "internalType": "bool",
-              "name": "_nextAutoProtocolFeeSharesBuyback",
+              "name": "_enabled",
               "type": "bool",
             },
           ],
@@ -88,7 +88,7 @@ test("should prepare params correctly", () => {
 
 test("should decode params correctly", () => {
   const params = {
-    nextAutoProtocolFeeSharesBuyback: true,
+    enabled: true,
   };
   const prepared = prepareSetAutoProtocolFeeSharesBuybackParams(params);
   const encoded = encodeFunctionData(prepared);

--- a/packages/sdk/src/actions/setAutoProtocolFeeSharesBuyback.test.ts
+++ b/packages/sdk/src/actions/setAutoProtocolFeeSharesBuyback.test.ts
@@ -68,7 +68,7 @@ test("should prepare params correctly", () => {
           "inputs": [
             {
               "internalType": "bool",
-              "name": "_enabled",
+              "name": "_nextAutoProtocolFeeSharesBuyback",
               "type": "bool",
             },
           ],

--- a/packages/sdk/src/actions/setAutoProtocolFeeSharesBuyback.ts
+++ b/packages/sdk/src/actions/setAutoProtocolFeeSharesBuyback.ts
@@ -3,19 +3,30 @@ import { prepareFunctionParams } from "../utils/viem.js";
 import { decodeFunctionData, getAbiItem } from "viem";
 import type { Hex } from "viem";
 
-export interface SetAutoProtocolFeeSharesBuybackParams {
-  nextAutoProtocolFeeSharesBuyback: boolean;
-}
+export type SetAutoProtocolFeeSharesBuybackParams = {
+  /**
+   * Whether to enable or disable the auto buyback of protocol fee shares.
+   */
+  enabled: boolean;
+};
 
-export function prepareSetAutoProtocolFeeSharesBuybackParams({
-  nextAutoProtocolFeeSharesBuyback,
-}: SetAutoProtocolFeeSharesBuybackParams) {
+/**
+ * Prepares the parameters for the `setAutoProtocolFeeSharesBuyback` function call.
+ *
+ * @returns The prepared parameters to be encoded.
+ */
+export function prepareSetAutoProtocolFeeSharesBuybackParams({ enabled }: SetAutoProtocolFeeSharesBuybackParams) {
   return prepareFunctionParams({
     abi: getAbiItem({ abi: IComptroller, name: "setAutoProtocolFeeSharesBuyback" }),
-    args: [nextAutoProtocolFeeSharesBuyback],
+    args: [enabled],
   });
 }
 
+/**
+ * Decodes the parameters for the `setAutoProtocolFeeSharesBuyback` function call.
+ *
+ * @returns The decoded parameters.
+ */
 export function decodeSetAutoProtocolFeeSharesBuybackParams(params: Hex): SetAutoProtocolFeeSharesBuybackParams {
   const abi = getAbiItem({ abi: IComptroller, name: "setAutoProtocolFeeSharesBuyback" });
   const decoded = decodeFunctionData({
@@ -23,9 +34,9 @@ export function decodeSetAutoProtocolFeeSharesBuybackParams(params: Hex): SetAut
     data: params,
   });
 
-  const [nextAutoProtocolFeeSharesBuyback] = decoded.args;
+  const [enabled] = decoded.args;
 
   return {
-    nextAutoProtocolFeeSharesBuyback,
+    enabled,
   };
 }

--- a/packages/sdk/src/actions/setNominatedOwner.test.ts
+++ b/packages/sdk/src/actions/setNominatedOwner.test.ts
@@ -2,15 +2,8 @@ import { expect, test } from "vitest";
 import { publicClient, testActions } from "../../tests/globals.js";
 import { ALICE, BOB, WETH } from "../../tests/constants.js";
 import { IVault } from "@enzymefinance/abis/IVault";
-import { EnzymeError, catchError } from "../errors/catchError.js";
 import { decodeSetNominatedOwnerParams, prepareSetNominatedOwnerParams } from "./setNominatedOwner.js";
 import { encodeFunctionData } from "viem";
-import { ZERO_ADDRESS } from "../constants/misc.js";
-import {
-  SET_NOMINATED_OWNER_ALREADY_NOMINATED,
-  SET_NOMINATED_OWNER_ALREADY_OWNER,
-  SET_NOMINATED_OWNER_CANNOT_BE_EMPTY,
-} from "../errors/errorCodes.js";
 
 test("should set nominated owner correctly", async () => {
   const { vaultProxy } = await testActions.createTestVault({
@@ -39,69 +32,6 @@ test("should set nominated owner correctly", async () => {
   });
 
   expect(newNominatedOwner).toEqual(BOB);
-});
-
-test("should fail if nominated owner is empty", async () => {
-  const { vaultProxy } = await testActions.createTestVault({
-    vaultOwner: ALICE,
-    denominationAsset: WETH,
-  });
-
-  await expect(async () => {
-    try {
-      await testActions.setNominatedOwner({
-        nominatedOwner: ZERO_ADDRESS,
-        account: ALICE,
-        vaultProxy,
-      });
-    } catch (error) {
-      throw catchError(error);
-    }
-  }).rejects.toThrow(new EnzymeError(SET_NOMINATED_OWNER_CANNOT_BE_EMPTY));
-});
-
-test("should fail if nominated owner is already nominated", async () => {
-  const { vaultProxy } = await testActions.createTestVault({
-    vaultOwner: ALICE,
-    denominationAsset: WETH,
-  });
-
-  await testActions.setNominatedOwner({
-    nominatedOwner: BOB,
-    account: ALICE,
-    vaultProxy,
-  });
-
-  await expect(async () => {
-    try {
-      await testActions.setNominatedOwner({
-        nominatedOwner: BOB,
-        account: ALICE,
-        vaultProxy,
-      });
-    } catch (error) {
-      throw catchError(error);
-    }
-  }).rejects.toThrow(new EnzymeError(SET_NOMINATED_OWNER_ALREADY_NOMINATED));
-});
-
-test("should fail if nominated owner is already owner", async () => {
-  const { vaultProxy } = await testActions.createTestVault({
-    vaultOwner: ALICE,
-    denominationAsset: WETH,
-  });
-
-  await expect(async () => {
-    try {
-      await testActions.setNominatedOwner({
-        nominatedOwner: ALICE,
-        account: ALICE,
-        vaultProxy,
-      });
-    } catch (error) {
-      throw catchError(error);
-    }
-  }).rejects.toThrow(new EnzymeError(SET_NOMINATED_OWNER_ALREADY_OWNER));
 });
 
 test("should prepare params correctly", () => {

--- a/packages/sdk/src/actions/setNominatedOwner.test.ts
+++ b/packages/sdk/src/actions/setNominatedOwner.test.ts
@@ -107,7 +107,7 @@ test("should fail if nominated owner is already owner", async () => {
 test("should prepare params correctly", () => {
   expect(
     prepareSetNominatedOwnerParams({
-      nextNominatedOwner: BOB,
+      nominatedOwner: BOB,
     }),
   ).toMatchInlineSnapshot(`
     {
@@ -136,7 +136,7 @@ test("should prepare params correctly", () => {
 
 test("should decode params correctly", () => {
   const params = {
-    nextNominatedOwner: BOB,
+    nominatedOwner: BOB,
   };
 
   const prepared = prepareSetNominatedOwnerParams(params);

--- a/packages/sdk/src/actions/setNominatedOwner.ts
+++ b/packages/sdk/src/actions/setNominatedOwner.ts
@@ -2,17 +2,37 @@ import { IVault } from "@enzymefinance/abis/IVault";
 import { prepareFunctionParams } from "../../src/utils/viem.js";
 import { getAbiItem, type Address, type Hex, decodeFunctionData } from "viem";
 
-export interface PrepareSetNominatedOwnerParams {
-  nextNominatedOwner: Address;
-}
+export type PrepareSetNominatedOwnerParams = {
+  /**
+   * The address of the to-be owner of the vault.
+   *
+   * @remarks
+   *
+   * After a new owner of the vault has been nominated, the to-be owner must accept the
+   * nomination before the ownership will be transferred. This is a safe-guard mechanism
+   * to prevent accidental ownership transfers or ownership transfers to addresses that
+   * the new owner has lost control of or otherwise is unable to transact with.
+   */
+  nominatedOwner: Address;
+};
 
-export function prepareSetNominatedOwnerParams({ nextNominatedOwner }: PrepareSetNominatedOwnerParams) {
+/**
+ * Prepare the parameters for the `setNominatedOwner` function.
+ *
+ * @returns The prepared parameters to be encoded.
+ */
+export function prepareSetNominatedOwnerParams({ nominatedOwner }: PrepareSetNominatedOwnerParams) {
   return prepareFunctionParams({
     abi: getAbiItem({ abi: IVault, name: "setNominatedOwner" }),
-    args: [nextNominatedOwner],
+    args: [nominatedOwner],
   });
 }
 
+/**
+ * Decodes the parameters for the `setNominatedOwner` function.
+ *
+ * @returns The decoded parameters.
+ */
 export function decodeSetNominatedOwnerParams(params: Hex): PrepareSetNominatedOwnerParams {
   const abi = getAbiItem({
     abi: IVault,
@@ -24,9 +44,9 @@ export function decodeSetNominatedOwnerParams(params: Hex): PrepareSetNominatedO
     data: params,
   });
 
-  const [nextNominatedOwner] = decoded.args;
+  const [nominatedOwner] = decoded.args;
 
   return {
-    nextNominatedOwner,
+    nominatedOwner,
   };
 }

--- a/packages/sdk/src/actions/setupVault.ts
+++ b/packages/sdk/src/actions/setupVault.ts
@@ -109,6 +109,8 @@ export function prepareSetupVaultParams({
 
 /**
  * Decode the parameters for the `createNewFund` function.
+ *
+ * @returns The decoded parameters.
  */
 export function decodeSetupVaultParams(params: Hex): SetupVaultParams<FeeSettings[], PolicySettings[]> {
   const abi = getAbiItem({ abi: IFundDeployer, name: "createNewFund" });

--- a/packages/sdk/src/actions/setupVault.ts
+++ b/packages/sdk/src/actions/setupVault.ts
@@ -7,21 +7,69 @@ import { decodeFunctionData, getAbiItem } from "viem";
 import type { Hex, Address } from "viem";
 import type { PartialPick } from "../utils/types.js";
 
-export interface SetupVaultParams {
+export type SetupVaultParams<
+  TFeeSettings extends Hex | FeeSettings[] = Hex | FeeSettings[],
+  TPolicySettings extends Hex | PolicySettings[] = Hex | PolicySettings[],
+> = {
+  /**
+   * The address of the owner of the vault.
+   */
   vaultOwner: Address;
+  /**
+   * The name of the vault.
+   *
+   * @remarks
+   *
+   * This is the ERC20 name of the vault token.
+   */
   vaultName: string;
+  /**
+   * The symbol of the vault.
+   *
+   * @remarks
+   *
+   * This is the ERC20 symbol of the vault token.
+   */
   vaultSymbol: string;
+  /**
+   * The address of the denomination asset of the vault.
+   *
+   * @remarks
+   *
+   * This is the asset that the vault will be denominated in. This asset will be used to
+   * compute the performance of the vault.
+   */
   denominationAsset: Address;
+  /**
+   * The shares action timelock of the vault.
+   *
+   * @remarks
+   *
+   * This is the time in seconds that must pass after shares have been bought they can be transferred
+   * or redeemed. This is a safety mechanism to make certain attacks on & arbitrage of vault shares
+   * more difficult.
+   */
   sharesActionTimelock: bigint;
-  feeSettings: Hex | FeeSettings[];
-  policySettings: Hex | PolicySettings[];
-}
+  /**
+   * The fee settings of the vault.
+   */
+  feeSettings: TFeeSettings;
+  /**
+   * The policy settings of the vault.
+   */
+  policySettings: TPolicySettings;
+};
 
 export type PrepareSetupVaultParamsArgs = PartialPick<
   SetupVaultParams,
   "sharesActionTimelock" | "feeSettings" | "policySettings"
 >;
 
+/**
+ * Prepare the parameters for the `createNewFund` function.
+ *
+ * @returns The prepared parameters to be encoded.
+ */
 export function prepareSetupVaultParams({
   vaultOwner,
   vaultName,
@@ -59,7 +107,10 @@ export function prepareSetupVaultParams({
   });
 }
 
-export function decodeSetupVaultParams(params: Hex): SetupVaultParams {
+/**
+ * Decode the parameters for the `createNewFund` function.
+ */
+export function decodeSetupVaultParams(params: Hex): SetupVaultParams<FeeSettings[], PolicySettings[]> {
   const abi = getAbiItem({ abi: IFundDeployer, name: "createNewFund" });
   const decoded = decodeFunctionData({
     abi: [abi],

--- a/packages/sdk/src/errors/catchError.ts
+++ b/packages/sdk/src/errors/catchError.ts
@@ -5,10 +5,28 @@ import { errorDictionary, type ErrorCode } from "./errorCodes.js";
 export class EnzymeError extends Error {
   public override readonly name = "EnzymeError";
 
+  /**
+   * The machine-readable revert code.
+   */
   public readonly code: ErrorCode;
+
+  /**
+   * The human-readable revert label.
+   */
   public readonly label: string;
+
+  /**
+   * The human-readable revert description.
+   */
   public readonly description: string;
 
+  /**
+   * Creates a new error instance from the given code and cause.
+   *
+   * @param code The protocol specific error code.
+   * @param cause The error cause.
+   * @returns The error instance.
+   */
   public static create(code: ErrorCode, cause: Error): EnzymeError {
     const error = new this(code);
     error.cause = cause;
@@ -27,6 +45,19 @@ export class EnzymeError extends Error {
   }
 }
 
+/**
+ * Catches the given error and returns a protocol specific revert error if possible.
+ *
+ * @remarks
+ *
+ * This function can be used to create a friendlier error message for end users and to more easily
+ * identify the cause of the error. It also provides a way to programmatically identify the error
+ * more easily through the `code` property. This way, developers can catch the error and handle it
+ * in a more granular way without having to parse the error message themselves.
+ *
+ * @param error The error to catch.
+ * @returns The protocol specific error instance or the original error if no match was found.
+ */
 export function catchError<TError extends Error | unknown>(error: TError): TError | EnzymeError {
   if (error instanceof ContractFunctionExecutionError) {
     if (error.cause instanceof ContractFunctionRevertedError) {

--- a/packages/sdk/src/errors/errorCodes.ts
+++ b/packages/sdk/src/errors/errorCodes.ts
@@ -124,11 +124,20 @@ export const errorCodes = [
 
 export type ErrorCode = typeof errorCodes[number];
 
-export interface ErrorDescription<TErrorCode extends ErrorCode = ErrorCode> {
+export type ErrorDescription<TErrorCode extends ErrorCode = ErrorCode> = {
+  /**
+   * The error code.
+   */
   code: TErrorCode;
+  /**
+   * A human-readable label for the error.
+   */
   label: string;
+  /**
+   * A human-readable description of the error.
+   */
   description: string;
-}
+};
 
 export const errorDictionary: {
   [TKey in ErrorCode]: ErrorDescription<TKey>;

--- a/packages/sdk/src/errors/getErrorCode.ts
+++ b/packages/sdk/src/errors/getErrorCode.ts
@@ -62,6 +62,12 @@ import {
   POLICY_ALREADY_ENABLED,
 } from "./errorCodes.js";
 
+/**
+ * Returns the protocol specific revert code for a given error or undefined if no match was found.
+ *
+ * @param error The contract function revert error to get the code for.
+ * @returns The protocol specific code for the given error or undefined if no match was found.
+ */
 export function getErrorCode(error: ContractFunctionRevertedError): ErrorCode | undefined {
   if (error.reason === undefined) {
     return undefined;

--- a/packages/sdk/src/fees/enums.ts
+++ b/packages/sdk/src/fees/enums.ts
@@ -32,14 +32,14 @@ export const FeeSettlementType = {
   Burn: 3,
   /**
    * The fee is paid by minting new vault shares and transferring them to the vault itself.
-   * @remarks Only used in v2 and v3. 
-   * @deprecated
+   *
+   * @deprecated This settlement type is only used in v2 and v3.
    */
   MintSharesOutstanding: 4,
   /**
    * The fee is paid by burning vault shares held by the vault itself.
-   * @remarks Only used in v2 and v3. 
-   * @deprecated
+   *
+   * @deprecated This settlement type is only used in v2 and v3.
    */
   BurnSharesOutstanding: 5,
 } as const;

--- a/packages/sdk/src/fees/enums.ts
+++ b/packages/sdk/src/fees/enums.ts
@@ -14,10 +14,32 @@ export const FeeManagerAction = {
 
 export type FeeSettlementType = typeof FeeSettlementType[keyof typeof FeeSettlementType];
 export const FeeSettlementType = {
+  /**
+   * No fees are being paid.
+   */
   None: 0,
+  /**
+   * The fee is paid by transfering vault shares from the depositor to the fee recipient.
+   */
   Direct: 1,
+  /**
+   * The fee is paid by minting new vault shares for the fee recipient.
+   */
   Mint: 2,
+  /**
+   * The fee is paid by burning vault shares of the depositor.
+   */
   Burn: 3,
+  /**
+   * The fee is paid by minting new vault shares and transferring them to the vault itself.
+   * @remarks Only used in v2 and v3. 
+   * @deprecated
+   */
   MintSharesOutstanding: 4,
+  /**
+   * The fee is paid by burning vault shares held by the vault itself.
+   * @remarks Only used in v2 and v3. 
+   * @deprecated
+   */
   BurnSharesOutstanding: 5,
 } as const;

--- a/packages/sdk/src/fees/fees/entranceFee.ts
+++ b/packages/sdk/src/fees/fees/entranceFee.ts
@@ -11,9 +11,9 @@ export const entranceRateBurnFeeSettingsEncoding = [
   },
 ] as const;
 
-export interface EntranceRateBurnFeeSettings {
+export type EntranceRateBurnFeeSettings = {
   feeRateInBps: bigint;
-}
+};
 
 export function encodeEntranceRateBurnFeeSettings({ feeRateInBps }: EntranceRateBurnFeeSettings): Hex {
   return encodeAbiParameters(entranceRateBurnFeeSettingsEncoding, [feeRateInBps]);
@@ -38,10 +38,10 @@ export const entranceRateDirectFeeSettingsEncoding = [
   },
 ] as const;
 
-export interface EntranceRateDirectFeeSettings {
+export type EntranceRateDirectFeeSettings = {
   feeRateInBps: bigint;
   feeRecipient: Address;
-}
+};
 
 export type EncodeEntranceRateDirectFeeSettingsArgs = PartialPick<EntranceRateDirectFeeSettings, "feeRecipient">;
 

--- a/packages/sdk/src/fees/fees/exitFee.ts
+++ b/packages/sdk/src/fees/fees/exitFee.ts
@@ -13,10 +13,10 @@ export const exitRateBurnFeeSettingsEncoding = [
   },
 ] as const;
 
-export interface ExitRateBurnFeeSettings {
+export type ExitRateBurnFeeSettings = {
   inKindRateInBps: bigint;
   specificAssetsRate: bigint;
-}
+};
 
 export type EncodeExitRateBurnFeeSettingsArgs = Partial<ExitRateBurnFeeSettings>;
 
@@ -48,11 +48,11 @@ export const exitRateDirectFeeSettingsEncoding = [
   },
 ] as const;
 
-export interface ExitRateDirectFeeSettings {
+export type ExitRateDirectFeeSettings = {
   inKindRateInBps: bigint;
   specificAssetsRate: bigint;
   feeRecipient: Address;
-}
+};
 
 export type EncodeExitRateDirectFeeSettingsArgs = Partial<ExitRateDirectFeeSettings>;
 
@@ -73,10 +73,10 @@ export function decodeExitRateDirectFeeSettings(settings: Hex): ExitRateDirectFe
   return { inKindRateInBps, specificAssetsRate, feeRecipient };
 }
 
-export interface CalculateExitRateFeeSharesDueArgs {
+export type CalculateExitRateFeeSharesDueArgs = {
   feeRate: bigint;
   sharesRedeemed: bigint;
-}
+};
 
 export function calculateExitRateFeeSharesDue({ feeRate, sharesRedeemed }: CalculateExitRateFeeSharesDueArgs) {
   return (sharesRedeemed * feeRate) / 10000n;

--- a/packages/sdk/src/fees/fees/managementFee.ts
+++ b/packages/sdk/src/fees/fees/managementFee.ts
@@ -14,10 +14,10 @@ export const managementFeeSettingsEncoding = [
   },
 ] as const;
 
-export interface ManagementFeeSettings {
+export type ManagementFeeSettings = {
   scaledPerSecondRate: bigint;
   feeRecipient: Address;
-}
+};
 
 export type EncodeManagementFeeSettingsArgs = {
   feeRecipient?: Address;
@@ -54,11 +54,11 @@ export function decodeManagementFeeSettings(settings: Hex): ManagementFeeSetting
   return { scaledPerSecondRate, feeRecipient };
 }
 
-export interface CalculateManagementFeeSharesDueArgs {
+export type CalculateManagementFeeSharesDueArgs = {
   scaledPerSecondRate: bigint;
   sharesSupply: bigint;
   secondsSinceLastSettled: bigint;
-}
+};
 
 export function calculateManagementFeeSharesDue({
   scaledPerSecondRate,

--- a/packages/sdk/src/fees/fees/performanceFee.ts
+++ b/packages/sdk/src/fees/fees/performanceFee.ts
@@ -15,10 +15,10 @@ export const performanceFeeSettingsEncoding = [
   },
 ] as const;
 
-export interface PerformanceFeeSettings {
+export type PerformanceFeeSettings = {
   feeRateInBps: bigint;
   feeRecipient: Address;
-}
+};
 
 export type EncodePerformanceFeeSettingsArgs = PartialPick<PerformanceFeeSettings, "feeRecipient">;
 

--- a/packages/sdk/src/fees/settings.ts
+++ b/packages/sdk/src/fees/settings.ts
@@ -19,7 +19,7 @@ export type FeeSettings = {
    * @remarks
    *
    * This is the address of the fee contract, e.g. `PerformanceFee`, `ManagementFee`, etc. that the
-   * settings belong to.
+   * provided settings belong to.
    */
   address: Address;
   /**
@@ -40,6 +40,11 @@ export function encodeFeeSettings(fees: FeeSettings[]): Hex {
   return encodeAbiParameters(feeSettingsAbi, [addresses, settings]);
 }
 
+/**
+ * Decode fee settings from a hex string.
+ *
+ * @returns The decoded fee settings.
+ */
 export function decodeFeeSettings(encoded: Hex): FeeSettings[] {
   const [addresses, settings] = decodeAbiParameters(feeSettingsAbi, encoded);
   if (addresses.length !== settings.length) {

--- a/packages/sdk/src/fees/settings.ts
+++ b/packages/sdk/src/fees/settings.ts
@@ -12,11 +12,27 @@ export const feeSettingsAbi = [
   },
 ] as const;
 
-export interface FeeSettings {
+export type FeeSettings = {
+  /**
+   * The address of the fee contract.
+   *
+   * @remarks
+   *
+   * This is the address of the fee contract, e.g. `PerformanceFee`, `ManagementFee`, etc. that the
+   * settings belong to.
+   */
   address: Address;
+  /**
+   * The encoded fee settings.
+   */
   settings: Hex;
-}
+};
 
+/**
+ * Encode fee settings for a set of fees.
+ *
+ * @returns The encoded fee settings.
+ */
 export function encodeFeeSettings(fees: FeeSettings[]): Hex {
   const addresses = fees.map(({ address }) => address);
   const settings = fees.map(({ settings }) => settings);

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -55,6 +55,7 @@ export {
 
 export {
   type PrepareFunctionParamsArgs,
+  type PrepareFunctionParamsReturnType,
   prepareFunctionParams,
 } from "./utils/viem.js";
 
@@ -201,39 +202,30 @@ export {
   type RedeemSharesInKindParams,
   prepareRedeemSharesInKindParams,
   decodeRedeemSharesParams,
-  type SimulateRedeemSharesInKindArgs,
-  simulateRedeemSharesInKind,
 } from "./actions/redeemSharesInKind.js";
 
 export {
   type RedeemSharesForSpecificAssetsParams,
   prepareRedeemSharesForSpecificAssetsParams,
   decodeRedeemSharesForSpecificAssetsParams,
-  type SimulateRedeemSharesForSpecificAssets,
-  simulateRedeemSharesForSpecificAssets,
 } from "./actions/redeemSharesForSpecificAssets.js";
 
 export {
   type SetAutoProtocolFeeSharesBuybackParams,
+  prepareSetAutoProtocolFeeSharesBuybackParams,
   decodeSetAutoProtocolFeeSharesBuybackParams,
-  type SimulateSetAutoProtocolFeeSharesBuybackParams,
-  simulateSetAutoProtocolFeeSharesBuyback,
 } from "./actions/setAutoProtocolFeeSharesBuyback.js";
 
 export {
   type AddAssetManagersParams,
   prepareAddAssetManagersParams,
   decodeAddAssetManagersParams,
-  type SimulateAddAssetManagersParams,
-  simulateAddAssetManagers,
 } from "./actions/addAssetManagers.js";
 
 export {
   type RemoveAssetManagersParams,
   prepareRemoveAssetManagersParams,
   decodeRemoveAssetManagersParams,
-  type SimulateRemoveAssetManagersParams,
-  simulateRemoveAssetManagers,
 } from "./actions/removeAssetManagers.js";
 
 export {
@@ -242,14 +234,6 @@ export {
   decodeSetNominatedOwnerParams,
 } from "./actions/setNominatedOwner.js";
 
-export {
-  prepareClaimOwnershipParams,
-  type SimulateClaimOwnershipParams,
-  simulateClaimOwnership,
-} from "./actions/claimOwnership.js";
+export { prepareClaimOwnershipParams } from "./actions/claimOwnership.js";
 
-export {
-  prepareRemoveNominatedOwnerParams,
-  type SimulateRemoveNominatedOwnerParams,
-  simulateRemoveNominatedOwner,
-} from "./actions/removeNominatedOwner.js";
+export { prepareRemoveNominatedOwnerParams } from "./actions/removeNominatedOwner.js";

--- a/packages/sdk/src/integrations/aaveV2.ts
+++ b/packages/sdk/src/integrations/aaveV2.ts
@@ -8,10 +8,10 @@ import { prepareCallOnExtensionParams } from "../actions/callOnExtension.js";
 // lend
 const integrationDataForAaveV2LendAbiParamaters = parseAbiParameters("address aToken, uint depositAmount");
 
-export interface IntegrationDataForAaveV2Lend {
+export type IntegrationDataForAaveV2Lend = {
   aToken: Address;
   depositAmount: bigint;
-}
+};
 
 export function encodeIntegrationDataForAaveV2Lend({ aToken, depositAmount }: IntegrationDataForAaveV2Lend): Hex {
   return encodeAbiParameters(integrationDataForAaveV2LendAbiParamaters, [aToken, depositAmount]);
@@ -25,11 +25,11 @@ export function decodeIntegrationDataForAaveV2Lend(integrationData: Hex): Integr
   return { aToken, depositAmount };
 }
 
-export interface CallArgsForAaveV2Lend {
+export type CallArgsForAaveV2Lend = {
   aToken: Address;
   depositAmount: bigint;
   adapter: Address;
-}
+};
 
 export function encodeCallArgsForAaveV2Lend({ aToken, adapter, depositAmount }: CallArgsForAaveV2Lend): Hex {
   const integrationData = encodeIntegrationDataForAaveV2Lend({
@@ -74,10 +74,10 @@ export type AaveV2LendTrade = {
 
 const integrationDataForAaveV2RedeemAbiParamaters = parseAbiParameters("address aToken, uint redeemAmount");
 
-export interface IntegrationDataForAaveV2Redeem {
+export type IntegrationDataForAaveV2Redeem = {
   aToken: Address;
   redeemAmount: bigint;
-}
+};
 
 export function encodeIntegrationDataForAaveV2Redeem({ aToken, redeemAmount }: IntegrationDataForAaveV2Redeem): Hex {
   return encodeAbiParameters(integrationDataForAaveV2RedeemAbiParamaters, [aToken, redeemAmount]);
@@ -91,11 +91,11 @@ export function decodeIntegrationDataForAaveV2Redeem(integrationData: Hex): Inte
   return { aToken, redeemAmount };
 }
 
-export interface CallArgsForAaveV2Redeem {
+export type CallArgsForAaveV2Redeem = {
   aToken: Address;
   redeemAmount: bigint;
   adapter: Address;
-}
+};
 
 export function encodeCallArgsForAaveV2Redeem({ aToken, adapter, redeemAmount }: CallArgsForAaveV2Redeem): Hex {
   const integrationData = encodeIntegrationDataForAaveV2Redeem({

--- a/packages/sdk/src/integrations/callArgs.ts
+++ b/packages/sdk/src/integrations/callArgs.ts
@@ -1,11 +1,11 @@
 import { type Address, parseAbiParameters } from "abitype";
 import { type Hex, encodeAbiParameters, decodeAbiParameters } from "viem";
 
-export interface CallArgsForIntegration {
+export type CallArgsForIntegration = {
   selector: Hex;
   integrationData: Hex;
   adapter: Address;
-}
+};
 
 const callArgsForIntegrationAbiParamaters = parseAbiParameters(
   "address adapter, bytes4 selector, bytes integrationData",

--- a/packages/sdk/src/policies/policies/allowedExternalPositionTypesPolicy.ts
+++ b/packages/sdk/src/policies/policies/allowedExternalPositionTypesPolicy.ts
@@ -7,9 +7,9 @@ export const allowedExternalPositionTypesPolicySettingsEncoding = [
   },
 ] as const;
 
-export interface AllowedExternalPositionTypesPolicySettings {
+export type AllowedExternalPositionTypesPolicySettings = {
   externalPositionTypeIds: readonly bigint[];
-}
+};
 
 export function encodeAllowedExternalPositionTypesPolicySettings({
   externalPositionTypeIds,

--- a/packages/sdk/src/policies/policies/allowedExternalPositionTypesPolicy.ts
+++ b/packages/sdk/src/policies/policies/allowedExternalPositionTypesPolicy.ts
@@ -8,15 +8,28 @@ export const allowedExternalPositionTypesPolicySettingsEncoding = [
 ] as const;
 
 export type AllowedExternalPositionTypesPolicySettings = {
+  /**
+   * The external position types that should be allowed.
+   */
   externalPositionTypeIds: readonly bigint[];
 };
 
+/**
+ * Encodes the given settings into a hex string.
+ *
+ * @returns The encoded settings.
+ */
 export function encodeAllowedExternalPositionTypesPolicySettings({
   externalPositionTypeIds,
 }: AllowedExternalPositionTypesPolicySettings): Hex {
   return encodeAbiParameters(allowedExternalPositionTypesPolicySettingsEncoding, [externalPositionTypeIds]);
 }
 
+/**
+ * Decodes the given settings from a hex string.
+ *
+ * @returns The decoded settings.
+ */
 export function decodeAllowedExternalPositionTypesPolicySettings(
   encoded: Hex,
 ): AllowedExternalPositionTypesPolicySettings {

--- a/packages/sdk/src/policies/policies/cumulativeSlippageTolerancePolicy.ts
+++ b/packages/sdk/src/policies/policies/cumulativeSlippageTolerancePolicy.ts
@@ -7,9 +7,9 @@ export const cumulativeSlippageTolerancePolicyEncoding = [
   },
 ] as const;
 
-export interface CumulativeSlippageTolerancePolicySettings {
+export type CumulativeSlippageTolerancePolicySettings = {
   tolerance: bigint;
-}
+};
 
 export function encodeCumulativeSlippageTolerancePolicySettings({
   tolerance,

--- a/packages/sdk/src/policies/policies/cumulativeSlippageTolerancePolicy.ts
+++ b/packages/sdk/src/policies/policies/cumulativeSlippageTolerancePolicy.ts
@@ -8,9 +8,23 @@ export const cumulativeSlippageTolerancePolicyEncoding = [
 ] as const;
 
 export type CumulativeSlippageTolerancePolicySettings = {
+  /**
+   * The allowed cumulative slippage tolerance.
+   *
+   * @remarks
+   *
+   * This is the maximum amount of slippage that the vault is allowed to accumulate over time.
+   * If the vault's cumulative slippage exceeds this amount, the trade will revert. The allowed
+   * slippage replenishes over time.
+   */
   tolerance: bigint;
 };
 
+/**
+ * Encodes the given settings into a hex string.
+ *
+ * @returns The encoded settings.
+ */
 export function encodeCumulativeSlippageTolerancePolicySettings({
   tolerance,
 }: CumulativeSlippageTolerancePolicySettings): Hex {

--- a/packages/sdk/src/policies/policies/minAssetBalancesPostRedemptionPolicy.test.ts
+++ b/packages/sdk/src/policies/policies/minAssetBalancesPostRedemptionPolicy.test.ts
@@ -8,17 +8,17 @@ import { encodeAbiParameters } from "viem";
 
 test("minAssetBalancesPostRedemptionPolicySettingsEncoding should have the correct properties", () => {
   expect(minAssetBalancesPostRedemptionPolicySettingsEncoding).toMatchInlineSnapshot(`
-      [
-        {
-          "name": "assets",
-          "type": "address[]",
-        },
-        {
-          "name": "minBalances",
-          "type": "uint256[]",
-        },
-      ]
-    `);
+    [
+      {
+        "name": "assets",
+        "type": "address[]",
+      },
+      {
+        "name": "limits",
+        "type": "uint256[]",
+      },
+    ]
+  `);
 });
 
 test("encodeMinAssetBalancesPostRedemptionPolicySettings should encode correctly", () => {
@@ -26,11 +26,11 @@ test("encodeMinAssetBalancesPostRedemptionPolicySettings should encode correctly
     encodeMinAssetBalancesPostRedemptionPolicySettings([
       {
         asset: "0xfedc73464dfd156d30f6524654a5d56e766da0c3",
-        minBalance: 1n,
+        limit: 1n,
       },
       {
         asset: "0xfaf2c3db614e9d38fe05edc634848be7ff0542b9",
-        minBalance: 2n,
+        limit: 2n,
       },
     ]),
   ).toMatchInlineSnapshot(
@@ -38,13 +38,13 @@ test("encodeMinAssetBalancesPostRedemptionPolicySettings should encode correctly
   );
 });
 
-test("decodeMinAssetBalancesPostRedemptionPolicySettings should throw error if encoded assets and minBalances have different lengths", () => {
+test("decodeMinAssetBalancesPostRedemptionPolicySettings should throw error if encoded assets and limits have different lengths", () => {
   const assets = ["0xfedc73464dfd156d30f6524654a5d56e766da0c3", "0xfaf2c3db614e9d38fe05edc634848be7ff0542b9"] as const;
-  const minBalances = [1n];
-  const encoded = encodeAbiParameters(minAssetBalancesPostRedemptionPolicySettingsEncoding, [assets, minBalances]);
+  const limits = [1n];
+  const encoded = encodeAbiParameters(minAssetBalancesPostRedemptionPolicySettingsEncoding, [assets, limits]);
 
   expect(() => decodeMinAssetBalancesPostRedemptionPolicySettings(encoded)).toThrowError(
-    "Expected minBalances and assets to have the same length",
+    "Expected limits and assets to have the same length",
   );
 });
 
@@ -57,11 +57,11 @@ test("decodeMinAssetBalancesPostRedemptionPolicySettings should decode correctly
     [
       {
         "asset": "0xfeDC73464Dfd156d30F6524654a5d56E766DA0c3",
-        "minBalance": 1n,
+        "limit": 1n,
       },
       {
         "asset": "0xFaF2c3DB614E9d38fE05EDc634848BE7Ff0542B9",
-        "minBalance": 2n,
+        "limit": 2n,
       },
     ]
   `);

--- a/packages/sdk/src/policies/policies/minAssetBalancesPostRedemptionPolicy.ts
+++ b/packages/sdk/src/policies/policies/minAssetBalancesPostRedemptionPolicy.ts
@@ -8,32 +8,53 @@ export const minAssetBalancesPostRedemptionPolicySettingsEncoding = [
   },
   {
     type: "uint256[]",
-    name: "minBalances",
+    name: "limits",
   },
 ] as const;
 
 export type MinAssetBalancesPostRedemptionPolicySettings = {
+  /**
+   * The asset that should be limited.
+   */
   asset: Address;
-  minBalance: bigint;
+  /**
+   * The minimum balance that should be maintained.
+   *
+   * @remarks
+   *
+   * If the vault's balance of this asset would fall below the specified limit as a result
+   * of the redeption, the transaction will revert.
+   */
+  limit: bigint;
 };
 
+/**
+ * Encodes the given settings into a hex string.
+ *
+ * @returns The encoded settings.
+ */
 export function encodeMinAssetBalancesPostRedemptionPolicySettings(
   policies: MinAssetBalancesPostRedemptionPolicySettings[],
 ): Hex {
   const assets = policies.map(({ asset }) => asset);
-  const minBalances = policies.map(({ minBalance }) => minBalance);
+  const limits = policies.map(({ limit }) => limit);
 
-  return encodeAbiParameters(minAssetBalancesPostRedemptionPolicySettingsEncoding, [assets, minBalances]);
+  return encodeAbiParameters(minAssetBalancesPostRedemptionPolicySettingsEncoding, [assets, limits]);
 }
 
+/**
+ * Decodes the given settings from a hex string.
+ *
+ * @returns The decoded settings.
+ */
 export function decodeMinAssetBalancesPostRedemptionPolicySettings(
   encoded: Hex,
 ): MinAssetBalancesPostRedemptionPolicySettings[] {
-  const [assets, minBalances] = decodeAbiParameters(minAssetBalancesPostRedemptionPolicySettingsEncoding, encoded);
-  if (assets.length !== minBalances.length) {
-    throw new Error("Expected minBalances and assets to have the same length");
+  const [assets, limits] = decodeAbiParameters(minAssetBalancesPostRedemptionPolicySettingsEncoding, encoded);
+  if (assets.length !== limits.length) {
+    throw new Error("Expected limits and assets to have the same length");
   }
 
   // rome-ignore lint/style/noNonNullAssertion: length is checked above
-  return assets.map((asset, i) => ({ asset, minBalance: minBalances[i]! }));
+  return assets.map((asset, i) => ({ asset, limit: limits[i]! }));
 }

--- a/packages/sdk/src/policies/policies/minAssetBalancesPostRedemptionPolicy.ts
+++ b/packages/sdk/src/policies/policies/minAssetBalancesPostRedemptionPolicy.ts
@@ -12,10 +12,10 @@ export const minAssetBalancesPostRedemptionPolicySettingsEncoding = [
   },
 ] as const;
 
-export interface MinAssetBalancesPostRedemptionPolicySettings {
+export type MinAssetBalancesPostRedemptionPolicySettings = {
   asset: Address;
   minBalance: bigint;
-}
+};
 
 export function encodeMinAssetBalancesPostRedemptionPolicySettings(
   policies: MinAssetBalancesPostRedemptionPolicySettings[],

--- a/packages/sdk/src/policies/policies/minMaxInvestmentPolicy.ts
+++ b/packages/sdk/src/policies/policies/minMaxInvestmentPolicy.ts
@@ -11,10 +11,10 @@ export const minMaxInvestmentPolicySettingsEncoding = [
   },
 ] as const;
 
-export interface MinMaxInvestmentPolicySettings {
+export type MinMaxInvestmentPolicySettings = {
   minInvestmentAmount: bigint;
   maxInvestmentAmount: bigint;
-}
+};
 
 export function encodeMinMaxInvestmentPolicySettings({
   minInvestmentAmount,

--- a/packages/sdk/src/policies/policies/minMaxInvestmentPolicy.ts
+++ b/packages/sdk/src/policies/policies/minMaxInvestmentPolicy.ts
@@ -1,4 +1,5 @@
 import { decodeAbiParameters, encodeAbiParameters, type Hex } from "viem";
+import { MAX_UINT_256 } from "../../constants/misc.js";
 
 export const minMaxInvestmentPolicySettingsEncoding = [
   {
@@ -12,20 +13,49 @@ export const minMaxInvestmentPolicySettingsEncoding = [
 ] as const;
 
 export type MinMaxInvestmentPolicySettings = {
+  /**
+   * The minimum investment amount enforced by this policy.
+   *
+   * @remarks
+   *
+   * If a depositor attempts to deposit less than this amount, the transaction will revert.
+   *
+   * @defaultValue 0n
+   */
   minInvestmentAmount: bigint;
+  /**
+   * The maximum investment amount enforced by this policy.
+   *
+   * @remarks
+   *
+   * If a depositor attempts to deposit more than this amount, the transaction will revert.
+   *
+   * @defaultValue MAX_UINT_256
+   */
   maxInvestmentAmount: bigint;
 };
 
+/**
+ * Encodes the given settings into a hex string.
+ *
+ * @returns The encoded settings.
+ */
 export function encodeMinMaxInvestmentPolicySettings({
-  minInvestmentAmount,
-  maxInvestmentAmount,
-}: MinMaxInvestmentPolicySettings): Hex {
+  minInvestmentAmount = 0n,
+  maxInvestmentAmount = MAX_UINT_256,
+}: Partial<MinMaxInvestmentPolicySettings>): Hex {
   if (minInvestmentAmount > maxInvestmentAmount) {
     throw new Error("maxInvestmentAmount should be greater than or equal to minInvestmentAmount");
   }
+
   return encodeAbiParameters(minMaxInvestmentPolicySettingsEncoding, [minInvestmentAmount, maxInvestmentAmount]);
 }
 
+/**
+ * Decodes the given settings from a hex string.
+ *
+ * @returns The decoded settings.
+ */
 export function decodeMinMaxInvestmentPolicySettings(settings: Hex): MinMaxInvestmentPolicySettings {
   const [minInvestmentAmount, maxInvestmentAmount] = decodeAbiParameters(
     minMaxInvestmentPolicySettingsEncoding,

--- a/packages/sdk/src/policies/settings.ts
+++ b/packages/sdk/src/policies/settings.ts
@@ -13,10 +13,26 @@ export const policySettingsAbi = [
 ] as const;
 
 export type PolicySettings = {
+  /**
+   * The address of the policy contract.
+   *
+   * @remarks
+   *
+   * This is the address of the policy contract, e.g. `MinMaxInvestmentPolicy`, `AllowedAdaptersPolicy`, etc. that the
+   * provided settings belong to.
+   */
   address: Address;
+  /**
+   * The encoded policy settings.
+   */
   settings: Hex;
 };
 
+/**
+ * Encode policy settings for a set of policies.
+ *
+ * @returns The encoded policy settings.
+ */
 export function encodePolicySettings(policies: PolicySettings[]): Hex {
   const addresses = policies.map(({ address }) => address);
   const settings = policies.map(({ settings }) => settings);
@@ -24,6 +40,11 @@ export function encodePolicySettings(policies: PolicySettings[]): Hex {
   return encodeAbiParameters(policySettingsAbi, [addresses, settings]);
 }
 
+/**
+ * Decode policy settings from a hex string.
+ *
+ * @returns The decoded policy settings.
+ */
 export function decodePolicySettings(encoded: Hex): PolicySettings[] {
   const [addresses, settings] = decodeAbiParameters(policySettingsAbi, encoded);
   if (addresses.length !== settings.length) {

--- a/packages/sdk/src/policies/settings.ts
+++ b/packages/sdk/src/policies/settings.ts
@@ -12,10 +12,10 @@ export const policySettingsAbi = [
   },
 ] as const;
 
-export interface PolicySettings {
+export type PolicySettings = {
   address: Address;
   settings: Hex;
-}
+};
 
 export function encodePolicySettings(policies: PolicySettings[]): Hex {
   const addresses = policies.map(({ address }) => address);

--- a/packages/sdk/tests/actions/buyShares.ts
+++ b/packages/sdk/tests/actions/buyShares.ts
@@ -53,9 +53,8 @@ export async function buyShares({
   });
 
   if (skipSharesActionTimelock) {
-    const sharesActionTimelock = await getSharesActionTimelock({
+    const sharesActionTimelock = await getSharesActionTimelock(publicClient, {
       comptrollerProxy,
-      publicClient,
     });
 
     await increaseTimeAndMine({

--- a/packages/sdk/tests/actions/setNominatedOwner.ts
+++ b/packages/sdk/tests/actions/setNominatedOwner.ts
@@ -15,7 +15,7 @@ export async function setNominatedOwner({
     address: vaultProxy,
     account,
     ...prepareSetNominatedOwnerParams({
-      nextNominatedOwner: nominatedOwner,
+      nominatedOwner: nominatedOwner,
     }),
   });
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds new types and interfaces, updates existing ones, and refactors some functions. Notable changes include:
- Refactored `getSharesActionTimelock` to use `readContract` from `viem/contract`
- Added `PrepareAdapterTradeParams` type for `prepareAdapterTrade` function
- Added `fuzziness` parameter to `assertBalanceOf` function
- Updated `CumulativeSlippageTolerancePolicySettings` and `AllowedExternalPositionTypesPolicySettings` interfaces to use `type` instead of `interface`
- Added `getErrorCode` function to get protocol specific error codes
- Updated `PerformanceFeeSettings` and `ManagementFeeSettings` interfaces to use `type` instead of `interface`
- Added `CalculateManagementFeeSharesDueArgs` and `EntranceRateDirectFeeSettings` types
- Added `RedeemSharesForSpecificAssetsParams` type

> The following files were skipped due to too many changes: `packages/sdk/src/actions/redeemSharesForSpecificAssets.ts`, `packages/sdk/src/fees/settings.ts`, `packages/sdk/src/actions/removeAssetManagers.ts`, `packages/sdk/src/fees/fees/exitFee.ts`, `packages/sdk/src/actions/callOnExtension.ts`, `packages/sdk/src/policies/settings.ts`, `packages/sdk/src/actions/setAutoProtocolFeeSharesBuyback.test.ts`, `packages/sdk/src/actions/redeemSharesInKind.ts`, `packages/sdk/src/errors/catchError.ts`, `packages/sdk/src/actions/setAutoProtocolFeeSharesBuyback.ts`, `packages/sdk/src/actions/setNominatedOwner.ts`, `packages/sdk/src/policies/policies/minMaxInvestmentPolicy.ts`, `packages/sdk/src/integrations/aaveV2.ts`, `packages/sdk/src/policies/policies/minAssetBalancesPostRedemptionPolicy.ts`, `packages/sdk/src/actions/setupVault.ts`, `packages/sdk/src/policies/policies/minAssetBalancesPostRedemptionPolicy.test.ts`, `packages/sdk/src/actions/setNominatedOwner.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->