### PR TITLE
chore: use buf.build remote plugins for api codegen

### DIFF
--- a/packages/api/buf.gen.yaml
+++ b/packages/api/buf.gen.yaml
@@ -4,11 +4,9 @@ managed:
   enabled: true
 
 plugins:
-  - name: es
-    path: ./node_modules/.bin/protoc-gen-es
+  - plugin: buf.build/bufbuild/es
     out: src/generated
     opt: target=ts
-  - name: connect-es
-    path: ./node_modules/.bin/protoc-gen-connect-es
+  - plugin: buf.build/bufbuild/connect-es
     out: src/generated
     opt: target=ts

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -44,8 +44,6 @@
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.15.0",
-    "@bufbuild/protoc-gen-connect-es": "^0.8.6",
-    "@bufbuild/protoc-gen-es": "^1.2.0",
     "@types/node": "^18.16.1",
     "@types/web": "^0.0.99",
     "@vitest/coverage-c8": "^0.30.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,12 +196,6 @@ importers:
       '@bufbuild/buf':
         specifier: ^1.15.0
         version: 1.15.0
-      '@bufbuild/protoc-gen-connect-es':
-        specifier: ^0.8.6
-        version: 0.8.6(@bufbuild/connect@0.8.6)(@bufbuild/protoc-gen-es@1.2.0)
-      '@bufbuild/protoc-gen-es':
-        specifier: ^1.2.0
-        version: 1.2.0(@bufbuild/protobuf@1.2.0)
       '@types/node':
         specifier: ^18.16.1
         version: 18.16.1
@@ -656,30 +650,11 @@ packages:
       '@bufbuild/protobuf': ^1.2.0
     dependencies:
       '@bufbuild/protobuf': 1.2.0
+    dev: false
 
   /@bufbuild/protobuf@1.2.0:
     resolution: {integrity: sha512-MBVuQMOBHxgGnZ9XCUIi8WOy5O/T4ma3TduCRhRvndv3UDbG9cHgd8h6nOYSGyBYPEvXf1z9nTwhp8mVIDbq2g==}
-
-  /@bufbuild/protoc-gen-connect-es@0.8.6(@bufbuild/connect@0.8.6)(@bufbuild/protoc-gen-es@1.2.0):
-    resolution: {integrity: sha512-AO4ixGlihKBWZvE9e/ZBBKmCeJGHK8FIMVBvwsr9NxTTvlTZN5oUk8mcR59DOE0YTHVpjgdtcz347HNmVvV6hQ==}
-    engines: {node: '>=14'}
-    hasBin: true
-    peerDependencies:
-      '@bufbuild/connect': 0.8.6
-      '@bufbuild/protoc-gen-es': ^1.2.0
-    peerDependenciesMeta:
-      '@bufbuild/connect':
-        optional: true
-      '@bufbuild/protoc-gen-es':
-        optional: true
-    dependencies:
-      '@bufbuild/connect': 0.8.6(@bufbuild/protobuf@1.2.0)
-      '@bufbuild/protobuf': 1.2.0
-      '@bufbuild/protoc-gen-es': 1.2.0(@bufbuild/protobuf@1.2.0)
-      '@bufbuild/protoplugin': 1.2.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
+    dev: false
 
   /@bufbuild/protoc-gen-connect-web@0.8.6(@bufbuild/connect@0.8.6):
     resolution: {integrity: sha512-BltKOzGONR8uGlGdjgZnMBqudNEcRgF75XcttfyyZJsKPsknivFrMSoSlI6ZUyR+TQ567vJDxKKGO4bukQiBWA==}
@@ -701,22 +676,6 @@ packages:
       - supports-color
     dev: false
 
-  /@bufbuild/protoc-gen-es@1.2.0(@bufbuild/protobuf@1.2.0):
-    resolution: {integrity: sha512-rdg2+Co4H+cImZ81EEzHLEi9bmzmMnS/bsf7XLHKtWYskj1PZVIalfquQejcSV6eWbdmVGKa29JwI5zEkSmkCQ==}
-    engines: {node: '>=14'}
-    hasBin: true
-    peerDependencies:
-      '@bufbuild/protobuf': 1.2.0
-    peerDependenciesMeta:
-      '@bufbuild/protobuf':
-        optional: true
-    dependencies:
-      '@bufbuild/protobuf': 1.2.0
-      '@bufbuild/protoplugin': 1.2.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@bufbuild/protoplugin@1.2.0:
     resolution: {integrity: sha512-TX0mEk+LdIbpK2xr5RqeUswR8jGZs6uCX6Cq8azADj8hhiUr7Xty8agEOU/zR+J71D4dV5SnyEPYyw0nGJ6dGQ==}
     dependencies:
@@ -725,6 +684,7 @@ packages:
       typescript: 4.5.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@changesets/apply-release-plan@6.1.3:
     resolution: {integrity: sha512-ECDNeoc3nfeAe1jqJb5aFQX7CqzQhD2klXRez2JDb/aVpGUbX673HgKrnrgJRuQR/9f2TtLoYIzrGB9qwD77mg==}
@@ -1541,6 +1501,7 @@ packages:
       debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@viem/anvil@0.0.3:
     resolution: {integrity: sha512-qB2MjX9Jox3+LKfmvKHQbfzPwxkMFLPaNj0Jh+F1DfEtitVZMSxS0I5NeCRYVMXkPCQ4GH+r5EC77gn4A8h09w==}
@@ -4342,6 +4303,7 @@ packages:
     resolution: {integrity: sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: false
 
   /typescript@5.0.4:
     resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `@bufbuild/protoc-gen-connect-es` and `@bufbuild/protoc-gen-es` dependencies to use `buf.build/bufbuild/es` and `buf.build/bufbuild/connect-es` plugins.

### Detailed summary
- Update `@bufbuild/protoc-gen-connect-es` dependency to use `buf.build/bufbuild/connect-es` plugin
- Update `@bufbuild/protoc-gen-es` dependency to use `buf.build/bufbuild/es` plugin

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->