### PR TITLE
feat: set freely transferable shares

### DIFF
--- a/.changeset/cool-cows-burn.md
+++ b/.changeset/cool-cows-burn.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Added `setFreelyTransferableShares` function and tests.

--- a/packages/sdk/src/actions/setFreelyTransferableShares.test.ts
+++ b/packages/sdk/src/actions/setFreelyTransferableShares.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "vitest";
+import { testActions } from "../../tests/globals.js";
+import { ALICE, WETH } from "../../tests/constants.js";
+import { prepareFreelyTransferableSharesParams } from "./setFreelyTransferableShares.js";
+
+test("sets freely transferable shares correctly", async () => {
+  const { vaultProxy } = await testActions.createTestVault({
+    vaultOwner: ALICE,
+    denominationAsset: WETH,
+  });
+
+  const firstFreelyTransferableShares = await testActions.sharesAreFreelyTransferable({
+    address: vaultProxy,
+  });
+
+  expect(firstFreelyTransferableShares).toBe(false);
+
+  await testActions.setFreelyTransferableShares({
+    vaultProxy,
+    account: ALICE,
+  });
+
+  const secondFreelyTransferableShares = await testActions.sharesAreFreelyTransferable({
+    address: vaultProxy,
+  });
+
+  expect(secondFreelyTransferableShares).toBe(true);
+});
+
+test("should prepare params correctly", () => {
+  expect(prepareFreelyTransferableSharesParams()).toMatchInlineSnapshot(`
+    {
+      "abi": [
+        {
+          "inputs": [],
+          "name": "setFreelyTransferableShares",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function",
+        },
+      ],
+      "functionName": "setFreelyTransferableShares",
+    }
+  `);
+});

--- a/packages/sdk/src/actions/setFreelyTransferableShares.ts
+++ b/packages/sdk/src/actions/setFreelyTransferableShares.ts
@@ -1,0 +1,14 @@
+import { IVault } from "@enzymefinance/abis/IVault";
+import { prepareFunctionParams } from "../../src/utils/viem.js";
+import { getAbiItem } from "viem";
+
+/**
+ * Prepare the parameters for the `setFreelyTransferableShares` function.
+ *
+ * @returns The prepared parameters to be encoded.
+ */
+export function prepareFreelyTransferableSharesParams() {
+  return prepareFunctionParams({
+    abi: getAbiItem({ abi: IVault, name: "setFreelyTransferableShares" }),
+  });
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -243,3 +243,5 @@ export {
   prepareSetRecipientForFundParams,
   decodeSetRecipientForFundParams,
 } from "./actions/setRecipientForFund.js";
+
+export { prepareFreelyTransferableSharesParams } from "./actions/setFreelyTransferableShares.js";

--- a/packages/sdk/tests/actions/setFreelyTransferableShares.ts
+++ b/packages/sdk/tests/actions/setFreelyTransferableShares.ts
@@ -1,0 +1,17 @@
+import { type Address } from "viem";
+import { sendTestTransaction } from "../globals.js";
+import { prepareFreelyTransferableSharesParams } from "../../src/actions/setFreelyTransferableShares.js";
+
+export function setFreelyTransferableShares({
+  vaultProxy,
+  account,
+}: {
+  vaultProxy: Address;
+  account: Address;
+}) {
+  return sendTestTransaction({
+    address: vaultProxy,
+    account,
+    ...prepareFreelyTransferableSharesParams(),
+  });
+}

--- a/packages/sdk/tests/actions/sharesAreFreelyTransferable.ts
+++ b/packages/sdk/tests/actions/sharesAreFreelyTransferable.ts
@@ -1,0 +1,11 @@
+import { type Address } from "viem";
+import { publicClient } from "../globals.js";
+import { IVault } from "@enzymefinance/abis/IVault";
+
+export function sharesAreFreelyTransferable({ address }: { address: Address }) {
+  return publicClient.readContract({
+    address,
+    abi: IVault,
+    functionName: "sharesAreFreelyTransferable",
+  });
+}

--- a/packages/sdk/tests/globals.ts
+++ b/packages/sdk/tests/globals.ts
@@ -17,6 +17,8 @@ import { overrideValueInterpreter } from "./actions/setStatelRateThreshold.js";
 import { transferToken } from "./actions/transferToken.js";
 import { setRecipientForFund } from "./actions/setRecipientForFund.js";
 import { getRecipientForFund } from "./actions/getRecipientForFund.js";
+import { setFreelyTransferableShares } from "./actions/setFreelyTransferableShares.js";
+import { sharesAreFreelyTransferable } from "./actions/sharesAreFreelyTransferable.js";
 
 export const testActions = {
   createTestVault,
@@ -34,6 +36,8 @@ export const testActions = {
   transferToken,
   setRecipientForFund,
   getRecipientForFund,
+  setFreelyTransferableShares,
+  sharesAreFreelyTransferable,
 };
 
 export const anvil = {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new function and tests for freely transferable shares to the `@enzymefinance/sdk` package.

### Detailed summary
- Added `setFreelyTransferableShares` function and tests.
- Exported `prepareFreelyTransferableSharesParams` function.
- Added `sharesAreFreelyTransferable` function and tests.
- Updated `testActions` and `globals` modules to include new functions.
- Added tests for `prepareFreelyTransferableSharesParams` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->