### PR TITLE
feat: add maple liquidity trade helpers

### DIFF
--- a/.changeset/cold-apes-yawn.md
+++ b/.changeset/cold-apes-yawn.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Add maple liquidity trade helpers

--- a/packages/sdk/src/extensions/external-positions/externalPositionTypes.ts
+++ b/packages/sdk/src/extensions/external-positions/externalPositionTypes.ts
@@ -19,6 +19,13 @@ import type {
   ConvexVotingWithdrawArgs,
 } from "./instances/convexVoting.js";
 import type { KilnStakeArgs } from "./instances/kiln.js";
+import type {
+  MapleLiquidityCancelRedeemV2Args,
+  MapleLiquidityClaimRewardsV1Args,
+  MapleLiquidityLendV2Args,
+  MapleLiquidityRedeemV2Args,
+  MapleLiquidityRequestRedeemV2Args,
+} from "./instances/mapleLiquidity.js";
 
 export type ExternalPosition = typeof ExternalPosition[keyof typeof ExternalPosition];
 export const ExternalPosition = {
@@ -37,6 +44,11 @@ export const ExternalPosition = {
   ConvexVotingWithdraw: "ConvexVotingWithdraw",
   ConvexVotingClaimRewards: "ConvexVotingClaimRewards",
   ConvexVotingDelegate: "ConvexVotingDelegate",
+  MapleLiquidityLendV2: "MapleLiquidityLendV2",
+  MapleLiquidityRedeemV2: "MapleLiquidityRedeemV2",
+  MapleLiquidityRequestRedeemV2: "MapleLiquidityRequestRedeemV2",
+  MapleLiquidityCancelRedeemV2: "MapleLiquidityCancelRedeemV2",
+  MapleLiquidityClaimRewardsV1: "MapleLiquidityClaimRewardsV1",
 } as const;
 
 export type ExternalPositionArgs = {
@@ -55,4 +67,9 @@ export type ExternalPositionArgs = {
   [ExternalPosition.ConvexVotingWithdraw]: ConvexVotingWithdrawArgs;
   [ExternalPosition.ConvexVotingClaimRewards]: ConvexVotingClaimRewardsArgs;
   [ExternalPosition.ConvexVotingDelegate]: ConvexVotingDelegateArgs;
+  [ExternalPosition.MapleLiquidityLendV2]: MapleLiquidityLendV2Args;
+  [ExternalPosition.MapleLiquidityRedeemV2]: MapleLiquidityRedeemV2Args;
+  [ExternalPosition.MapleLiquidityRequestRedeemV2]: MapleLiquidityRequestRedeemV2Args;
+  [ExternalPosition.MapleLiquidityCancelRedeemV2]: MapleLiquidityCancelRedeemV2Args;
+  [ExternalPosition.MapleLiquidityClaimRewardsV1]: MapleLiquidityClaimRewardsV1Args;
 };

--- a/packages/sdk/src/extensions/external-positions/instances/mapleLiquidity.test.ts
+++ b/packages/sdk/src/extensions/external-positions/instances/mapleLiquidity.test.ts
@@ -1,4 +1,4 @@
-import { EXTERNAL_POSITION_MANAGER } from "../../../../tests/constants.js";
+import { EXTERNAL_POSITION_MANAGER, WETH } from "../../../../tests/constants.js";
 import { sendTestTransaction, testActions, testClient } from "../../../../tests/globals.js";
 import { ExternalPosition } from "../externalPositionTypes.js";
 import { prepareUseExternalPosition } from "../prepareUseExternalPosition.js";
@@ -12,7 +12,8 @@ import {
 import { parseEther } from "viem";
 import { test } from "vitest";
 
-test("prepare external position trade for Maple Liquidity lend V2 should work correctly", async () => {
+test.only("prepare external position trade for Maple Liquidity lend V2 should work correctly", async () => {
+  const vaultProxy = "0x278c647f7cfb9d55580c69d3676938608c945ba8" as const;
   const comptrollerProxy = "0x746de9838BB3D14f1aC1b78Bd855E48201F221a6" as const;
   const vaultOwner = "0x0D947D68f583e8B23ff816df9ff3f23a8Cfd7496" as const;
 
@@ -41,10 +42,9 @@ test("prepare external position trade for Maple Liquidity lend V2 should work co
   });
 
   await testActions.assertBalanceOf({
-    token: decodedCallArgs.pool,
-    account: decodedCallArgs.externalPositionProxy,
+    token: WETH,
+    account: vaultProxy,
     expected: 2137266192270935n,
-    fuzziness: 7_000_000n, // shares amount can be different due to on which block lend will be executed
   });
 });
 

--- a/packages/sdk/src/extensions/external-positions/instances/mapleLiquidity.test.ts
+++ b/packages/sdk/src/extensions/external-positions/instances/mapleLiquidity.test.ts
@@ -12,7 +12,7 @@ import {
 import { parseEther } from "viem";
 import { test } from "vitest";
 
-test.only("prepare external position trade for Maple Liquidity lend V2 should work correctly", async () => {
+test("prepare external position trade for Maple Liquidity lend V2 should work correctly", async () => {
   const vaultProxy = "0x278c647f7cfb9d55580c69d3676938608c945ba8" as const;
   const comptrollerProxy = "0x746de9838BB3D14f1aC1b78Bd855E48201F221a6" as const;
   const vaultOwner = "0x0D947D68f583e8B23ff816df9ff3f23a8Cfd7496" as const;
@@ -44,7 +44,7 @@ test.only("prepare external position trade for Maple Liquidity lend V2 should wo
   await testActions.assertBalanceOf({
     token: WETH,
     account: vaultProxy,
-    expected: 2137266192270935n,
+    expected: 1383799807066830248n,
   });
 });
 

--- a/packages/sdk/src/extensions/external-positions/instances/mapleLiquidity.test.ts
+++ b/packages/sdk/src/extensions/external-positions/instances/mapleLiquidity.test.ts
@@ -1,0 +1,190 @@
+import { EXTERNAL_POSITION_MANAGER } from "../../../../tests/constants.js";
+import { sendTestTransaction, testActions, testClient } from "../../../../tests/globals.js";
+import { ExternalPosition } from "../externalPositionTypes.js";
+import { prepareUseExternalPosition } from "../prepareUseExternalPosition.js";
+import {
+  decodeMapleLiquidityCancelRedeemV2Args,
+  decodeMapleLiquidityClaimRewardsV1Args,
+  decodeMapleLiquidityLendV2Args,
+  decodeMapleLiquidityRedeemV2Args,
+  decodeMapleLiquidityRequestRedeemV2Args,
+} from "./mapleLiquidity.js";
+import { parseEther } from "viem";
+import { test } from "vitest";
+
+test("prepare external position trade for Maple Liquidity lend V2 should work correctly", async () => {
+  const comptrollerProxy = "0x746de9838BB3D14f1aC1b78Bd855E48201F221a6" as const;
+  const vaultOwner = "0x0D947D68f583e8B23ff816df9ff3f23a8Cfd7496" as const;
+
+  await testClient.reset({
+    blockNumber: 17270518n,
+  });
+
+  await testClient.setBalance({ address: vaultOwner, value: parseEther("1") });
+
+  // Taken from tx 0xec93a05a52d999b353508818510e157d0632aeceaae60d06638857a423dc63ba
+  const callArgs =
+    "0x00000000000000000000000010ee63e67f1599abe651e526a761f428a725f235000000000000000000000000000000000000000000000000000000000000000900000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000040000000000000000000000000fff9a1caf78b2e5b0a49355a8637ea78b43fb6c300000000000000000000000000000000000000000000000000038d7ea4c68000";
+
+  const decodedCallArgs = decodeMapleLiquidityLendV2Args(callArgs);
+
+  await sendTestTransaction({
+    ...prepareUseExternalPosition({
+      externalPositionManager: EXTERNAL_POSITION_MANAGER,
+      callArgs: {
+        type: ExternalPosition.MapleLiquidityLendV2,
+        ...decodedCallArgs,
+      },
+    }),
+    account: vaultOwner,
+    address: comptrollerProxy,
+  });
+
+  await testActions.assertBalanceOf({
+    token: decodedCallArgs.pool,
+    account: decodedCallArgs.externalPositionProxy,
+    expected: 2137266192270935n,
+    fuzziness: 7_000_000n, // shares amount can be different due to on which block lend will be executed
+  });
+});
+
+test("prepare external position trade for Maple Liquidity redeem V2 should work correctly", async () => {
+  const comptrollerProxy = "0x746de9838BB3D14f1aC1b78Bd855E48201F221a6" as const;
+  const vaultOwner = "0x0D947D68f583e8B23ff816df9ff3f23a8Cfd7496" as const;
+
+  await testClient.reset({
+    blockNumber: 16238961n,
+  });
+
+  await testClient.setBalance({ address: vaultOwner, value: parseEther("1") });
+
+  // Taken from tx 0x5a54cb31c0b059ee7a280ea4da3bcf03c53760e8aebe3fe71e181bcfee4422de
+  const callArgs =
+    "0x00000000000000000000000010ee63e67f1599abe651e526a761f428a725f235000000000000000000000000000000000000000000000000000000000000000b00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000040000000000000000000000000fff9a1caf78b2e5b0a49355a8637ea78b43fb6c3000000000000000000000000000000000000000000000000000034793ae2a28c";
+
+  const decodedCallArgs = decodeMapleLiquidityRedeemV2Args(callArgs);
+
+  await sendTestTransaction({
+    ...prepareUseExternalPosition({
+      externalPositionManager: EXTERNAL_POSITION_MANAGER,
+      callArgs: {
+        type: ExternalPosition.MapleLiquidityRedeemV2,
+        ...decodedCallArgs,
+      },
+    }),
+    account: vaultOwner,
+    address: comptrollerProxy,
+  });
+
+  await testActions.assertBalanceOf({
+    token: decodedCallArgs.pool,
+    account: decodedCallArgs.externalPositionProxy,
+    expected: 950394819398592n,
+  });
+});
+
+test("prepare external position trade for Maple Liquidity request redeem V2 should work correctly", async () => {
+  const comptrollerProxy = "0x746de9838BB3D14f1aC1b78Bd855E48201F221a6" as const;
+  const vaultOwner = "0x0D947D68f583e8B23ff816df9ff3f23a8Cfd7496" as const;
+
+  await testClient.reset({
+    blockNumber: 16238972n,
+  });
+
+  await testClient.setBalance({ address: vaultOwner, value: parseEther("1") });
+
+  // Taken from tx 0x80c91825d037c2e85e39a9ab5d13348f079dfd6817c039cfe91a4d7ca9545aed
+  const callArgs =
+    "0x0000000000000000000000002affcd7650c2c116edb6907725dab53a259285c7000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000004000000000000000000000000079400a2c9a5e2431419cac98bf46893c86e8bdd700000000000000000000000000000000000000000000000000000000000f3a6b";
+
+  const decodedCallArgs = decodeMapleLiquidityRequestRedeemV2Args(callArgs);
+
+  await sendTestTransaction({
+    ...prepareUseExternalPosition({
+      externalPositionManager: EXTERNAL_POSITION_MANAGER,
+      callArgs: {
+        type: ExternalPosition.MapleLiquidityRequestRedeemV2,
+        ...decodedCallArgs,
+      },
+    }),
+    account: vaultOwner,
+    address: comptrollerProxy,
+  });
+
+  await testActions.assertBalanceOf({
+    token: decodedCallArgs.pool,
+    account: decodedCallArgs.externalPositionProxy,
+    expected: 3072431n,
+  });
+});
+
+test("prepare external position trade for Maple Liquidity cancel redeem V2 should work correctly", async () => {
+  const comptrollerProxy = "0x746de9838BB3D14f1aC1b78Bd855E48201F221a6" as const;
+  const vaultOwner = "0x0D947D68f583e8B23ff816df9ff3f23a8Cfd7496" as const;
+
+  await testClient.reset({
+    blockNumber: 16274942n,
+  });
+
+  await testClient.setBalance({ address: vaultOwner, value: parseEther("1") });
+
+  // Taken from tx 0xf4b5cd5fc4e801907041f2de96bc5cad98223f0c5c410b1f785f5d2e94ebd192
+  const callArgs =
+    "0x00000000000000000000000010ee63e67f1599abe651e526a761f428a725f235000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000040000000000000000000000000fff9a1caf78b2e5b0a49355a8637ea78b43fb6c3000000000000000000000000000000000000000000000000000012cd64268075";
+
+  const decodedCallArgs = decodeMapleLiquidityCancelRedeemV2Args(callArgs);
+
+  await sendTestTransaction({
+    ...prepareUseExternalPosition({
+      externalPositionManager: EXTERNAL_POSITION_MANAGER,
+      callArgs: {
+        type: ExternalPosition.MapleLiquidityCancelRedeemV2,
+        ...decodedCallArgs,
+      },
+    }),
+    account: vaultOwner,
+    address: comptrollerProxy,
+  });
+
+  await testActions.assertBalanceOf({
+    token: decodedCallArgs.pool,
+    account: decodedCallArgs.externalPositionProxy,
+    expected: 971068177239093n,
+  });
+});
+
+test("prepare external position trade for Maple Liquidity claim rewards V1 should work correctly", async () => {
+  const vaultProxy = "0x339b7ba786e6cf938b34f81d7c9543264ddf73b7" as const;
+  const comptrollerProxy = "0x69E38c085A2f87BC27c5fCE9B126a50Df960Ab63" as const;
+  const vaultOwner = "0xbf687e4f225e86faf1bbdd5b7b14eccec2f71fdb" as const;
+
+  await testClient.reset({
+    blockNumber: 16770470n,
+  });
+
+  await testClient.setBalance({ address: vaultOwner, value: parseEther("1") });
+
+  // Taken from tx 0x368f571ad93ac9e9a1f3dfef05f0721c22daafaf5a5000955a76c722ca6776ec
+  const callArgs =
+    "0x0000000000000000000000009f37f4fb3f4f9a2eaa2300bd79530bf73f11d2ef000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000020000000000000000000000000d0123f5220a36e9ec6082d83b4a11f92aa48ccd0";
+
+  const decodedCallArgs = decodeMapleLiquidityClaimRewardsV1Args(callArgs);
+
+  await sendTestTransaction({
+    ...prepareUseExternalPosition({
+      externalPositionManager: EXTERNAL_POSITION_MANAGER,
+      callArgs: {
+        type: ExternalPosition.MapleLiquidityClaimRewardsV1,
+        ...decodedCallArgs,
+      },
+    }),
+    account: vaultOwner,
+    address: comptrollerProxy,
+  });
+
+  await testActions.assertBalanceOf({
+    token: "0x33349B282065b0284d756F0577FB39c158F935e6", // MPL token
+    account: vaultProxy,
+    expected: 34975869761446182024n,
+  });
+});

--- a/packages/sdk/src/extensions/external-positions/instances/mapleLiquidity.ts
+++ b/packages/sdk/src/extensions/external-positions/instances/mapleLiquidity.ts
@@ -1,0 +1,215 @@
+import { decodeCallOnExternalPositionArgs, encodeCallOnExternalPositionArgs } from "../callOnExternalPosition.js";
+import { type Address, type Hex, decodeAbiParameters, encodeAbiParameters } from "viem";
+
+export type MapleLiquidityAction = typeof MapleLiquidityAction[keyof typeof MapleLiquidityAction];
+export const MapleLiquidityAction = {
+  // Lower action ids are deprecated, and we don't support them
+  ClaimRewardsV1: 8n,
+  LendV2: 9n,
+  RequestRedeemV2: 10n,
+  RedeemV2: 11n,
+  CancelRedeemV2: 12n,
+} as const;
+
+export const mapleLiquidityLendV2ArgsEncoding = [
+  {
+    name: "pool",
+    type: "address",
+  },
+  {
+    name: "liquidityAssetAmount",
+    type: "uint256",
+  },
+] as const;
+
+export type MapleLiquidityLendV2Args = {
+  pool: Address;
+  liquidityAssetAmount: bigint;
+  externalPositionProxy: Address;
+};
+
+export function encodeMapleLiquidityLendV2Args({
+  externalPositionProxy,
+  pool,
+  liquidityAssetAmount,
+}: MapleLiquidityLendV2Args): Hex {
+  const actionArgs = encodeAbiParameters(mapleLiquidityLendV2ArgsEncoding, [pool, liquidityAssetAmount]);
+
+  return encodeCallOnExternalPositionArgs({
+    externalPositionProxy,
+    actionId: MapleLiquidityAction.LendV2,
+    actionArgs,
+  });
+}
+
+export function decodeMapleLiquidityLendV2Args(callArgs: Hex): MapleLiquidityLendV2Args {
+  const { externalPositionProxy, actionArgs } = decodeCallOnExternalPositionArgs(callArgs);
+  const [pool, liquidityAssetAmount] = decodeAbiParameters(mapleLiquidityLendV2ArgsEncoding, actionArgs);
+
+  return {
+    pool,
+    liquidityAssetAmount,
+    externalPositionProxy,
+  };
+}
+
+export const mapleLiquidityRequestRedeemV2ArgsEncoding = [
+  {
+    name: "pool",
+    type: "address",
+  },
+  {
+    name: "poolTokenAmount",
+    type: "uint256",
+  },
+] as const;
+
+export type MapleLiquidityRequestRedeemV2Args = {
+  pool: Address;
+  poolTokenAmount: bigint;
+  externalPositionProxy: Address;
+};
+
+export function encodeMapleLiquidityRequestRedeemV2Args({
+  externalPositionProxy,
+  pool,
+  poolTokenAmount,
+}: MapleLiquidityRequestRedeemV2Args): Hex {
+  const actionArgs = encodeAbiParameters(mapleLiquidityRequestRedeemV2ArgsEncoding, [pool, poolTokenAmount]);
+
+  return encodeCallOnExternalPositionArgs({
+    externalPositionProxy,
+    actionId: MapleLiquidityAction.RequestRedeemV2,
+    actionArgs,
+  });
+}
+
+export function decodeMapleLiquidityRequestRedeemV2Args(callArgs: Hex): MapleLiquidityRequestRedeemV2Args {
+  const { externalPositionProxy, actionArgs } = decodeCallOnExternalPositionArgs(callArgs);
+  const [pool, poolTokenAmount] = decodeAbiParameters(mapleLiquidityRequestRedeemV2ArgsEncoding, actionArgs);
+
+  return {
+    pool,
+    poolTokenAmount,
+    externalPositionProxy,
+  };
+}
+
+export const mapleLiquidityRedeemV2ArgsEncoding = [
+  {
+    name: "pool",
+    type: "address",
+  },
+  {
+    name: "poolTokenAmount",
+    type: "uint256",
+  },
+] as const;
+
+export type MapleLiquidityRedeemV2Args = {
+  pool: Address;
+  poolTokenAmount: bigint;
+  externalPositionProxy: Address;
+};
+
+export function encodeMapleLiquidityRedeemV2Args({
+  externalPositionProxy,
+  pool,
+  poolTokenAmount,
+}: MapleLiquidityRedeemV2Args): Hex {
+  const actionArgs = encodeAbiParameters(mapleLiquidityRedeemV2ArgsEncoding, [pool, poolTokenAmount]);
+
+  return encodeCallOnExternalPositionArgs({
+    externalPositionProxy,
+    actionId: MapleLiquidityAction.RedeemV2,
+    actionArgs,
+  });
+}
+
+export function decodeMapleLiquidityRedeemV2Args(callArgs: Hex): MapleLiquidityRedeemV2Args {
+  const { externalPositionProxy, actionArgs } = decodeCallOnExternalPositionArgs(callArgs);
+  const [pool, poolTokenAmount] = decodeAbiParameters(mapleLiquidityRedeemV2ArgsEncoding, actionArgs);
+
+  return {
+    pool,
+    poolTokenAmount,
+    externalPositionProxy,
+  };
+}
+
+export const mapleLiquidityCancelRedeemV2ArgsEncoding = [
+  {
+    name: "pool",
+    type: "address",
+  },
+  {
+    name: "poolTokenAmount",
+    type: "uint256",
+  },
+] as const;
+
+export type MapleLiquidityCancelRedeemV2Args = {
+  pool: Address;
+  poolTokenAmount: bigint;
+  externalPositionProxy: Address;
+};
+
+export function encodeMapleLiquidityCancelRedeemV2Args({
+  externalPositionProxy,
+  pool,
+  poolTokenAmount,
+}: MapleLiquidityCancelRedeemV2Args): Hex {
+  const actionArgs = encodeAbiParameters(mapleLiquidityCancelRedeemV2ArgsEncoding, [pool, poolTokenAmount]);
+
+  return encodeCallOnExternalPositionArgs({
+    externalPositionProxy,
+    actionId: MapleLiquidityAction.CancelRedeemV2,
+    actionArgs,
+  });
+}
+
+export function decodeMapleLiquidityCancelRedeemV2Args(callArgs: Hex): MapleLiquidityCancelRedeemV2Args {
+  const { externalPositionProxy, actionArgs } = decodeCallOnExternalPositionArgs(callArgs);
+  const [pool, poolTokenAmount] = decodeAbiParameters(mapleLiquidityCancelRedeemV2ArgsEncoding, actionArgs);
+
+  return {
+    pool,
+    poolTokenAmount,
+    externalPositionProxy,
+  };
+}
+
+export const mapleLiquidityClaimRewardsV1ArgsEncoding = [
+  {
+    name: "rewardsContract",
+    type: "address",
+  },
+] as const;
+
+export type MapleLiquidityClaimRewardsV1Args = {
+  rewardsContract: Address;
+  externalPositionProxy: Address;
+};
+
+export function encodeMapleLiquidityClaimRewardsV1Args({
+  externalPositionProxy,
+  rewardsContract,
+}: MapleLiquidityClaimRewardsV1Args): Hex {
+  const actionArgs = encodeAbiParameters(mapleLiquidityClaimRewardsV1ArgsEncoding, [rewardsContract]);
+
+  return encodeCallOnExternalPositionArgs({
+    externalPositionProxy,
+    actionId: MapleLiquidityAction.ClaimRewardsV1,
+    actionArgs,
+  });
+}
+
+export function decodeMapleLiquidityClaimRewardsV1Args(callArgs: Hex): MapleLiquidityClaimRewardsV1Args {
+  const { externalPositionProxy, actionArgs } = decodeCallOnExternalPositionArgs(callArgs);
+  const [rewardsContract] = decodeAbiParameters(mapleLiquidityClaimRewardsV1ArgsEncoding, actionArgs);
+
+  return {
+    rewardsContract,
+    externalPositionProxy,
+  };
+}

--- a/packages/sdk/src/extensions/external-positions/prepareUseExternalPosition.ts
+++ b/packages/sdk/src/extensions/external-positions/prepareUseExternalPosition.ts
@@ -22,6 +22,13 @@ import {
   encodeConvexVotingWithdrawArgs,
 } from "./instances/convexVoting.js";
 import { encodeKilnStakeArgs } from "./instances/kiln.js";
+import {
+  encodeMapleLiquidityCancelRedeemV2Args,
+  encodeMapleLiquidityClaimRewardsV1Args,
+  encodeMapleLiquidityLendV2Args,
+  encodeMapleLiquidityRedeemV2Args,
+  encodeMapleLiquidityRequestRedeemV2Args,
+} from "./instances/mapleLiquidity.js";
 import type { Address } from "viem";
 
 export type TypedExternalPositionCallArgs = {
@@ -79,5 +86,15 @@ export function encodeExternalPositionCallArgs(callArgs: TypedExternalPositionCa
       return encodeConvexVotingClaimRewardsArgs(callArgs);
     case ExternalPosition.ConvexVotingDelegate:
       return encodeConvexVotingDelegateArgs(callArgs);
+    case ExternalPosition.MapleLiquidityClaimRewardsV1:
+      return encodeMapleLiquidityClaimRewardsV1Args(callArgs);
+    case ExternalPosition.MapleLiquidityLendV2:
+      return encodeMapleLiquidityLendV2Args(callArgs);
+    case ExternalPosition.MapleLiquidityRequestRedeemV2:
+      return encodeMapleLiquidityRequestRedeemV2Args(callArgs);
+    case ExternalPosition.MapleLiquidityRedeemV2:
+      return encodeMapleLiquidityRedeemV2Args(callArgs);
+    case ExternalPosition.MapleLiquidityCancelRedeemV2:
+      return encodeMapleLiquidityCancelRedeemV2Args(callArgs);
   }
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -569,6 +569,31 @@ export {
   type KilnStakeArgs,
 } from "./extensions/external-positions/instances/kiln.js";
 
+// ./extensions/external-positions/instances/mapleLiquidity.js
+export {
+  encodeMapleLiquidityLendV2Args,
+  decodeMapleLiquidityLendV2Args,
+  encodeMapleLiquidityRequestRedeemV2Args,
+  decodeMapleLiquidityRequestRedeemV2Args,
+  encodeMapleLiquidityRedeemV2Args,
+  decodeMapleLiquidityRedeemV2Args,
+  encodeMapleLiquidityCancelRedeemV2Args,
+  decodeMapleLiquidityCancelRedeemV2Args,
+  encodeMapleLiquidityClaimRewardsV1Args,
+  decodeMapleLiquidityClaimRewardsV1Args,
+  type MapleLiquidityAction,
+  mapleLiquidityLendV2ArgsEncoding,
+  type MapleLiquidityLendV2Args,
+  mapleLiquidityRequestRedeemV2ArgsEncoding,
+  type MapleLiquidityRequestRedeemV2Args,
+  mapleLiquidityRedeemV2ArgsEncoding,
+  type MapleLiquidityRedeemV2Args,
+  mapleLiquidityCancelRedeemV2ArgsEncoding,
+  type MapleLiquidityCancelRedeemV2Args,
+  mapleLiquidityClaimRewardsV1ArgsEncoding,
+  type MapleLiquidityClaimRewardsV1Args,
+} from "./extensions/external-positions/instances/mapleLiquidity.js";
+
 // ./extensions/fees/instances/entranceFee.js
 export {
   encodeEntranceRateBurnFeeSettings,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added maple liquidity trade helpers for encoding and decoding various actions
- Added functions to encode and decode Maple Liquidity LendV2, RequestRedeemV2, RedeemV2, CancelRedeemV2, and ClaimRewardsV1 actions
- Updated the `TypedExternalPositionCallArgs` type to include the new Maple Liquidity actions

> The following files were skipped due to too many changes: `packages/sdk/src/extensions/external-positions/instances/mapleLiquidity.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->