### PR TITLE
feat: add the graph delegation trade helpers

### DIFF
--- a/.changeset/tall-weeks-sneeze.md
+++ b/.changeset/tall-weeks-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Add the graph delegation trade helpers

--- a/packages/sdk/src/extensions/external-positions/externalPositionTypes.ts
+++ b/packages/sdk/src/extensions/external-positions/externalPositionTypes.ts
@@ -19,6 +19,11 @@ import type {
   ConvexVotingWithdrawArgs,
 } from "./instances/convexVoting.js";
 import type { KilnStakeArgs } from "./instances/kiln.js";
+import type {
+  TheGraphDelegationDelegateArgs,
+  TheGraphDelegationUndelegateArgs,
+  TheGraphDelegationWithdrawArgs,
+} from "./instances/theGraphDelegation.js";
 
 export type ExternalPosition = typeof ExternalPosition[keyof typeof ExternalPosition];
 export const ExternalPosition = {
@@ -37,6 +42,9 @@ export const ExternalPosition = {
   ConvexVotingWithdraw: "ConvexVotingWithdraw",
   ConvexVotingClaimRewards: "ConvexVotingClaimRewards",
   ConvexVotingDelegate: "ConvexVotingDelegate",
+  TheGraphDelegationDelegate: "TheGraphDelegationDelegate",
+  TheGraphDelegationUndelegate: "TheGraphDelegationUndelegate",
+  TheGraphDelegationWithdraw: "TheGraphDelegationWithdraw",
 } as const;
 
 export type ExternalPositionArgs = {
@@ -55,4 +63,7 @@ export type ExternalPositionArgs = {
   [ExternalPosition.ConvexVotingWithdraw]: ConvexVotingWithdrawArgs;
   [ExternalPosition.ConvexVotingClaimRewards]: ConvexVotingClaimRewardsArgs;
   [ExternalPosition.ConvexVotingDelegate]: ConvexVotingDelegateArgs;
+  [ExternalPosition.TheGraphDelegationDelegate]: TheGraphDelegationDelegateArgs;
+  [ExternalPosition.TheGraphDelegationUndelegate]: TheGraphDelegationUndelegateArgs;
+  [ExternalPosition.TheGraphDelegationWithdraw]: TheGraphDelegationWithdrawArgs;
 };

--- a/packages/sdk/src/extensions/external-positions/instances/theGraphDelegation.test.ts
+++ b/packages/sdk/src/extensions/external-positions/instances/theGraphDelegation.test.ts
@@ -1,0 +1,120 @@
+import { ITheGraphDelegationPositionLib } from "../../../../../abis/src/abis/ITheGraphDelegationPositionLib.js";
+import { EXTERNAL_POSITION_MANAGER } from "../../../../tests/constants.js";
+import { publicClient, sendTestTransaction, testClient } from "../../../../tests/globals.js";
+import { ExternalPosition } from "../externalPositionTypes.js";
+import { prepareUseExternalPosition } from "../prepareUseExternalPosition.js";
+import {
+  decodeTheGraphDelegationDelegateArgs,
+  decodeTheGraphDelegationUndelegateArgs,
+  decodeTheGraphDelegationWithdrawArgs,
+} from "./theGraphDelegation.js";
+import { parseEther } from "viem";
+import { expect, test } from "vitest";
+
+const comptrollerProxy = "0x746de9838BB3D14f1aC1b78Bd855E48201F221a6" as const;
+const vaultOwner = "0x0D947D68f583e8B23ff816df9ff3f23a8Cfd7496" as const;
+
+test("prepare external position trade for The Graph Delegation delegate should work correctly", async () => {
+  await testClient.reset({
+    blockNumber: 15680558n,
+  });
+
+  await testClient.setBalance({ address: vaultOwner, value: parseEther("1") });
+
+  // Taken from tx 0x90d6d22bbd36f6138c7f6ae1e84ac0afe1c77d8a54cdf873bb70c5c101f7fd51
+  const callArgs =
+    "0x00000000000000000000000077bc80782bdceb445cbfcf6f7c31d0205d9a702500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000004000000000000000000000000062a0bd1d110ff4e5b793119e95fc07c9d1fc8c4a0000000000000000000000000000000000000000000000000a688906bd8b0000";
+
+  const decodedCallArgs = decodeTheGraphDelegationDelegateArgs(callArgs);
+
+  await sendTestTransaction({
+    ...prepareUseExternalPosition({
+      externalPositionManager: EXTERNAL_POSITION_MANAGER,
+      callArgs: {
+        type: ExternalPosition.TheGraphDelegationDelegate,
+        ...decodedCallArgs,
+      },
+    }),
+    account: vaultOwner,
+    address: comptrollerProxy,
+  });
+
+  const grtValue = await publicClient.readContract({
+    abi: ITheGraphDelegationPositionLib,
+    address: decodedCallArgs.externalPositionProxy,
+    functionName: "getDelegationGrtValue",
+    args: [decodedCallArgs.indexer],
+  });
+
+  expect(grtValue).toBe(746249999999999999n);
+});
+
+test("prepare external position trade for The Graph Delegation undelegate should work correctly", async () => {
+  await testClient.reset({
+    blockNumber: 16125126n,
+  });
+
+  await testClient.setBalance({ address: vaultOwner, value: parseEther("1") });
+
+  // Taken from tx 0x3880f2eacccefe49c1f4fb893b630416c2fe576dfc4a6e401ea7bf633eded593
+  const callArgs =
+    "0x00000000000000000000000077bc80782bdceb445cbfcf6f7c31d0205d9a702500000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000004000000000000000000000000063e2c9a3db9ffd3cc108f08ead601966ea031f5c00000000000000000000000000000000000000000000000000990409fc05124d";
+
+  const decodedCallArgs = decodeTheGraphDelegationUndelegateArgs(callArgs);
+
+  await sendTestTransaction({
+    ...prepareUseExternalPosition({
+      externalPositionManager: EXTERNAL_POSITION_MANAGER,
+      callArgs: {
+        type: ExternalPosition.TheGraphDelegationUndelegate,
+        ...decodedCallArgs,
+      },
+    }),
+    account: vaultOwner,
+    address: comptrollerProxy,
+  });
+
+  const grtValue = await publicClient.readContract({
+    abi: ITheGraphDelegationPositionLib,
+    address: decodedCallArgs.externalPositionProxy,
+    functionName: "getDelegationGrtValue",
+    args: [decodedCallArgs.indexer],
+  });
+
+  expect(grtValue).toBe(1011381388327971961n);
+});
+
+test("prepare external position trade for The Graph Delegation withdraw should work correctly", async () => {
+  await testClient.reset({
+    blockNumber: 16125134n,
+  });
+
+  await testClient.setBalance({ address: vaultOwner, value: parseEther("1") });
+
+  // Taken from tx 0x2f4f6c1f5a522d3770a6594503f0ee936792ac7732d79f8db544b1464f9e1dd1
+  const callArgs =
+    "0x000000000000000000000000c9c461fa8580b897b7bd10d75305d608489e822300000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000004000000000000000000000000085fe868adf7f5950b052469075556fb207e5372d0000000000000000000000000000000000000000000000000000000000000000";
+
+  const decodedCallArgs = decodeTheGraphDelegationWithdrawArgs(callArgs);
+
+  await sendTestTransaction({
+    ...prepareUseExternalPosition({
+      externalPositionManager: EXTERNAL_POSITION_MANAGER,
+      callArgs: {
+        type: ExternalPosition.TheGraphDelegationWithdraw,
+        ...decodedCallArgs,
+      },
+    }),
+    account: vaultOwner,
+    address: comptrollerProxy,
+  });
+
+  const grtValue = await publicClient.readContract({
+    abi: ITheGraphDelegationPositionLib,
+    address: decodedCallArgs.externalPositionProxy,
+    functionName: "getDelegationGrtValue",
+    args: [decodedCallArgs.indexer],
+  });
+
+  expect(grtValue).toBe(1n);
+});

--- a/packages/sdk/src/extensions/external-positions/instances/theGraphDelegation.ts
+++ b/packages/sdk/src/extensions/external-positions/instances/theGraphDelegation.ts
@@ -1,0 +1,135 @@
+import { decodeCallOnExternalPositionArgs, encodeCallOnExternalPositionArgs } from "../callOnExternalPosition.js";
+import { type Address, type Hex, decodeAbiParameters, encodeAbiParameters } from "viem";
+
+export type TheGraphDelegationAction = typeof TheGraphDelegationAction[keyof typeof TheGraphDelegationAction];
+export const TheGraphDelegationAction = {
+  Delegate: 0n,
+  Undelegate: 1n,
+  Withdraw: 2n,
+} as const;
+
+export const theGraphDelegationDelegateArgsEncoding = [
+  {
+    name: "indexer",
+    type: "address",
+  },
+  {
+    name: "tokens",
+    type: "uint256",
+  },
+] as const;
+
+export type TheGraphDelegationDelegateArgs = {
+  indexer: Address;
+  tokens: bigint;
+  externalPositionProxy: Address;
+};
+
+export function encodeTheGraphDelegationDelegateArgs({
+  externalPositionProxy,
+  indexer,
+  tokens,
+}: TheGraphDelegationDelegateArgs): Hex {
+  const actionArgs = encodeAbiParameters(theGraphDelegationDelegateArgsEncoding, [indexer, tokens]);
+
+  return encodeCallOnExternalPositionArgs({
+    externalPositionProxy,
+    actionId: TheGraphDelegationAction.Delegate,
+    actionArgs,
+  });
+}
+
+export function decodeTheGraphDelegationDelegateArgs(callArgs: Hex): TheGraphDelegationDelegateArgs {
+  const { externalPositionProxy, actionArgs } = decodeCallOnExternalPositionArgs(callArgs);
+  const [indexer, tokens] = decodeAbiParameters(theGraphDelegationDelegateArgsEncoding, actionArgs);
+
+  return {
+    indexer,
+    tokens,
+    externalPositionProxy,
+  };
+}
+
+export const theGraphDelegationUndelegateArgsEncoding = [
+  {
+    name: "indexer",
+    type: "address",
+  },
+  {
+    name: "shares",
+    type: "uint256",
+  },
+] as const;
+
+export type TheGraphDelegationUndelegateArgs = {
+  indexer: Address;
+  shares: bigint;
+  externalPositionProxy: Address;
+};
+
+export function encodeTheGraphDelegationUndelegateArgs({
+  externalPositionProxy,
+  indexer,
+  shares,
+}: TheGraphDelegationUndelegateArgs): Hex {
+  const actionArgs = encodeAbiParameters(theGraphDelegationUndelegateArgsEncoding, [indexer, shares]);
+
+  return encodeCallOnExternalPositionArgs({
+    externalPositionProxy,
+    actionId: TheGraphDelegationAction.Undelegate,
+    actionArgs,
+  });
+}
+
+export function decodeTheGraphDelegationUndelegateArgs(callArgs: Hex): TheGraphDelegationUndelegateArgs {
+  const { externalPositionProxy, actionArgs } = decodeCallOnExternalPositionArgs(callArgs);
+  const [indexer, shares] = decodeAbiParameters(theGraphDelegationUndelegateArgsEncoding, actionArgs);
+
+  return {
+    indexer,
+    shares,
+    externalPositionProxy,
+  };
+}
+
+export const theGraphDelegationWithdrawArgsEncoding = [
+  {
+    name: "indexer",
+    type: "address",
+  },
+  {
+    name: "nextIndexer",
+    type: "address",
+  },
+] as const;
+
+export type TheGraphDelegationWithdrawArgs = {
+  indexer: Address;
+  nextIndexer: Address;
+  externalPositionProxy: Address;
+};
+
+export function encodeTheGraphDelegationWithdrawArgs({
+  externalPositionProxy,
+  indexer,
+  nextIndexer,
+}: TheGraphDelegationWithdrawArgs): Hex {
+  const actionArgs = encodeAbiParameters(theGraphDelegationWithdrawArgsEncoding, [indexer, nextIndexer]);
+
+  return encodeCallOnExternalPositionArgs({
+    externalPositionProxy,
+    actionId: TheGraphDelegationAction.Withdraw,
+    actionArgs,
+  });
+}
+
+export function decodeTheGraphDelegationWithdrawArgs(callArgs: Hex): TheGraphDelegationWithdrawArgs {
+  const { externalPositionProxy, actionArgs } = decodeCallOnExternalPositionArgs(callArgs);
+  const [indexer, nextIndexer] = decodeAbiParameters(theGraphDelegationWithdrawArgsEncoding, actionArgs);
+
+  return {
+    indexer,
+    nextIndexer,
+    externalPositionProxy,
+  };
+}

--- a/packages/sdk/src/extensions/external-positions/prepareUseExternalPosition.ts
+++ b/packages/sdk/src/extensions/external-positions/prepareUseExternalPosition.ts
@@ -22,6 +22,11 @@ import {
   encodeConvexVotingWithdrawArgs,
 } from "./instances/convexVoting.js";
 import { encodeKilnStakeArgs } from "./instances/kiln.js";
+import {
+  encodeTheGraphDelegationDelegateArgs,
+  encodeTheGraphDelegationUndelegateArgs,
+  encodeTheGraphDelegationWithdrawArgs,
+} from "./instances/theGraphDelegation.js";
 import type { Address } from "viem";
 
 export type TypedExternalPositionCallArgs = {
@@ -79,5 +84,11 @@ export function encodeExternalPositionCallArgs(callArgs: TypedExternalPositionCa
       return encodeConvexVotingClaimRewardsArgs(callArgs);
     case ExternalPosition.ConvexVotingDelegate:
       return encodeConvexVotingDelegateArgs(callArgs);
+    case ExternalPosition.TheGraphDelegationDelegate:
+      return encodeTheGraphDelegationDelegateArgs(callArgs);
+    case ExternalPosition.TheGraphDelegationUndelegate:
+      return encodeTheGraphDelegationUndelegateArgs(callArgs);
+    case ExternalPosition.TheGraphDelegationWithdraw:
+      return encodeTheGraphDelegationWithdrawArgs(callArgs);
   }
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -569,6 +569,23 @@ export {
   type KilnStakeArgs,
 } from "./extensions/external-positions/instances/kiln.js";
 
+// ./extensions/external-positions/instances/theGraphDelegation.js
+export {
+  encodeTheGraphDelegationDelegateArgs,
+  decodeTheGraphDelegationDelegateArgs,
+  encodeTheGraphDelegationUndelegateArgs,
+  decodeTheGraphDelegationUndelegateArgs,
+  encodeTheGraphDelegationWithdrawArgs,
+  decodeTheGraphDelegationWithdrawArgs,
+  type TheGraphDelegationAction,
+  theGraphDelegationDelegateArgsEncoding,
+  type TheGraphDelegationDelegateArgs,
+  theGraphDelegationUndelegateArgsEncoding,
+  type TheGraphDelegationUndelegateArgs,
+  theGraphDelegationWithdrawArgsEncoding,
+  type TheGraphDelegationWithdrawArgs,
+} from "./extensions/external-positions/instances/theGraphDelegation.js";
+
 // ./extensions/fees/instances/entranceFee.js
 export {
   encodeEntranceRateBurnFeeSettings,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added the graph delegation trade helpers to the SDK.
- Added functions for encoding and decoding the graph delegation delegate, undelegate, and withdraw arguments.
- Added types for the graph delegation delegate, undelegate, and withdraw arguments.
- Updated the `ExternalPosition` enum to include the graph delegation delegate, undelegate, and withdraw positions.
- Updated the `ExternalPositionArgs` type to include the graph delegation delegate, undelegate, and withdraw arguments.

> The following files were skipped due to too many changes: `packages/sdk/src/extensions/external-positions/instances/theGraphDelegation.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->