### PR TITLE
feat: get vault nominated owner

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -343,17 +343,12 @@ export { getTrackedAssets } from "./reads/getTrackedAssets.js";
 
 // ./reads/getVaultHasMigration.js
 export { getVaultHasMigrationRequest } from "./reads/getVaultHasMigration.js";
+
 // ./reads/getVaultHasReconfiguration.js
 export { getVaultHasReconfigurationRequest } from "./reads/getVaultHasReconfiguration.js";
 
 // ./reads/getVaultName.js
 export { getVaultName } from "./reads/getVaultName.js";
-
-// ./reads/getVaultNav.js
-export { getVaultNav } from "./reads/getVaultNav.js";
-
-// ./reads/getVaultNavInAsset.js
-export { getVaultNavInAsset } from "./reads/getVaultNavInAsset.js";
 
 // ./reads/getVaultNominatedOwner.js
 export { getVaultNominatedOwner } from "./reads/getVaultNominatedOwner.js";

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -349,6 +349,15 @@ export { getVaultHasReconfigurationRequest } from "./reads/getVaultHasReconfigur
 // ./reads/getVaultName.js
 export { getVaultName } from "./reads/getVaultName.js";
 
+// ./reads/getVaultNav.js
+export { getVaultNav } from "./reads/getVaultNav.js";
+
+// ./reads/getVaultNavInAsset.js
+export { getVaultNavInAsset } from "./reads/getVaultNavInAsset.js";
+
+// ./reads/getVaultNominatedOwner.js
+export { getVaultNominatedOwner } from "./reads/getVaultNominatedOwner.js";
+
 // ./reads/getVaultOwner.js
 export { getVaultOwner } from "./reads/getVaultOwner.js";
 

--- a/packages/sdk/src/reads/getVaultNominatedOwner.ts
+++ b/packages/sdk/src/reads/getVaultNominatedOwner.ts
@@ -1,0 +1,18 @@
+import { IVaultLib } from "@enzymefinance/abis/IVaultLib";
+import type { Address, PublicClient } from "viem";
+import { readContract } from "viem/contract";
+
+export function getVaultNominatedOwner(
+  client: PublicClient,
+  {
+    vault,
+  }: {
+    vault: Address;
+  },
+) {
+  return readContract(client, {
+    abi: IVaultLib,
+    functionName: "getNominatedOwner",
+    address: vault,
+  });
+}

--- a/packages/sdk/src/reads/getVaultNominatedOwner.ts
+++ b/packages/sdk/src/reads/getVaultNominatedOwner.ts
@@ -1,18 +1,17 @@
 import { IVaultLib } from "@enzymefinance/abis/IVaultLib";
 import type { Address, PublicClient } from "viem";
-import { readContract } from "viem/contract";
+import { type ReadContractParameters, readContractParameters } from "../utils/viem.js";
 
 export function getVaultNominatedOwner(
   client: PublicClient,
-  {
-    vault,
-  }: {
+  args: ReadContractParameters<{
     vault: Address;
-  },
+  }>,
 ) {
-  return readContract(client, {
+  return client.readContract({
+    ...readContractParameters(args),
     abi: IVaultLib,
     functionName: "getNominatedOwner",
-    address: vault,
+    address: args.vault,
   });
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new function `getVaultNominatedOwner` to the SDK's `reads` module. 

### Detailed summary
- Added a new file `getVaultNominatedOwner.ts` in the `reads` directory.
- Imported `IVaultLib` from `@enzymefinance/abis/IVaultLib`.
- Imported `Address` and `PublicClient` types from `viem`.
- Imported `readContractParameters` function from `../utils/viem.js`.
- Exported `getVaultNominatedOwner` function.
- Updated `index.ts` to export `getVaultNominatedOwner` from the `reads` module.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->