### PR TITLE
test: get vault owner

### DIFF
--- a/packages/sdk/src/reads/getVaultOwner.test.ts
+++ b/packages/sdk/src/reads/getVaultOwner.test.ts
@@ -1,0 +1,14 @@
+import { publicClientMainnet } from "../../tests/globals.js";
+import { getVaultOwner } from "./getVaultOwner.js";
+import { isAddress } from "viem";
+import { expect, test } from "vitest";
+
+test("read vault owner should work correctly", async () => {
+  const vaultProxy = "0x278C647F7cfb9D55580c69d3676938608C945ba8" as const;
+
+  const vaultOwner = await getVaultOwner(publicClientMainnet, {
+    vaultProxy,
+  });
+
+  expect(isAddress(vaultOwner)).toBeTruthy();
+});


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

This PR focuses on adding a test for the `getVaultOwner` function in the `packages/sdk/src/reads/getVaultOwner.test.ts` file. The test ensures that the function works correctly by checking if the returned `vaultOwner` is a valid address.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->