### PR TITLE
feat: get accrued protocol fee

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -215,6 +215,9 @@ export {
 // ./reads/doesAutoProtocolFeeSharesBuyback.js
 export { doesAutoProtocolFeeSharesBuyback } from "./reads/doesAutoProtocolFeeSharesBuyback.js";
 
+// ./reads/getAccruedProtocolFee.js
+export { getAccruedProtocolFee } from "./reads/getAccruedProtocolFee.js";
+
 // ./reads/getActiveExternalPositions.js
 export { getActiveExternalPositions } from "./reads/getActiveExternalPositions.js";
 

--- a/packages/sdk/src/reads/getAccruedProtocolFee.ts
+++ b/packages/sdk/src/reads/getAccruedProtocolFee.ts
@@ -1,0 +1,20 @@
+import { IProtocolFeeTracker } from "../../../abis/src/abis/IProtocolFeeTracker.js";
+import { type ReadContractParameters, readContractParameters } from "../utils/viem.js";
+import type { Address, PublicClient } from "viem";
+import { simulateContract } from "viem/contract";
+
+export function getAccruedProtocolFee(
+  client: PublicClient,
+  args: ReadContractParameters<{
+    vaultProxy: Address;
+    protocolFeeTracker: Address;
+  }>,
+) {
+  return simulateContract(client, {
+    ...readContractParameters(args),
+    abi: IProtocolFeeTracker,
+    functionName: "payFee",
+    address: args.protocolFeeTracker,
+    account: args.vaultProxy,
+  });
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding a new function `getAccruedProtocolFee` to the SDK's `reads` module.

### Detailed summary:
- Added a new file `getAccruedProtocolFee.ts` under `packages/sdk/src/reads`.
- Imported `IProtocolFeeTracker` from `../../../abis/src/abis/IProtocolFeeTracker.js`.
- Imported `ReadContractParameters` and `readContractParameters` from `../utils/viem.js`.
- Imported `Address` and `PublicClient` from `"viem"`.
- Imported `simulateContract` from `"viem/contract"`.
- Added a new function `getAccruedProtocolFee` with the following parameters:
  - `client: PublicClient`
  - `args: ReadContractParameters<{vaultProxy: Address; protocolFeeTracker: Address;}>`
- The function uses `simulateContract` to simulate contract interaction.
- The function returns the result of the simulated contract interaction.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->