### PR TITLE
feat: convert maple shares to exit assets

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -127,6 +127,7 @@ export {
   UNSTAKE_SELECTOR,
   UNSTAKE_AND_REDEEM_SELECTOR,
   TAKE_ORDER_SELECTOR,
+  TAKE_MULTIPLE_ORDERS_SELECTOR,
   TOGGLE_APPROVE_MINT_SELECTOR,
 } from "./constants/selectors.js";
 
@@ -211,6 +212,9 @@ export {
   type ExternalPositionManagerActionId,
   type IntegrationManagerActionId,
 } from "./extensions/callOnExtension.js";
+
+// ./reads/convertMapleSharesToExitAssets.js
+export { convertMapleSharesToExitAssets } from "./reads/convertMapleSharesToExitAssets.js";
 
 // ./reads/doesAutoProtocolFeeSharesBuyback.js
 export { doesAutoProtocolFeeSharesBuyback } from "./reads/doesAutoProtocolFeeSharesBuyback.js";
@@ -413,7 +417,7 @@ export {
 export { multiplyBySlippage } from "./utils/slippage.js";
 
 // ./utils/types.js
-export type { PartialPick, Prettify, TupleOf, Tuple } from "./utils/types.js";
+export type { PartialPick, Prettify, TupleOf, Tuple, DeepWriteable } from "./utils/types.js";
 
 // ./utils/viem.js
 export {
@@ -575,6 +579,8 @@ export {
   decodeKilnPausePositionValueArgs,
   encodeKilnUnpausePositionValueArgs,
   decodeKilnUnpausePositionValueArgs,
+  encodeKilnUnstakeArgs,
+  decodeKilnUnstakeArgs,
   type KilnAction,
   type KilnClaimType,
   type KilnStakeArgs,
@@ -582,6 +588,7 @@ export {
   type KilnSweepEthArgs,
   type KilnPausePositionValueArgs,
   type KilnUnpausePositionValueArgs,
+  type KilnUnstakeArgs,
 } from "./extensions/external-positions/instances/kiln.js";
 
 // ./extensions/external-positions/instances/liquity.js
@@ -855,7 +862,17 @@ export {
 export {
   encodeParaswapV5TakeOrderArgs,
   decodeParaswapV5TakeOrderArgs,
+  encodeParaswapV5TakeMultipleOrdersArgs,
+  decodeParaswapV5TakeMultipleOrdersArgs,
+  type ParaswapV5SwapType,
+  type ParaswapV5Route,
+  type ParaswapV5Adapter,
+  type ParaswapV5Path,
+  type ParaswapV5MegaSwapData,
+  type ParaswapV5MultiSwapData,
+  type ParaswapV5SimpleSwapData,
   type ParaswapV5TakeOrderArgs,
+  type ParaswapV5TakeMultipleOrdersArgs,
 } from "./extensions/integrations/instances/paraswapV5.js";
 
 // ./extensions/integrations/instances/uniswapV2Exchange.js

--- a/packages/sdk/src/reads/convertMapleSharesToExitAssets.ts
+++ b/packages/sdk/src/reads/convertMapleSharesToExitAssets.ts
@@ -1,0 +1,26 @@
+import { type ReadContractParameters, readContractParameters } from "../utils/viem.js";
+import type { Address, PublicClient } from "viem";
+
+const abi = {
+  inputs: [{ internalType: "uint256", name: "shares_", type: "uint256" }],
+  name: "convertToExitAssets",
+  outputs: [{ internalType: "uint256", name: "assets_", type: "uint256" }],
+  stateMutability: "view",
+  type: "function",
+} as const;
+
+export async function convertMapleSharesToExitAssets(
+  client: PublicClient,
+  args: ReadContractParameters<{
+    pool: Address;
+    shares: bigint;
+  }>,
+) {
+  return client.readContract({
+    ...readContractParameters(args),
+    abi: [abi],
+    functionName: "convertToExitAssets",
+    address: args.pool,
+    args: [args.shares],
+  });
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding a new function `convertMapleSharesToExitAssets` and making several updates to the codebase.

### Detailed summary:
- Added a new function `convertMapleSharesToExitAssets` in the file `convertMapleSharesToExitAssets.ts` under the `packages/sdk/src/reads` directory.
- Imported `readContractParameters` and `type ReadContractParameters` from `../utils/viem.js` in the file `convertMapleSharesToExitAssets.ts`.
- Imported `Address` and `PublicClient` from `"viem"` in the file `convertMapleSharesToExitAssets.ts`.
- Defined `abi` object in the file `convertMapleSharesToExitAssets.ts`.
- Updated the `index.ts` file to export the newly added function `convertMapleSharesToExitAssets`.
- Added a new import statement for `TAKE_MULTIPLE_ORDERS_SELECTOR` in the file `index.ts`.
- Updated the `utils/types.js` file to export `DeepWriteable` type.
- Updated the `extensions/external-positions/instances/kiln.js` file to export `encodeKilnUnstakeArgs` and `decodeKilnUnstakeArgs` types.
- Updated the `extensions/integrations/instances/paraswapV5.js` file to export `encodeParaswapV5TakeMultipleOrdersArgs`, `decodeParaswapV5TakeMultipleOrdersArgs`, `ParaswapV5TakeMultipleOrdersArgs`, `ParaswapV5MegaSwapData`, `ParaswapV5MultiSwapData`, and `ParaswapV5SimpleSwapData` types.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->