### PR TITLE
feat: get idle speeds

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -309,6 +309,9 @@ export { getGrossAssetValueInAsset } from "./reads/getGrossAssetValueInAsset.js"
 // ./reads/getIdleRate.js
 export { getIdleRate } from "./reads/getIdleRate.js";
 
+// ./reads/getIdleSpeeds.js
+export { getIdleSpeeds } from "./reads/getIdleSpeeds.js";
+
 // ./reads/getLabelForPositionType.js
 export { getLabelForExternalPositionType } from "./reads/getLabelForPositionType.js";
 
@@ -347,6 +350,9 @@ export { getPolicyManager } from "./reads/getPolicyManager.js";
 
 // ./reads/getPortfolio.js
 export { getPortfolio } from "./reads/getPortfolio.js";
+
+// ./reads/getProtocolFeeRate.js
+export { getProtocolFeeRate } from "./reads/getProtocolFeeRate.js";
 
 // ./reads/getSharePrice.js
 export { getSharePrice } from "./reads/getSharePrice.js";

--- a/packages/sdk/src/reads/getIdleSpeeds.ts
+++ b/packages/sdk/src/reads/getIdleSpeeds.ts
@@ -1,0 +1,26 @@
+import { type ReadContractParameters, readContractParameters } from "../utils/viem.js";
+import type { Address, PublicClient } from "viem";
+
+const abi = {
+  inputs: [{ internalType: "address", name: "", type: "address" }],
+  name: "idleSpeeds",
+  outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+  stateMutability: "view",
+  type: "function",
+} as const;
+
+export function getIdleSpeeds(
+  client: PublicClient,
+  args: ReadContractParameters<{
+    idleController: Address;
+    idlePool: Address;
+  }>,
+) {
+  return client.readContract({
+    ...readContractParameters(args),
+    abi: [abi],
+    functionName: "idleSpeeds",
+    address: args.idleController,
+    args: [args.idlePool],
+  });
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
This PR introduces a new function `getIdleSpeeds` in the `sdk/src/reads/getIdleSpeeds.ts` file. It allows reading the idle speeds from a contract using the Viem library.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->