### PR TITLE
feat: add get liquity troves

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -315,6 +315,9 @@ export { getLabelForExternalPositionType } from "./reads/getLabelForPositionType
 // ./reads/getLastSharesBoughtTimestamp.js
 export { getLastSharesBoughtTimestamp } from "./reads/getLastSharesBoughtTimestamp.js";
 
+// ./reads/getLiquityTroves.js
+export { getLiquityTrove, getLiquityTroves, type LiquityTrove } from "./reads/getLiquityTroves.js";
+
 // ./reads/getListIdsForVaultPolicy.js
 export { getListIdsForVaultPolicy } from "./reads/getListIdsForVaultPolicy.js";
 

--- a/packages/sdk/src/reads/getLiquityTroves.test.ts
+++ b/packages/sdk/src/reads/getLiquityTroves.test.ts
@@ -1,0 +1,24 @@
+import { publicClientMainnet } from "../../tests/globals.js";
+import { getLiquityTroves } from "./getLiquityTroves.js";
+import { isAddress } from "viem";
+import { assert, expect, test } from "vitest";
+
+test("get liquity troves should work correctly", async () => {
+  const result = await getLiquityTroves(publicClientMainnet, {
+    // use data from tx 0x17a5931f4d11516f4238983af1970f10cf171ae87b7dbedfb7766cdd6372caf7
+    liquityTroveManager: "0xa39739ef8b0231dbfa0dcda07d7e29faabcf4bb2",
+    debtPositions: ["0x30f003f39a295866df145e1fb5afaa2913ee7e3f"],
+  });
+
+  assert(result !== undefined);
+  expect(Object.keys(result).length).toBeGreaterThan(0);
+
+  for (const [position, trove] of Object.entries(result)) {
+    expect(isAddress(position)).toBeTruthy();
+    expect(trove.collateral).toBeTypeOf("bigint");
+    expect(trove.debt).toBeTypeOf("bigint");
+    expect(trove.stake).toBeTypeOf("bigint");
+    expect(trove.arrayIndex).toBeTypeOf("bigint");
+    expect(trove.status).toBeTypeOf("number");
+  }
+});

--- a/packages/sdk/src/reads/getLiquityTroves.ts
+++ b/packages/sdk/src/reads/getLiquityTroves.ts
@@ -39,7 +39,7 @@ const abi = {
   ],
   stateMutability: "view",
   type: "function",
-};
+} as const;
 
 export type LiquityTrove = {
   debt: bigint;
@@ -56,24 +56,20 @@ export async function getLiquityTrove(
     debtPosition: Address;
   }>,
 ) {
-  const result = (await client.readContract({
+  const [debt, collateral, stake, status, arrayIndex] = await client.readContract({
     ...readContractParameters(args),
     abi: [abi],
     functionName: "Troves",
     address: args.liquityTroveManager,
     args: [args.debtPosition],
-  })) as unknown as [bigint, bigint, bigint, number, bigint];
-
-  if (result === undefined) {
-    throw new Error("Trove not found");
-  }
+  });
 
   return {
-    debt: result[0],
-    collateral: result[1],
-    stake: result[2],
-    status: result[3],
-    arrayIndex: result[4],
+    debt,
+    collateral,
+    stake,
+    status,
+    arrayIndex,
   };
 }
 

--- a/packages/sdk/src/reads/getLiquityTroves.ts
+++ b/packages/sdk/src/reads/getLiquityTroves.ts
@@ -6,63 +6,75 @@ const abi = {
     {
       internalType: "address",
       name: "",
-      type: "address"
-    }
+      type: "address",
+    },
   ],
   name: "Troves",
   outputs: [
     {
       internalType: "uint256",
       name: "debt",
-      type: "uint256"
+      type: "uint256",
     },
     {
       internalType: "uint256",
       name: "coll",
-      type: "uint256"
+      type: "uint256",
     },
     {
       internalType: "uint256",
       name: "stake",
-      type: "uint256"
+      type: "uint256",
     },
     {
       internalType: "enum TroveManager.Status",
       name: "status",
-      type: "uint8"
+      type: "uint8",
     },
     {
       internalType: "uint128",
       name: "arrayIndex",
-      type: "uint128"
-    }
+      type: "uint128",
+    },
   ],
   stateMutability: "view",
-  type: "function"
-}
+  type: "function",
+};
 
 export type LiquityTrove = {
   debt: bigint;
-  coll: bigint;
+  collateral: bigint;
   stake: bigint;
   status: number;
   arrayIndex: bigint;
-}
+};
 
-export function getLiquityTrove(
+export async function getLiquityTrove(
   client: PublicClient,
   args: ReadContractParameters<{
     liquityTroveManager: Address;
     debtPosition: Address;
   }>,
 ) {
-  return client.readContract({
+  const result = (await client.readContract({
     ...readContractParameters(args),
     abi: [abi],
     functionName: "Troves",
     address: args.liquityTroveManager,
     args: [args.debtPosition],
-  }) as unknown as Promise<LiquityTrove>;
+  })) as unknown as [bigint, bigint, bigint, number, bigint];
+
+  if (result === undefined) {
+    throw new Error("Trove not found");
+  }
+
+  return {
+    debt: result[0],
+    collateral: result[1],
+    stake: result[2],
+    status: result[3],
+    arrayIndex: result[4],
+  };
 }
 
 export async function getLiquityTroves(

--- a/packages/sdk/src/reads/getLiquityTroves.ts
+++ b/packages/sdk/src/reads/getLiquityTroves.ts
@@ -1,0 +1,92 @@
+import { type ReadContractParameters, readContractParameters } from "../utils/viem.js";
+import type { Address, PublicClient } from "viem";
+
+const abi = {
+  inputs: [
+    {
+      internalType: "address",
+      name: "",
+      type: "address"
+    }
+  ],
+  name: "Troves",
+  outputs: [
+    {
+      internalType: "uint256",
+      name: "debt",
+      type: "uint256"
+    },
+    {
+      internalType: "uint256",
+      name: "coll",
+      type: "uint256"
+    },
+    {
+      internalType: "uint256",
+      name: "stake",
+      type: "uint256"
+    },
+    {
+      internalType: "enum TroveManager.Status",
+      name: "status",
+      type: "uint8"
+    },
+    {
+      internalType: "uint128",
+      name: "arrayIndex",
+      type: "uint128"
+    }
+  ],
+  stateMutability: "view",
+  type: "function"
+}
+
+export type LiquityTrove = {
+  debt: bigint;
+  coll: bigint;
+  stake: bigint;
+  status: number;
+  arrayIndex: bigint;
+}
+
+export function getLiquityTrove(
+  client: PublicClient,
+  args: ReadContractParameters<{
+    liquityTroveManager: Address;
+    debtPosition: Address;
+  }>,
+) {
+  return client.readContract({
+    ...readContractParameters(args),
+    abi: [abi],
+    functionName: "Troves",
+    address: args.liquityTroveManager,
+    args: [args.debtPosition],
+  }) as unknown as Promise<LiquityTrove>;
+}
+
+export async function getLiquityTroves(
+  client: PublicClient,
+  args: ReadContractParameters<{
+    liquityTroveManager: Address;
+    debtPositions: [Address];
+  }>,
+) {
+  const troves = await Promise.all(
+    args.debtPositions.map(async (position) => {
+      const trove = await getLiquityTrove(client, {
+        ...args,
+        debtPosition: position,
+      });
+
+      return { position, trove };
+    }),
+  );
+
+  const troveMap: Record<Address, LiquityTrove> = {};
+  for (const { position, trove } of troves) {
+    troveMap[position] = trove;
+  }
+
+  return troveMap;
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding a new function `getLiquityTroves` to the SDK, which retrieves Liquity trove information from the blockchain.

### Detailed summary:
- Added `getLiquityTroves` function to `packages/sdk/src/reads/getLiquityTroves.ts` file.
- Added `getLiquityTrove` function to `packages/sdk/src/reads/getLiquityTroves.ts` file.
- Added `LiquityTrove` type to `packages/sdk/src/reads/getLiquityTroves.ts` file.
- Added tests for `getLiquityTroves` function in `packages/sdk/src/reads/getLiquityTroves.test.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->