### PR TITLE
feat: add get convex token locked balances

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -384,6 +384,14 @@ export { getVaultOwner } from "./reads/getVaultOwner.js";
 // ./reads/getVaultTimelockRemainingForMigrationRequest.js
 export { getVaultTimelockRemainingForMigrationRequest } from "./reads/getVaultTimelockRemainingForMigrationRequest.js";
 
+// ./reads/getVoteLockedConvexTokenLockedBalances.js
+export {
+  getVoteLockedConvexTokenLockedBalances,
+  getAllVoteLockedConvexTokenLockedBalances,
+  type lockedData,
+  type LockedBalances,
+} from "./reads/getVoteLockedConvexTokenLockedBalances.js";
+
 // ./reads/hasExecutableMigrationRequest.js
 export { hasExecutableMigrationRequest } from "./reads/hasExecutableMigrationRequest.js";
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -388,8 +388,6 @@ export { getVaultTimelockRemainingForMigrationRequest } from "./reads/getVaultTi
 export {
   getVoteLockedConvexTokenLockedBalances,
   getAllVoteLockedConvexTokenLockedBalances,
-  type lockedData,
-  type LockedBalances,
 } from "./reads/getVoteLockedConvexTokenLockedBalances.js";
 
 // ./reads/hasExecutableMigrationRequest.js

--- a/packages/sdk/src/reads/getVoteLockedConvexTokenLockedBalances.test.ts
+++ b/packages/sdk/src/reads/getVoteLockedConvexTokenLockedBalances.test.ts
@@ -2,12 +2,19 @@ import { publicClientMainnet } from "../../tests/globals.js";
 import { getVoteLockedConvexTokenLockedBalances } from "./getVoteLockedConvexTokenLockedBalances.js";
 import { assert, expect, test } from "vitest";
 
-test("get liquity troves should work correctly", async () => {
+test("get vote locked convex token locked balances should work correctly", async () => {
+  const voteLockedConvexToken = "0x72a19342e8F1838460eBFCCEf09F6585e32db86E" as const;
+  const positionAddress = "0x09602d67d2db8166ad38add363f025f5c8feaad9" as const;
+
   const result = await getVoteLockedConvexTokenLockedBalances(publicClientMainnet, {
-    voteLockedConvexToken: "0x72a19342e8F1838460eBFCCEf09F6585e32db86E",
-    positionAddress: "0x09602d67d2db8166ad38add363f025f5c8feaad9",
+    voteLockedConvexToken,
+    positionAddress,
   });
 
   assert(result !== undefined && result !== null);
   expect(Object.keys(result).length).toBeGreaterThan(0);
+
+  expect(result.total).toBeTypeOf("bigint");
+  expect(result.unlockable).toBeTypeOf("bigint");
+  expect(result.locked).toBeTypeOf("bigint");
 });

--- a/packages/sdk/src/reads/getVoteLockedConvexTokenLockedBalances.test.ts
+++ b/packages/sdk/src/reads/getVoteLockedConvexTokenLockedBalances.test.ts
@@ -1,6 +1,6 @@
 import { publicClientMainnet } from "../../tests/globals.js";
 import { getVoteLockedConvexTokenLockedBalances } from "./getVoteLockedConvexTokenLockedBalances.js";
-import { assert, expect, test } from "vitest";
+import { expect, test } from "vitest";
 
 test("get vote locked convex token locked balances should work correctly", async () => {
   const voteLockedConvexToken = "0x72a19342e8F1838460eBFCCEf09F6585e32db86E" as const;
@@ -11,7 +11,6 @@ test("get vote locked convex token locked balances should work correctly", async
     positionAddress,
   });
 
-  assert(result !== undefined && result !== null);
   expect(Object.keys(result).length).toBeGreaterThan(0);
 
   expect(result.total).toBeTypeOf("bigint");

--- a/packages/sdk/src/reads/getVoteLockedConvexTokenLockedBalances.test.ts
+++ b/packages/sdk/src/reads/getVoteLockedConvexTokenLockedBalances.test.ts
@@ -1,0 +1,13 @@
+import { publicClientMainnet } from "../../tests/globals.js";
+import { getVoteLockedConvexTokenLockedBalances } from "./getVoteLockedConvexTokenLockedBalances.js";
+import { assert, expect, test } from "vitest";
+
+test("get liquity troves should work correctly", async () => {
+  const result = await getVoteLockedConvexTokenLockedBalances(publicClientMainnet, {
+    voteLockedConvexToken: "0x72a19342e8F1838460eBFCCEf09F6585e32db86E",
+    positionAddress: "0x09602d67d2db8166ad38add363f025f5c8feaad9",
+  });
+
+  assert(result !== undefined && result !== null);
+  expect(Object.keys(result).length).toBeGreaterThan(0);
+});

--- a/packages/sdk/src/reads/getVoteLockedConvexTokenLockedBalances.ts
+++ b/packages/sdk/src/reads/getVoteLockedConvexTokenLockedBalances.ts
@@ -47,7 +47,7 @@ export type LockedBalances = {
   total: bigint;
   unlockable: bigint;
   locked: bigint;
-  lockedData: lockedData[],
+  lockedData: lockedData[];
 };
 
 export async function getVoteLockedConvexTokenLockedBalances(

--- a/packages/sdk/src/reads/getVoteLockedConvexTokenLockedBalances.ts
+++ b/packages/sdk/src/reads/getVoteLockedConvexTokenLockedBalances.ts
@@ -35,19 +35,19 @@ const abi = {
   ],
   stateMutability: "view",
   type: "function",
-};
+} as const;
 
-export type lockedData = {
+type LockData = {
   amount: bigint;
   boosted: bigint;
-  unlockTime: bigint;
+  unlockTime: number;
 };
 
-export type LockedBalances = {
+type LockedBalances = {
   total: bigint;
   unlockable: bigint;
   locked: bigint;
-  lockedData: lockedData[];
+  lockedData: LockData[];
 };
 
 export async function getVoteLockedConvexTokenLockedBalances(
@@ -57,15 +57,15 @@ export async function getVoteLockedConvexTokenLockedBalances(
     positionAddress: Address;
   }>,
 ) {
-  const lockedBalances = (await client.readContract({
+  const [total, unlockable, locked, balancesData] = await client.readContract({
     ...readContractParameters(args),
     abi: [abi],
     address: args.voteLockedConvexToken,
     functionName: "lockedBalances",
     args: [args.positionAddress],
-  })) as unknown as [bigint, bigint, bigint, lockedData[]];
+  });
 
-  const lockedData = lockedBalances[3].map((data) => {
+  const lockedData = balancesData.map((data) => {
     return {
       amount: data.amount,
       boosted: data.boosted,
@@ -74,9 +74,9 @@ export async function getVoteLockedConvexTokenLockedBalances(
   });
 
   const lockedBalancesData = {
-    total: lockedBalances[0],
-    unlockable: lockedBalances[1],
-    locked: lockedBalances[2],
+    total,
+    unlockable,
+    locked,
     lockedData,
   };
 

--- a/packages/sdk/src/reads/getVoteLockedConvexTokenLockedBalances.ts
+++ b/packages/sdk/src/reads/getVoteLockedConvexTokenLockedBalances.ts
@@ -1,0 +1,87 @@
+import type { Address, PublicClient } from "viem";
+import { type ReadContractParameters, readContractParameters } from "../utils/viem.js";
+
+
+const abi = {
+  inputs: [
+    {
+      internalType: "address",
+      name: "_user",
+      type: "address"
+    },
+  ],
+  name: "lockedBalances",
+  outputs: [
+    { internalType: "uint256",
+      name: "total",
+      type: "uint256"
+    },
+    {
+      internalType: "uint256",
+      name: "unlockable",
+      type: "uint256"
+    },
+    {
+      internalType: "uint256",
+      name: "locked",
+      type: "uint256"
+    },
+    { 
+      components: [
+        { internalType: "uint112", name: "amount", type: "uint112" },
+        { internalType: "uint112", name: "boosted", type: "uint112" },
+        { internalType: "uint32", name: "unlockTime", type: "uint32" }
+      ],
+      internalType: "struct CvxLockerV2.LockedBalance[]",
+      name: "lockData",
+      type: "tuple[]"
+    },
+  ],
+  stateMutability: "view",
+  type: "function"
+};
+
+export async function getVoteLockedConvexTokenLockedBalances(
+  client: PublicClient,
+  args: ReadContractParameters<{
+    voteLockedConvexToken: Address;
+    positionAddress: Address;
+  }>,
+) {
+
+  const lockedBalances = await client.readContract({
+    ...readContractParameters(args),
+    abi: [abi],
+    address: args.voteLockedConvexToken,
+    functionName: "lockedBalances",
+    args: [args.positionAddress],
+  });
+
+  return lockedBalances;
+}
+
+export async function getAllVoteLockedConvexTokenLockedBalances(
+  client: PublicClient,
+  args: ReadContractParameters<{
+    voteLockedConvexToken: Address;
+    positionAddresses: Address[];
+  }>,
+) {
+  const allLockedBalances = await Promise.all(
+    args.positionAddresses.map(async (position) => {
+      const lockedBalances = await getVoteLockedConvexTokenLockedBalances(client, {
+        voteLockedConvexToken: args.voteLockedConvexToken,
+        positionAddress: position,
+      });
+
+      return { position, lockedBalances };
+    }),
+  );
+
+  const lockedBalancesMap: Record<Address, any> = {};
+  for (const { position, lockedBalances } of allLockedBalances) {
+    lockedBalancesMap[position] = lockedBalances;
+  }
+
+  return lockedBalancesMap;
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding new functions `getVoteLockedConvexTokenLockedBalances` and `getAllVoteLockedConvexTokenLockedBalances` to the SDK. 

### Detailed summary
- Added `getVoteLockedConvexTokenLockedBalances` function to retrieve locked balances for a specific vote-locked Convex token and position address.
- Added `getAllVoteLockedConvexTokenLockedBalances` function to retrieve locked balances for multiple position addresses.
- Added tests for the new functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->