### PR TITLE
feat: add get shares splitter token balance claimable for user

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -363,6 +363,9 @@ export { getSharePriceInAsset } from "./reads/getSharePriceInAsset.js";
 // ./reads/getSharesActionTimelock.js
 export { getSharesActionTimelock } from "./reads/getSharesActionTimelock.js";
 
+// ./reads/getSharesSplitterTokenBalanceClaimableForUser.js
+export { getSharesSplitterTokenBalanceClaimableForUser } from "./reads/getSharesSplitterTokenBalanceClaimableForUser.js";
+
 // ./reads/getSharesWrapperRedemptionQueueUsers.js
 export { getSharesWrapperRedemptionQueueUsers } from "./reads/getSharesWrapperRedemptionQueueUsers.js";
 

--- a/packages/sdk/src/reads/getSharesSplitterTokenBalanceClaimableForUser.ts
+++ b/packages/sdk/src/reads/getSharesSplitterTokenBalanceClaimableForUser.ts
@@ -1,0 +1,20 @@
+import { type ReadContractParameters, readContractParameters } from "../utils/viem.js";
+import { ISharesSplitterLib } from "@enzymefinance/abis";
+import type { Address, PublicClient } from "viem";
+
+export function getSharesSplitterTokenBalanceClaimableForUser(
+  client: PublicClient,
+  args: ReadContractParameters<{
+    splitterAddress: Address;
+    token: Address;
+    user: Address;
+  }>,
+) {
+  return client.readContract({
+    ...readContractParameters(args),
+    abi: ISharesSplitterLib,
+    address: args.splitterAddress,
+    functionName: "getTokenBalClaimableForUser",
+    args: [args.user, args.token],
+  });
+}

--- a/packages/sdk/src/reads/getSharesSplitterTokenBalanceClaimableForUser.ts
+++ b/packages/sdk/src/reads/getSharesSplitterTokenBalanceClaimableForUser.ts
@@ -5,7 +5,7 @@ import type { Address, PublicClient } from "viem";
 export function getSharesSplitterTokenBalanceClaimableForUser(
   client: PublicClient,
   args: ReadContractParameters<{
-    splitterAddress: Address;
+    splitter: Address;
     token: Address;
     user: Address;
   }>,
@@ -13,7 +13,7 @@ export function getSharesSplitterTokenBalanceClaimableForUser(
   return client.readContract({
     ...readContractParameters(args),
     abi: ISharesSplitterLib,
-    address: args.splitterAddress,
+    address: args.splitter,
     functionName: "getTokenBalClaimableForUser",
     args: [args.user, args.token],
   });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new function `getSharesSplitterTokenBalanceClaimableForUser` to the SDK. 

### Detailed summary
- Added `getSharesSplitterTokenBalanceClaimableForUser` function to `index.ts` in `sdk/src/reads` directory.
- Created `getSharesSplitterTokenBalanceClaimableForUser.ts` file in `sdk/src/reads` directory.
- Imported necessary dependencies in `getSharesSplitterTokenBalanceClaimableForUser.ts`.
- Defined `getSharesSplitterTokenBalanceClaimableForUser` function with required parameters and implementation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->