### PR TITLE
feat: get mln value and burn amount for shares buyback

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -333,6 +333,9 @@ export { getMigrationRequestDetails } from "./reads/getMigrationRequestDetails.j
 // ./reads/getMinMaxInvestmentPolicySettings.js
 export { getMinMaxInvestmentPolicySettings } from "./reads/getMinMaxInvestmentPolicySettings.js";
 
+// ./reads/getMlnValueAndBurnAmountForSharesBuyback.js
+export { getMlnValueAndBurnAmountForSharesBuyback } from "./reads/getMlnValueAndBurnAmountForSharesBuyback.js";
+
 // ./reads/getNetAssetValue.js
 export { getNetAssetValue } from "./reads/getNetAssetValue.js";
 

--- a/packages/sdk/src/reads/getMlnValueAndBurnAmountForSharesBuyback.ts
+++ b/packages/sdk/src/reads/getMlnValueAndBurnAmountForSharesBuyback.ts
@@ -1,0 +1,55 @@
+import { IComptrollerLib } from "../../../abis/src/abis/IComptrollerLib.js";
+import { IValueInterpreter } from "../../../abis/src/abis/IValueInterpreter.js";
+import { IVaultLib } from "../../../abis/src/abis/IVaultLib.js";
+import { invariant } from "../utils/assertions.js";
+import { type ReadContractParameters, readContractParameters } from "../utils/viem.js";
+import { getComptrollerProxy } from "./getComptrollerProxy.js";
+import type { Address, PublicClient } from "viem";
+
+export async function getMlnValueAndBurnAmountForSharesBuyback(
+  client: PublicClient,
+  args: ReadContractParameters<{
+    denominationAsset: Address;
+    buybackSharesAmount: bigint;
+    mln: Address;
+    valueInterpreter: Address;
+    vaultProxy: Address;
+    comptrollerProxy?: Address;
+  }>,
+) {
+  const [sharesSupply, _comptrollerProxy] = await Promise.all([
+    client.readContract({
+      ...readContractParameters(args),
+      abi: IVaultLib,
+      functionName: "totalSupply",
+      address: args.vaultProxy,
+    }),
+    ...(args.comptrollerProxy === undefined ? [getComptrollerProxy(client, { vaultProxy: args.vaultProxy })] : []),
+  ]);
+
+  const comptrollerProxy = args.comptrollerProxy ?? _comptrollerProxy;
+
+  invariant(comptrollerProxy !== undefined, "Comptroller is undefined");
+
+  const { result: gav } = await client.simulateContract({
+    ...readContractParameters(args),
+    abi: IComptrollerLib,
+    functionName: "calcGav",
+    address: comptrollerProxy,
+  });
+
+  const denominationValue = (gav * args.buybackSharesAmount) / sharesSupply;
+
+  const { result: mlnValueOfBuyback } = await client.simulateContract({
+    ...readContractParameters(args),
+    abi: IValueInterpreter,
+    functionName: "calcCanonicalAssetValue",
+    address: args.valueInterpreter,
+    args: [args.denominationAsset, denominationValue, args.mln],
+  });
+
+  // 50% discount
+  const mlnAmountToBurn = mlnValueOfBuyback / 2n;
+
+  return { mlnAmountToBurn, mlnValue: mlnValueOfBuyback };
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new function `getMlnValueAndBurnAmountForSharesBuyback` to the SDK that calculates the MLN value and amount to burn for a shares buyback. 

### Detailed summary
- Added `getMlnValueAndBurnAmountForSharesBuyback` function to calculate MLN value and burn amount for shares buyback.
- Imported necessary dependencies and types.
- Used `readContract` and `simulateContract` methods to interact with smart contracts.
- Added logic to calculate the MLN value and burn amount based on input parameters.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->