### PR TITLE
feat: get enabled min max investment policy

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -276,6 +276,9 @@ export { getDenominationAsset } from "./reads/getDenominationAsset.js";
 // ./reads/getEnabledFees.js
 export { getEnabledFees } from "./reads/getEnabledFees.js";
 
+// ./reads/getEnabledMinMaxInvestmentPolicySettings.js
+export { getEnabledMinMaxInvestmentPolicySettings } from "./reads/getEnabledMinMaxInvestmentPolicySettings.js";
+
 // ./reads/getEnabledPolicies.js
 export { getEnabledPolicies } from "./reads/getEnabledPolicies.js";
 

--- a/packages/sdk/src/reads/getEnabledMinMaxInvestmentPolicySettings.ts
+++ b/packages/sdk/src/reads/getEnabledMinMaxInvestmentPolicySettings.ts
@@ -1,0 +1,25 @@
+import type { ReadContractParameters } from "../utils/viem.js";
+import { getEnabledPolicies } from "./getEnabledPolicies.js";
+import { getMinMaxInvestmentPolicySettings } from "./getMinMaxInvestmentPolicySettings.js";
+import { type Address, type PublicClient, isAddressEqual } from "viem";
+
+export async function getEnabledMinMaxInvestmentPolicySettings(
+  client: PublicClient,
+  args: ReadContractParameters<{
+    comptrollerProxy: Address;
+    minMaxInvestmentPolicy: Address;
+    policyManager?: Address;
+  }>,
+) {
+  const enabledPolicies = await getEnabledPolicies(client, args);
+
+  const hasMinMaxInvestmentPolicy = enabledPolicies.some((policy) =>
+    isAddressEqual(policy, args.minMaxInvestmentPolicy),
+  );
+
+  if (!hasMinMaxInvestmentPolicy) {
+    return null;
+  }
+
+  return getMinMaxInvestmentPolicySettings(client, args);
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding a new function `getEnabledMinMaxInvestmentPolicySettings` to the SDK, which retrieves the enabled minimum and maximum investment policy settings.

### Detailed summary:
- Added a new file `getEnabledMinMaxInvestmentPolicySettings.js` in the `reads` directory.
- Exported the `getEnabledMinMaxInvestmentPolicySettings` function from `getEnabledMinMaxInvestmentPolicySettings.js`.
- Imported the `ReadContractParameters` type from `../utils/viem.js`.
- Imported the `getEnabledPolicies` function from `./getEnabledPolicies.js`.
- Imported the `getMinMaxInvestmentPolicySettings` function from `./getMinMaxInvestmentPolicySettings.js`.
- Imported the `Address`, `PublicClient`, and `isAddressEqual` types from `"viem"`.
- Defined the `getEnabledMinMaxInvestmentPolicySettings` function with parameters `client` and `args`.
- Inside the `getEnabledMinMaxInvestmentPolicySettings` function:
  - Retrieved the enabled policies using the `getEnabledPolicies` function.
  - Checked if the minimum and maximum investment policy is enabled.
  - If not enabled, returned `null`.
  - Otherwise, returned the minimum and maximum investment policy settings using the `getMinMaxInvestmentPolicySettings` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->