### PR TITLE
feat: get idle gov tokens amounts

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -309,6 +309,9 @@ export { getGrossAssetValue } from "./reads/getGrossAssetValue.js";
 // ./reads/getGrossAssetValueInAsset.js
 export { getGrossAssetValueInAsset } from "./reads/getGrossAssetValueInAsset.js";
 
+// ./reads/getIdleGovTokensAmountAndAddress.js
+export { getIdleGovTokensAmounts as getIdleGovTokensAmountAndAddress } from "./reads/getIdleGovTokensAmounts.js";
+
 // ./reads/getIdleRate.js
 export { getIdleRate } from "./reads/getIdleRate.js";
 

--- a/packages/sdk/src/reads/getIdleGovTokensAmounts.ts
+++ b/packages/sdk/src/reads/getIdleGovTokensAmounts.ts
@@ -1,0 +1,63 @@
+import { type ReadContractParameters, readContractParameters } from "../utils/viem.js";
+import type { Address, PublicClient } from "viem";
+
+const abi = [
+  {
+    constant: true,
+    inputs: [{ internalType: "address", name: "_usr", type: "address" }],
+    name: "getGovTokensAmounts",
+    outputs: [{ internalType: "uint256[]", name: "_amounts", type: "uint256[]" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    constant: true,
+    inputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    name: "govTokens",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    payable: false,
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+export async function getIdleGovTokensAmounts(
+  client: PublicClient,
+  args: ReadContractParameters<{
+    pool: Address;
+    tokensOwner: Address;
+  }>,
+) {
+  const amounts = await client.readContract({
+    ...readContractParameters(args),
+    abi,
+    functionName: "getGovTokensAmounts",
+    address: args.pool,
+    args: [args.tokensOwner],
+  });
+
+  const tokensAmounts = await Promise.all(
+    amounts.map(async (amount, index) => {
+      const token = await client.readContract({
+        ...readContractParameters(args),
+        abi,
+        functionName: "govTokens",
+        address: args.pool,
+        args: [BigInt(index)],
+      });
+
+      return {
+        amount,
+        token,
+      };
+    }),
+  );
+
+  const tokensAmountsMap: Record<Address, bigint> = {};
+  for (const { token, amount } of tokensAmounts) {
+    tokensAmountsMap[token] = amount;
+  }
+
+  return tokensAmountsMap;
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new function `getIdleGovTokensAmountAndAddress` and its dependencies to the SDK package. 

### Detailed summary
- Added `getIdleGovTokensAmountAndAddress` function to `index.ts`.
- Added `getIdleGovTokensAmounts` function to `getIdleGovTokensAmounts.ts`.
- Imported `readContractParameters` and `ReadContractParameters` from `viem.js`.
- Imported `Address` and `PublicClient` from `viem`.
- Defined ABI for `getIdleGovTokensAmounts` function.
- Implemented `getIdleGovTokensAmounts` function to retrieve idle governance token amounts and addresses.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->