### PR TITLE
feat: get c token from borrowed asset

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -261,6 +261,9 @@ export { getCanonicalAssetValue } from "./reads/getCanonicalAssetValue.js";
 // ./reads/getComptrollerProxy.js
 export { getComptrollerProxy } from "./reads/getComptrollerProxy.js";
 
+// ./reads/getCTokenFromBorrowedAsset.js
+export { getCTokenFromBorrowedAsset } from "./reads/getCTokenFromBorrowedAsset.js";
+
 // ./reads/getCumulativeSlippageTolerancePolicySettings.js
 export { getCumulativeSlippageTolerancePolicySettings } from "./reads/getCumulativeSlippageTolerancePolicySettings.js";
 

--- a/packages/sdk/src/reads/getCTokenFromBorrowedAsset.ts
+++ b/packages/sdk/src/reads/getCTokenFromBorrowedAsset.ts
@@ -1,0 +1,19 @@
+import { ICompoundDebtPositionLib } from "../../../abis/src/abis/ICompoundDebtPositionLib.js";
+import { type ReadContractParameters, readContractParameters } from "../utils/viem.js";
+import type { Address, PublicClient } from "viem";
+
+export function getCTokenFromBorrowedAsset(
+  client: PublicClient,
+  args: ReadContractParameters<{
+    externalPositionProxy: Address;
+    borrowesAsset: Address;
+  }>,
+) {
+  return client.readContract({
+    ...readContractParameters(args),
+    abi: ICompoundDebtPositionLib,
+    functionName: "getCTokenFromBorrowedAsset",
+    address: args.externalPositionProxy,
+    args: [args.borrowesAsset],
+  });
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new function `getCTokenFromBorrowedAsset` to the SDK. 

### Detailed summary
- Added `getCTokenFromBorrowedAsset` function to `sdk/src/reads/getCTokenFromBorrowedAsset.ts`
- Imported `ICompoundDebtPositionLib` from `../../../abis/src/abis/ICompoundDebtPositionLib.js`
- Imported `ReadContractParameters` and `readContractParameters` from `../utils/viem.js`
- Imported `Address` and `PublicClient` from "viem"
- Added function parameters `client` and `args` to `getCTokenFromBorrowedAsset` function
- Implemented logic to read contract using `client.readContract`
- Set ABI to `ICompoundDebtPositionLib` and functionName to "getCTokenFromBorrowedAsset"
- Passed `args.externalPositionProxy` as the address and `args.borrowesAsset` as the argument to the function call

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->