### PR TITLE
feat: add get curve best price

### DIFF
--- a/packages/sdk/src/constants/selectors.ts
+++ b/packages/sdk/src/constants/selectors.ts
@@ -21,3 +21,4 @@ export const UNSTAKE_AND_REDEEM_SELECTOR = "0x8334eb99"; // unstakeAndRedeem(add
 export const TAKE_ORDER_SELECTOR = "0x03e38a2b" as const; // takeOrder(address,bytes,bytes)
 export const TAKE_MULTIPLE_ORDERS_SELECTOR = "0x0e7f692d" as const; // takeMultipleOrders(address,bytes,bytes)
 export const TOGGLE_APPROVE_MINT_SELECTOR = "0xdd289d60" as const; // toggle_approve_mint(address)
+export const CURVE_REGISTRY = "0x0000000022d53366457f9d5e68ec105046fc4383" as const; // get_address(address)

--- a/packages/sdk/src/constants/selectors.ts
+++ b/packages/sdk/src/constants/selectors.ts
@@ -21,4 +21,3 @@ export const UNSTAKE_AND_REDEEM_SELECTOR = "0x8334eb99"; // unstakeAndRedeem(add
 export const TAKE_ORDER_SELECTOR = "0x03e38a2b" as const; // takeOrder(address,bytes,bytes)
 export const TAKE_MULTIPLE_ORDERS_SELECTOR = "0x0e7f692d" as const; // takeMultipleOrders(address,bytes,bytes)
 export const TOGGLE_APPROVE_MINT_SELECTOR = "0xdd289d60" as const; // toggle_approve_mint(address)
-export const CURVE_REGISTRY = "0x0000000022d53366457f9d5e68ec105046fc4383" as const; // get_address(address)

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -267,6 +267,9 @@ export { getCumulativeSlippageTolerancePolicySettings } from "./reads/getCumulat
 // ./reads/getCurrentCumulativeSlippage.js
 export { getCurrentCumulativeSlippage } from "./reads/getCurrentCumulativeSlippage.js";
 
+// ./reads/getCurveBestPrice.js
+export { getCurveBestPrice } from "./reads/getCurveBestPrice.js";
+
 // ./reads/getDebtAssets.js
 export { getDebtAssets } from "./reads/getDebtAssets.js";
 

--- a/packages/sdk/src/reads/getCurveBestPrice.ts
+++ b/packages/sdk/src/reads/getCurveBestPrice.ts
@@ -1,7 +1,6 @@
-import { WETH } from "../../tests/constants.js";
 import { ETH_ADDRESS } from "../constants/misc.js";
 import { type ReadContractParameters, readContractParameters } from "../utils/viem.js";
-import { type Address, ContractFunctionExecutionError, type PublicClient } from "viem";
+import { type Address, ContractFunctionExecutionError, type PublicClient, isAddressEqual } from "viem";
 
 // same address for polygon and ethereum
 const CURVE_REGISTRY = "0x0000000022d53366457f9d5e68ec105046fc4383" as const;
@@ -45,6 +44,7 @@ export async function getCurveBestPrice(
     incoming: Address;
     outgoing: Address;
     quantity: bigint;
+    weth: Address;
   }>,
 ) {
   const curveSwaps = await client.readContract({
@@ -55,8 +55,8 @@ export async function getCurveBestPrice(
     args: [swapId],
   });
 
-  const curveOutgoing = args.outgoing === WETH ? ETH_ADDRESS : args.outgoing;
-  const curveIncoming = args.incoming === WETH ? ETH_ADDRESS : args.incoming;
+  const curveOutgoing = isAddressEqual(args.outgoing, args.weth) ? ETH_ADDRESS : args.outgoing;
+  const curveIncoming = isAddressEqual(args.incoming, args.weth) ? ETH_ADDRESS : args.incoming;
 
   const [bestPool, amountReceived] = await client.readContract({
     abi: [curveSwapsAbi],

--- a/packages/sdk/src/reads/getCurveBestPrice.ts
+++ b/packages/sdk/src/reads/getCurveBestPrice.ts
@@ -1,0 +1,81 @@
+import { WETH } from "../../tests/constants.js";
+import { invariant } from "../utils/assertions.js";
+import { type ReadContractParameters, readContractParameters } from "../utils/viem.js";
+import { type Address, type PublicClient, parseAbi, zeroAddress } from "viem";
+
+const abi = {
+  name: "get_address",
+  outputs: [{ type: "address", name: "" }],
+  inputs: [{ type: "uint256", name: "_id" }],
+  stateMutability: "view",
+  type: "function",
+  gas: 1308,
+} as const;
+
+type Asset = {
+  address: Address;
+  decimals: number;
+  symbol: string;
+};
+
+const curveRegistry = "0x0000000022d53366457f9d5e68ec105046fc4383" as const;
+const ethAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE" as const;
+const swapId = 2n; // id won't change, for swaps it will be always the same id in the registry
+
+export async function getCurveBestPrice(
+  client: PublicClient,
+  args: ReadContractParameters<{
+    incoming: Asset;
+    outgoing: Asset;
+    quantity: bigint;
+  }>,
+) {
+  invariant(args.incoming.address !== args.outgoing.address, "Incoming and outgoing asset are identical");
+
+  const address = await client.readContract({
+    ...readContractParameters(args),
+    abi: [abi],
+    functionName: "get_address",
+    address: curveRegistry,
+    args: [swapId],
+  });
+
+  const curveOutgoing = args.outgoing.address === WETH ? ethAddress : args.outgoing.address;
+  const curveIncoming = args.incoming.address === WETH ? ethAddress : args.incoming.address;
+
+  const curveSwaps = parseAbi([
+    "function get_best_rate(address _from, address to, uint256 amount) view returns (address bestPool, uint256 amountReceived)",
+  ] as const);
+
+  const [bestPool, amountReceived] = (await client.readContract({
+    abi: curveSwaps,
+    address,
+    functionName: "get_best_rate",
+    args: [curveOutgoing, curveIncoming, args.quantity],
+  })) as unknown as [Address, bigint];
+
+  invariant(bestPool !== zeroAddress, "Pool returned zero address");
+  invariant(amountReceived !== 0n, "Amount received is zero");
+
+  const amount = amountReceived;
+  const price = amount / args.quantity;
+
+  invariant(price > 0n, "Price is zero");
+
+  const ERC20 = parseAbi(["function name() view returns (string)"] as const);
+
+  const [name] = (await client.readContract({
+    abi: ERC20,
+    address: bestPool,
+    functionName: "name",
+  })) as unknown as [string];
+
+  const bestPoolName = name ?? `Curve Pool ${args.incoming.symbol}-${args.outgoing.symbol}`;
+
+  return {
+    amount,
+    bestRoute: bestPoolName,
+    pool: bestPool,
+    price,
+  };
+}

--- a/packages/sdk/src/reads/getCurveBestPrice.ts
+++ b/packages/sdk/src/reads/getCurveBestPrice.ts
@@ -1,83 +1,80 @@
 import { WETH } from "../../tests/constants.js";
 import { ETH_ADDRESS } from "../constants/misc.js";
-import { invariant } from "../utils/assertions.js";
+import { CURVE_REGISTRY } from "../constants/selectors.js";
 import { type ReadContractParameters, readContractParameters } from "../utils/viem.js";
-import { type Address, type PublicClient, parseAbi, zeroAddress } from "viem";
+import type { Address, PublicClient } from "viem";
 
-const abi = {
+const curveRegistryAbi = {
   name: "get_address",
   outputs: [{ type: "address", name: "" }],
   inputs: [{ type: "uint256", name: "_id" }],
   stateMutability: "view",
   type: "function",
-  gas: 1308,
 } as const;
 
-type Asset = {
-  address: Address;
-  decimals: number;
-  symbol: string;
-};
+const curveSwapsAbi = {
+  name: "get_best_rate",
+  outputs: [
+    { type: "address", name: "bestPool" },
+    { type: "uint256", name: "amountReceived" },
+  ],
+  inputs: [
+    { type: "address", name: "_from" },
+    { type: "address", name: "_to" },
+    { type: "uint256", name: "_amount" },
+  ],
+  stateMutability: "view",
+  type: "function",
+} as const;
 
-const curveRegistry = "0x0000000022d53366457f9d5e68ec105046fc4383" as const;
+const erc20Abi = {
+  name: "name",
+  outputs: [{ type: "string", name: "" }],
+  inputs: [],
+  stateMutability: "view",
+  type: "function",
+} as const;
+
 const swapId = 2n; // id won't change, for swaps it will be always the same id in the registry
 
 export async function getCurveBestPrice(
   client: PublicClient,
   args: ReadContractParameters<{
-    incoming: Asset;
-    outgoing: Asset;
+    incoming: Address;
+    outgoing: Address;
     quantity: bigint;
   }>,
 ) {
-  invariant(args.incoming.address !== args.outgoing.address, "Incoming and outgoing asset are identical");
-
-  const [address] = await client.readContract({
+  const address = await client.readContract({
     ...readContractParameters(args),
-    abi: [abi],
+    abi: [curveRegistryAbi],
     functionName: "get_address",
-    address: curveRegistry,
+    address: CURVE_REGISTRY,
     args: [swapId],
   });
 
-  invariant(address !== zeroAddress, "Registry returned zero address");
-  invariant(address !== undefined, "Registry returned undefined address");
-
-  const curveOutgoing = args.outgoing.address === WETH ? ETH_ADDRESS : args.outgoing.address;
-  const curveIncoming = args.incoming.address === WETH ? ETH_ADDRESS : args.incoming.address;
-
-  const curveSwaps = parseAbi([
-    "function get_best_rate(address _from, address to, uint256 amount) view returns (address bestPool, uint256 amountReceived)",
-  ] as const);
+  const curveOutgoing = args.outgoing === WETH ? ETH_ADDRESS : args.outgoing;
+  const curveIncoming = args.incoming === WETH ? ETH_ADDRESS : args.incoming;
 
   const [bestPool, amountReceived] = await client.readContract({
-    abi: curveSwaps,
-    address: address as Address,
+    abi: [curveSwapsAbi],
+    address: address,
     functionName: "get_best_rate",
     args: [curveOutgoing, curveIncoming, args.quantity],
   });
 
-  invariant(bestPool !== zeroAddress, "Pool returned zero address");
-  invariant(amountReceived !== 0n, "Amount received is zero");
-
   const amount = amountReceived;
   const price = amount / args.quantity;
 
-  invariant(price > 0n, "Price is zero");
-
-  const ERC20 = parseAbi(["function name() view returns (string)"] as const);
-
-  const [name] = await client.readContract({
-    abi: ERC20,
+  const name = await client.readContract({
+    abi: [erc20Abi],
     address: bestPool,
     functionName: "name",
   });
 
-  const bestPoolName = name ?? `Curve Pool ${args.incoming.symbol}-${args.outgoing.symbol}`;
-
   return {
     amount,
-    bestRoute: bestPoolName,
+    bestRoute: name,
     pool: bestPool,
     price,
   };

--- a/packages/sdk/src/reads/getCurveBestPrice.ts
+++ b/packages/sdk/src/reads/getCurveBestPrice.ts
@@ -1,4 +1,5 @@
 import { WETH } from "../../tests/constants.js";
+import { ETH_ADDRESS } from "../constants/misc.js";
 import { invariant } from "../utils/assertions.js";
 import { type ReadContractParameters, readContractParameters } from "../utils/viem.js";
 import { type Address, type PublicClient, parseAbi, zeroAddress } from "viem";
@@ -19,7 +20,6 @@ type Asset = {
 };
 
 const curveRegistry = "0x0000000022d53366457f9d5e68ec105046fc4383" as const;
-const ethAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE" as const;
 const swapId = 2n; // id won't change, for swaps it will be always the same id in the registry
 
 export async function getCurveBestPrice(
@@ -40,8 +40,8 @@ export async function getCurveBestPrice(
     args: [swapId],
   });
 
-  const curveOutgoing = args.outgoing.address === WETH ? ethAddress : args.outgoing.address;
-  const curveIncoming = args.incoming.address === WETH ? ethAddress : args.incoming.address;
+  const curveOutgoing = args.outgoing.address === WETH ? ETH_ADDRESS : args.outgoing.address;
+  const curveIncoming = args.incoming.address === WETH ? ETH_ADDRESS : args.incoming.address;
 
   const curveSwaps = parseAbi([
     "function get_best_rate(address _from, address to, uint256 amount) view returns (address bestPool, uint256 amountReceived)",

--- a/packages/sdk/src/reads/getCurveBestPrice.ts
+++ b/packages/sdk/src/reads/getCurveBestPrice.ts
@@ -70,6 +70,7 @@ export async function getCurveBestPrice(
 
   let poolName;
   try {
+    // not all pools support this method, this is why we need to catch the error
     poolName = await client.readContract({
       abi: [erc20Abi],
       address: bestPool,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added `getCurveBestPrice` function to `sdk/src/reads/getCurveBestPrice.ts` module.
- Imported necessary dependencies and constants.
- Defined ABI for Curve Registry, Curve Swaps, and ERC20 contracts.
- Implemented `getCurveBestPrice` function to calculate the best price for a swap on Curve.
- Handled cases where the pool does not support the `name` method.
- Returned the amount, pool name, pool address, and price in the response.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->