### PR TITLE
feat: add get accrued continuous fees

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -219,6 +219,9 @@ export { convertMapleSharesToExitAssets } from "./reads/convertMapleSharesToExit
 // ./reads/doesAutoProtocolFeeSharesBuyback.js
 export { doesAutoProtocolFeeSharesBuyback } from "./reads/doesAutoProtocolFeeSharesBuyback.js";
 
+// ./reads/getAccruedContinuousFees.js
+export { getAccruedContinuousFees } from "./reads/getAccruedContinuousFees.js";
+
 // ./reads/getAccruedProtocolFee.js
 export { getAccruedProtocolFee } from "./reads/getAccruedProtocolFee.js";
 

--- a/packages/sdk/src/reads/getAccruedContinuousFees.ts
+++ b/packages/sdk/src/reads/getAccruedContinuousFees.ts
@@ -1,0 +1,91 @@
+import { type ReadContractParameters, readContractParameters } from "../utils/viem.js";
+import { IComptrollerLib } from "@enzymefinance/abis";
+import { IPerformanceFee } from "@enzymefinance/abis";
+import { IUnpermissionedActionsWrapper } from "@enzymefinance/abis/IUnpermissionedActionsWrapper";
+import { type Address, type PublicClient, parseAbi } from "viem";
+
+export async function getAccruedContinuousFees(
+  client: PublicClient,
+  args: ReadContractParameters<{
+    unpermissionedActionsWrapper: Address;
+    accessor: Address;
+    vaultProxy: Address;
+    contracts: {
+      feeManager: Address;
+      unpermissionedActionsWrapper: Address;
+      managementFee: Address;
+      performanceFee: Address;
+    };
+  }>,
+) {
+  const continuousFees = (await client.readContract({
+    ...readContractParameters(args),
+    abi: IUnpermissionedActionsWrapper,
+    functionName: "getContinuousFeesForFund",
+    address: args.unpermissionedActionsWrapper,
+    args: [args.accessor],
+  })) as unknown as Address[];
+
+  const hasManagementFee = continuousFees.some((fee) => fee === args.contracts.managementFee);
+  const hasPerformanceFee = continuousFees.some((fee) => fee === args.contracts.performanceFee);
+
+  const managementAbi = parseAbi([
+    "function settle(address,address,uint8,bytes,uint256) view returns (bigitn, string, bigint)",
+  ] as const);
+  let managementFeeSharesDue = 0n;
+
+  if (hasManagementFee) {
+    const managementFeeSettledReturn = (await client.readContract({
+      ...readContractParameters(args),
+      abi: managementAbi,
+      functionName: "settle",
+      address: args.accessor,
+      args: [args.accessor, args.vaultProxy, 0, "0x", 0n],
+    })) as unknown as {
+      settlementType_: bigint;
+      "1": string;
+      sharesDue_: bigint;
+    };
+
+    managementFeeSharesDue = managementFeeSettledReturn.sharesDue_;
+  }
+
+  let performanceFeeSharesDue = 0n;
+  let highWaterMark = 0n;
+
+  if (hasPerformanceFee) {
+    const gav = (await client.readContract({
+      ...readContractParameters(args),
+      abi: IComptrollerLib,
+      functionName: "calcGav",
+      address: args.accessor,
+    })) as unknown as bigint;
+
+    const performanceFeeSettledReturn = (await client.readContract({
+      ...readContractParameters(args),
+      abi: IPerformanceFee,
+      functionName: "settle",
+      address: args.contracts.managementFee,
+      args: [args.accessor, args.vaultProxy, 0, "0x", gav],
+    })) as unknown as [number, Address, bigint];
+
+    performanceFeeSharesDue = performanceFeeSettledReturn[2];
+
+    const performanceFeeHighWaterMarkReturn = (await client.readContract({
+      ...readContractParameters(args),
+      abi: IPerformanceFee,
+      functionName: "getFeeInfoForFund",
+      address: args.contracts.performanceFee,
+      args: [args.accessor],
+    })) as unknown as [bigint, bigint];
+
+    highWaterMark = performanceFeeHighWaterMarkReturn[1];
+  }
+
+  return {
+    continuousFees,
+    highWaterMark,
+    managementFeeSharesDue,
+    performanceFeeSharesDue,
+  };
+}

--- a/packages/sdk/src/reads/getAccruedContinuousFees.ts
+++ b/packages/sdk/src/reads/getAccruedContinuousFees.ts
@@ -2,7 +2,57 @@ import { type ReadContractParameters, readContractParameters } from "../utils/vi
 import { IComptrollerLib } from "@enzymefinance/abis";
 import { IPerformanceFee } from "@enzymefinance/abis";
 import { IUnpermissionedActionsWrapper } from "@enzymefinance/abis/IUnpermissionedActionsWrapper";
-import { type Address, type PublicClient, parseAbi } from "viem";
+import type { Address, PublicClient } from "viem";
+
+const managementAbi = {
+  name: "settle",
+  type: "function",
+  inputs: [
+    {
+      internalType: "address",
+      name: "accessor",
+      type: "address",
+    },
+    {
+      internalType: "address",
+      name: "vaultProxy",
+      type: "address",
+    },
+    {
+      internalType: "uint8",
+      name: "feeType",
+      type: "uint8",
+    },
+    {
+      internalType: "bytes",
+      name: "feeData",
+      type: "bytes",
+    },
+    {
+      internalType: "uint256",
+      name: "gav",
+      type: "uint256",
+    },
+  ],
+  outputs: [
+    {
+      internalType: "uint256",
+      name: "sharesDue_",
+      type: "uint256",
+    },
+    {
+      internalType: "string",
+      name: "reason",
+      type: "string",
+    },
+    {
+      internalType: "uint256",
+      name: "sharesTransferred_",
+      type: "uint256",
+    },
+  ],
+  stateMutability: "view",
+} as const;
 
 export async function getAccruedContinuousFees(
   client: PublicClient,
@@ -18,68 +68,66 @@ export async function getAccruedContinuousFees(
     };
   }>,
 ) {
-  const continuousFees = (await client.readContract({
+  const continuousFees = await client.readContract({
     ...readContractParameters(args),
     abi: IUnpermissionedActionsWrapper,
     functionName: "getContinuousFeesForFund",
     address: args.unpermissionedActionsWrapper,
     args: [args.accessor],
-  })) as unknown as Address[];
+  });
 
   const hasManagementFee = continuousFees.some((fee) => fee === args.contracts.managementFee);
   const hasPerformanceFee = continuousFees.some((fee) => fee === args.contracts.performanceFee);
 
-  const managementAbi = parseAbi([
-    "function settle(address,address,uint8,bytes,uint256) view returns (bigitn, string, bigint)",
-  ] as const);
   let managementFeeSharesDue = 0n;
 
   if (hasManagementFee) {
-    const managementFeeSettledReturn = (await client.readContract({
+    const [sharesDue, _, __] = await client.readContract({
       ...readContractParameters(args),
-      abi: managementAbi,
+      abi: [managementAbi],
       functionName: "settle",
       address: args.accessor,
       args: [args.accessor, args.vaultProxy, 0, "0x", 0n],
-    })) as unknown as {
-      settlementType_: bigint;
-      "1": string;
-      sharesDue_: bigint;
-    };
+    });
 
-    managementFeeSharesDue = managementFeeSettledReturn.sharesDue_;
+    managementFeeSharesDue = sharesDue;
   }
 
   let performanceFeeSharesDue = 0n;
   let highWaterMark = 0n;
 
   if (hasPerformanceFee) {
-    const gav = (await client.readContract({
+    const { result: gav } = await client.simulateContract({
       ...readContractParameters(args),
       abi: IComptrollerLib,
       functionName: "calcGav",
       address: args.accessor,
-    })) as unknown as bigint;
+    });
 
-    const performanceFeeSettledReturn = (await client.readContract({
-      ...readContractParameters(args),
-      abi: IPerformanceFee,
-      functionName: "settle",
-      address: args.contracts.managementFee,
-      args: [args.accessor, args.vaultProxy, 0, "0x", gav],
-    })) as unknown as [number, Address, bigint];
+    const [
+      {
+        result: [_, __, performanceSharesDue],
+      },
+      feeInfoForFund,
+    ] = await Promise.all([
+      client.simulateContract({
+        ...readContractParameters(args),
+        abi: IPerformanceFee,
+        functionName: "settle",
+        address: args.contracts.managementFee,
+        args: [args.accessor, args.vaultProxy, 0, "0x", gav],
+      }),
+      client.readContract({
+        ...readContractParameters(args),
+        abi: IPerformanceFee,
+        functionName: "getFeeInfoForFund",
+        address: args.contracts.performanceFee,
+        args: [args.accessor],
+      }),
+    ]);
 
-    performanceFeeSharesDue = performanceFeeSettledReturn[2];
-
-    const performanceFeeHighWaterMarkReturn = (await client.readContract({
-      ...readContractParameters(args),
-      abi: IPerformanceFee,
-      functionName: "getFeeInfoForFund",
-      address: args.contracts.performanceFee,
-      args: [args.accessor],
-    })) as unknown as [bigint, bigint];
-
-    highWaterMark = performanceFeeHighWaterMarkReturn[1];
+    performanceFeeSharesDue = performanceSharesDue;
+    highWaterMark = feeInfoForFund.highWaterMark;
   }
 
   return {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added `getAccruedContinuousFees` function to calculate accrued continuous fees for a fund
- Imported necessary dependencies and types
- Added optional `comptrollerProxy` parameter to `getAccruedContinuousFees` function
- Implemented logic to calculate management fee and performance fee shares due
- Calculated high water mark for performance fee
- Returned the calculated values in an object

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->