### PR TITLE
fix: fix paraswap abi

### DIFF
--- a/packages/sdk/src/internal/Extensions/IntegrationAdapters/ParaswapV5.ts
+++ b/packages/sdk/src/internal/Extensions/IntegrationAdapters/ParaswapV5.ts
@@ -172,7 +172,7 @@ export type Adapter = {
 export type Path = {
   to: Address;
   totalNetworkFee: bigint;
-  adapter: ReadonlyArray<Adapter>;
+  adapters: ReadonlyArray<Adapter>;
 };
 
 export type MegaSwapData = ReadonlyArray<{

--- a/packages/sdk/src/internal/Extensions/IntegrationAdapters/ParaswapV5.ts
+++ b/packages/sdk/src/internal/Extensions/IntegrationAdapters/ParaswapV5.ts
@@ -98,7 +98,7 @@ const pathEncoding = {
       type: "uint256",
     },
     {
-      name: "adapter",
+      name: "adapters",
       type: "tuple[]",
       ...adapterEncoding,
     },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on renaming the `adapter` property to `adapters` in the `Path` type within the `ParaswapV5` integration adapter. 

### Detailed summary:
- Renamed the `adapter` property to `adapters` in the `Path` type.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->