### PR TITLE
fix: use better parameter name

### DIFF
--- a/.changeset/strong-pugs-run.md
+++ b/.changeset/strong-pugs-run.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Use better parameter name

--- a/packages/sdk/src/internal/Extensions/IntegrationAdapters/CurveExchange.ts
+++ b/packages/sdk/src/internal/Extensions/IntegrationAdapters/CurveExchange.ts
@@ -35,7 +35,7 @@ export type TakeOrderArgs = {
   pool: Address;
   outgoingAsset: Address;
   outgoingAssetAmount: bigint;
-  minIncomingAsset: Address;
+  incomingAsset: Address;
   minIncomingAssetAmount: bigint;
 };
 
@@ -44,13 +44,13 @@ export function takeOrderEncode(args: TakeOrderArgs): Hex {
     args.pool,
     args.outgoingAsset,
     args.outgoingAssetAmount,
-    args.minIncomingAsset,
+    args.incomingAsset,
     args.minIncomingAssetAmount,
   ]);
 }
 
 export function takeOrderDecode(encoded: Hex): TakeOrderArgs {
-  const [pool, outgoingAsset, outgoingAssetAmount, minIncomingAsset, minIncomingAssetAmount] = decodeAbiParameters(
+  const [pool, outgoingAsset, outgoingAssetAmount, incomingAsset, minIncomingAssetAmount] = decodeAbiParameters(
     takeOrderEncoding,
     encoded,
   );
@@ -59,7 +59,7 @@ export function takeOrderDecode(encoded: Hex): TakeOrderArgs {
     pool,
     outgoingAsset,
     outgoingAssetAmount,
-    minIncomingAsset,
+    incomingAsset,
     minIncomingAssetAmount,
   };
 }

--- a/packages/sdk/src/internal/Extensions/IntegrationAdapters/CurveExchange.ts
+++ b/packages/sdk/src/internal/Extensions/IntegrationAdapters/CurveExchange.ts
@@ -22,7 +22,7 @@ const takeOrderEncoding = [
     type: "uint256",
   },
   {
-    name: "minIncomingAsset",
+    name: "incomingAsset",
     type: "address",
   },
   {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the parameter name in the `TakeOrderArgs` interface and related functions in `CurveExchange.ts`.

### Detailed summary
- Renamed the parameter `minIncomingAsset` to `incomingAsset` in `TakeOrderArgs` interface.
- Updated the parameter name in the `takeOrderEncode` and `takeOrderDecode` functions accordingly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->