### PR TITLE
fix: 0x adapter arguments

### DIFF
--- a/.changeset/dry-peas-give.md
+++ b/.changeset/dry-peas-give.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+0x adapter fix

--- a/packages/sdk/src/internal/Extensions/IntegrationAdapters/ZeroExV4.ts
+++ b/packages/sdk/src/internal/Extensions/IntegrationAdapters/ZeroExV4.ts
@@ -136,7 +136,7 @@ const signatureEncoding = {
 
 const takeOrderEncoding = [
   {
-    name: "dZeroExOrderEncode",
+    name: "encodedZeroExOrderArgs",
     type: "bytes",
   },
   {
@@ -200,7 +200,6 @@ export type Signature = {
 };
 
 export type TakeOrderArgs = {
-  dZeroExOrderEncode: Hex;
   takerAssetFillAmount: bigint;
   signature: Signature;
 } & ({ orderType: typeof OrderType.Limit; order: LimitOrder } | { orderType: typeof OrderType.Rfq; order: RfqOrder });
@@ -236,7 +235,7 @@ export function isValidSignatureType(value: number): value is SignatureType {
 }
 
 export function takeOrderDecode(encoded: Hex): TakeOrderArgs {
-  const [dZeroExOrderEncode, takerAssetFillAmount, orderType] = decodeAbiParameters(takeOrderEncoding, encoded);
+  const [encodedZeroExOrderArgs, takerAssetFillAmount, orderType] = decodeAbiParameters(takeOrderEncoding, encoded);
 
   if (!isValidOrderType(orderType)) {
     Assertion.invariant(false, "Invalid order type");
@@ -244,7 +243,7 @@ export function takeOrderDecode(encoded: Hex): TakeOrderArgs {
 
   switch (orderType) {
     case OrderType.Limit: {
-      const [order, signature] = decodeAbiParameters([limitOrderEncoding, signatureEncoding], dZeroExOrderEncode);
+      const [order, signature] = decodeAbiParameters([limitOrderEncoding, signatureEncoding], encodedZeroExOrderArgs);
 
       const signatureType = signature.signatureType;
       if (!isValidSignatureType(signatureType)) {
@@ -252,7 +251,6 @@ export function takeOrderDecode(encoded: Hex): TakeOrderArgs {
       }
 
       return {
-        dZeroExOrderEncode,
         takerAssetFillAmount,
         orderType,
         order,
@@ -264,7 +262,7 @@ export function takeOrderDecode(encoded: Hex): TakeOrderArgs {
     }
 
     case OrderType.Rfq: {
-      const [order, signature] = decodeAbiParameters([rfqOrderEncoding, signatureEncoding], dZeroExOrderEncode);
+      const [order, signature] = decodeAbiParameters([rfqOrderEncoding, signatureEncoding], encodedZeroExOrderArgs);
 
       const signatureType = signature.signatureType;
       if (!isValidSignatureType(signatureType)) {
@@ -272,7 +270,6 @@ export function takeOrderDecode(encoded: Hex): TakeOrderArgs {
       }
 
       return {
-        dZeroExOrderEncode,
         takerAssetFillAmount,
         orderType,
         order,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing the `0x` adapter issue. 

### Detailed summary
- Renamed the `dZeroExOrderEncode` variable to `encodedZeroExOrderArgs`
- Updated function parameters and variable assignments accordingly

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->