### PR TITLE
feat: stakeWise external position

### DIFF
--- a/.changeset/strong-needles-explain.md
+++ b/.changeset/strong-needles-explain.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+StakeWise External Position

--- a/packages/sdk/src/internal/Extensions/ExternalPositions.ts
+++ b/packages/sdk/src/internal/Extensions/ExternalPositions.ts
@@ -5,5 +5,6 @@ export * as ConvexVoting from "@enzymefinance/sdk/internal/Extensions/ExternalPo
 export * as Kiln from "@enzymefinance/sdk/internal/Extensions/ExternalPositions/Kiln";
 export * as Liquity from "@enzymefinance/sdk/internal/Extensions/ExternalPositions/Liquity";
 export * as MapleLiquidity from "@enzymefinance/sdk/internal/Extensions/ExternalPositions/MapleLiquidity";
+export * as StakeWise from "@enzymefinance/sdk/internal/Extensions/ExternalPositions/StakeWise";
 export * as TheGraphDelegation from "@enzymefinance/sdk/internal/Extensions/ExternalPositions/TheGraphDelegation";
 export * as UniswapV3Liquidity from "@enzymefinance/sdk/internal/Extensions/ExternalPositions/UniswapV3Liquidity";

--- a/packages/sdk/src/internal/Extensions/ExternalPositions/StakeWise.ts
+++ b/packages/sdk/src/internal/Extensions/ExternalPositions/StakeWise.ts
@@ -1,0 +1,157 @@
+import * as ExternalPositionManager from "@enzymefinance/sdk/internal/ExternalPositionManager";
+import { type Address, type Hex, decodeAbiParameters, encodeAbiParameters } from "viem";
+
+export type Action = typeof Action[keyof typeof Action];
+export const Action = {
+  Stake: 0n,
+  Redeem: 1n,
+  EnterExitQueue: 2n,
+  ClaimExitedAssets: 3n,
+} as const;
+
+export const create = ExternalPositionManager.createOnly;
+
+//--------------------------------------------------------------------------------------------
+// STAKE
+//--------------------------------------------------------------------------------------------
+
+export const stake = ExternalPositionManager.makeUse(Action.Stake, stakeEncode);
+export const createAndStake = ExternalPositionManager.makeCreateAndUse(Action.Stake, stakeEncode);
+
+const stakeEncoding = [
+  {
+    type: "address",
+    name: "stakeWiseVaultAddress",
+  },
+  {
+    name: "assetAmount",
+    type: "uint256",
+  },
+] as const;
+
+export type StakeArgs = {
+  stakeWiseVaultAddress: Address;
+  assetAmount: bigint;
+};
+
+export function stakeEncode(args: StakeArgs): Hex {
+  return encodeAbiParameters(
+    stakeEncoding,
+    [args.stakeWiseVaultAddress, args.assetAmount],
+  );
+}
+
+export function stakeDecode(encoded: Hex): StakeArgs {
+  const [stakeWiseVaultAddress, assetAmount] = decodeAbiParameters(stakeEncoding, encoded);
+
+  return {
+    stakeWiseVaultAddress,
+    assetAmount,
+  };
+}
+
+//--------------------------------------------------------------------------------------------
+// REDEEM
+//--------------------------------------------------------------------------------------------
+
+export const redeem = ExternalPositionManager.makeUse(Action.Redeem, redeemEncode);
+
+const redeemEncoding = [
+  {
+    type: "address",
+    name: "stakeWiseVaultAddress",
+  },
+  {
+    name: "shareAmount",
+    type: "uint256",
+  },
+] as const;
+
+export type RedeemArgs = {
+  stakeWiseVaultAddress: Address;
+  sharesAmount: bigint;
+};
+
+export function redeemEncode(args: RedeemArgs): Hex {
+  return encodeAbiParameters(redeemEncoding, [args.stakeWiseVaultAddress, args.sharesAmount]);
+}
+
+export function claimFeesDecode(encoded: Hex): RedeemArgs {
+  const [stakeWiseVaultAddress, sharesAmount] = decodeAbiParameters(redeemEncoding, encoded);
+
+
+  return {
+    stakeWiseVaultAddress,
+    sharesAmount,
+  };
+}
+
+//--------------------------------------------------------------------------------------------
+// ENTER EXIT QUEUE
+//--------------------------------------------------------------------------------------------
+
+export const enterExitQueue = ExternalPositionManager.makeUse(Action.EnterExitQueue, enterExitQueueEncode);
+
+const enterExitQueueEncoding = [
+  {
+    type: "address",
+    name: "stakeWiseVaultAddress",
+  },
+  {
+    name: "sharesAmount",
+    type: "uint256",
+  },
+] as const;
+
+export type EnterExitQueueArgs = {
+  sharesAmount: bigint;
+  stakeWiseVaultAddress: Address;
+};
+
+export function enterExitQueueEncode(args: EnterExitQueueArgs): Hex {
+  return encodeAbiParameters(enterExitQueueEncoding, [args.stakeWiseVaultAddress, args.sharesAmount]);
+}
+
+export function enterExitQueueDecode(encoded: Hex): EnterExitQueueArgs {
+  const [stakeWiseVaultAddress, sharesAmount] = decodeAbiParameters(enterExitQueueEncoding, encoded);
+
+  return {
+    stakeWiseVaultAddress,
+    sharesAmount,
+  };
+}
+
+//--------------------------------------------------------------------------------------------
+// CLAIM EXITED ASSET
+//--------------------------------------------------------------------------------------------
+
+export const claimExitedAssets = ExternalPositionManager.makeUse(Action.ClaimExitedAssets, claimExitedAssetsEncode);
+
+const claimExitedAssetsEncoding = [
+  {
+    type: "address",
+    name: "stakeWiseVaultAddress",
+  },
+  {
+    name: "positionTicket",
+    type: "uint256",
+  },
+] as const;
+
+export type ClaimExitedAssetsArgs = {
+  sharesAmount: bigint;
+  stakeWiseVaultAddress: Address;
+};
+
+export function claimExitedAssetsEncode(args: ClaimExitedAssetsArgs): Hex {
+  return encodeAbiParameters(claimExitedAssetsEncoding, [args.stakeWiseVaultAddress, args.sharesAmount]);
+}
+
+export function claimExitedAssetsDecode(encoded: Hex): ClaimExitedAssetsArgs {
+  const [stakeWiseVaultAddress, sharesAmount] = decodeAbiParameters(claimExitedAssetsEncoding, encoded);
+
+  return {
+    stakeWiseVaultAddress,
+    sharesAmount,
+  };
+}

--- a/packages/sdk/src/internal/Extensions/ExternalPositions/StakeWise.ts
+++ b/packages/sdk/src/internal/Extensions/ExternalPositions/StakeWise.ts
@@ -135,19 +135,19 @@ const claimExitedAssetsEncoding = [
 ] as const;
 
 export type ClaimExitedAssetsArgs = {
-  sharesAmount: bigint;
+  positionTicket: bigint;
   stakeWiseVaultAddress: Address;
 };
 
 export function claimExitedAssetsEncode(args: ClaimExitedAssetsArgs): Hex {
-  return encodeAbiParameters(claimExitedAssetsEncoding, [args.stakeWiseVaultAddress, args.sharesAmount]);
+  return encodeAbiParameters(claimExitedAssetsEncoding, [args.stakeWiseVaultAddress, args.positionTicket]);
 }
 
 export function claimExitedAssetsDecode(encoded: Hex): ClaimExitedAssetsArgs {
-  const [stakeWiseVaultAddress, sharesAmount] = decodeAbiParameters(claimExitedAssetsEncoding, encoded);
+  const [stakeWiseVaultAddress, positionTicket] = decodeAbiParameters(claimExitedAssetsEncoding, encoded);
 
   return {
     stakeWiseVaultAddress,
-    sharesAmount,
+    positionTicket,
   };
 }

--- a/packages/sdk/src/internal/Extensions/ExternalPositions/StakeWise.ts
+++ b/packages/sdk/src/internal/Extensions/ExternalPositions/StakeWise.ts
@@ -35,10 +35,7 @@ export type StakeArgs = {
 };
 
 export function stakeEncode(args: StakeArgs): Hex {
-  return encodeAbiParameters(
-    stakeEncoding,
-    [args.stakeWiseVaultAddress, args.assetAmount],
-  );
+  return encodeAbiParameters(stakeEncoding, [args.stakeWiseVaultAddress, args.assetAmount]);
 }
 
 export function stakeDecode(encoded: Hex): StakeArgs {
@@ -78,7 +75,6 @@ export function redeemEncode(args: RedeemArgs): Hex {
 
 export function claimFeesDecode(encoded: Hex): RedeemArgs {
   const [stakeWiseVaultAddress, sharesAmount] = decodeAbiParameters(redeemEncoding, encoded);
-
 
   return {
     stakeWiseVaultAddress,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- This PR adds a new module called `StakeWise` to the `ExternalPositions` extension in the `@enzymefinance/sdk` package.
- The `StakeWise` module provides functions for staking, redeeming, entering/exiting the queue, and claiming exited assets in the StakeWise protocol.
- Each function has its corresponding encoding and decoding functions for the arguments.
- The `StakeWise` module uses the `ExternalPositionManager` to interact with the StakeWise protocol.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->