### PR TITLE
feat: add decodedOneInchSwapArgs

### DIFF
--- a/.changeset/clever-students-live.md
+++ b/.changeset/clever-students-live.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Add helper function to decode 1Inch data received from their API

--- a/packages/sdk/src/internal/Extensions/IntegrationAdapters/OneInchV5.ts
+++ b/packages/sdk/src/internal/Extensions/IntegrationAdapters/OneInchV5.ts
@@ -90,3 +90,67 @@ export function takeOrderDecode(encoded: Hex): TakeOrderArgs {
     data,
   };
 }
+
+const oneInchSwapArgsEncoding = [
+  {
+    name: "executor",
+    type: "address",
+  },
+  {
+    components: [
+      {
+        internalType: "address",
+        name: "srcToken",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "dstToken",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "srcReceiver",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "dstReceiver",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "minReturnAmount",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "flags",
+        type: "uint256",
+      },
+    ],
+    name: "orderDescription",
+    type: "tuple",
+  },
+  { name: "unknown", type: "bytes" },
+  {
+    name: "data",
+    type: "bytes",
+  },
+] as const;
+
+export function decodedOneInchSwapArgs(encoded: Hex): TakeOrderArgs {
+  const [executor, orderDescription, , data] = decodeAbiParameters(oneInchSwapArgsEncoding, `0x${encoded.slice(10)}`);
+  const { srcToken, dstToken, srcReceiver, dstReceiver, amount, minReturnAmount, flags } = orderDescription;
+
+  return {
+    executor,
+    orderDescription: { srcToken, dstToken, srcReceiver, dstReceiver, amount, minReturnAmount, flags },
+    data,
+  };
+}


### PR DESCRIPTION
This is a helper function which is needed to decode data received from the 1Inch API.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a helper function to decode 1Inch data received from their API.

### Detailed summary
- Added `decodedOneInchSwapArgs` function to decode 1Inch swap arguments
- Defined `oneInchSwapArgsEncoding` array to specify the encoding structure
- Extracted relevant data from the decoded arguments
- Returned the extracted data in a structured format

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->