### PR TITLE
fix: improve 1Inch function naming

### DIFF
--- a/.changeset/weak-doors-promise.md
+++ b/.changeset/weak-doors-promise.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Improve 1Inch naming

--- a/packages/sdk/src/internal/Extensions/IntegrationAdapters/OneInchV5.ts
+++ b/packages/sdk/src/internal/Extensions/IntegrationAdapters/OneInchV5.ts
@@ -91,7 +91,7 @@ export function takeOrderDecode(encoded: Hex): TakeOrderArgs {
   };
 }
 
-const oneInchSwapArgsEncoding = [
+const swapArgsEncoding = [
   {
     name: "executor",
     type: "address",
@@ -144,8 +144,8 @@ const oneInchSwapArgsEncoding = [
   },
 ] as const;
 
-export function decodedOneInchSwapArgs(encoded: Hex): TakeOrderArgs {
-  const [executor, orderDescription, , data] = decodeAbiParameters(oneInchSwapArgsEncoding, `0x${encoded.slice(10)}`);
+export function decodedSwapArgs(encoded: Hex): TakeOrderArgs {
+  const [executor, orderDescription, , data] = decodeAbiParameters(swapArgsEncoding, `0x${encoded.slice(10)}`);
   const { srcToken, dstToken, srcReceiver, dstReceiver, amount, minReturnAmount, flags } = orderDescription;
 
   return {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
Improve naming in 1Inch integration adapter.

### Detailed summary:
- Renamed `oneInchSwapArgsEncoding` to `swapArgsEncoding`.
- Renamed `decodedOneInchSwapArgs` function to `decodedSwapArgs`.
- Updated references to the renamed variables and function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->