### PR TITLE
feat: rename toAddress to asAddress and toHex to asHex

### DIFF
--- a/.changeset/wise-chicken-share.md
+++ b/.changeset/wise-chicken-share.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Rename utils

--- a/packages/sdk/src/internal/Utils/address.ts
+++ b/packages/sdk/src/internal/Utils/address.ts
@@ -17,7 +17,7 @@ export function isNonZeroAddress(value: any): value is Address {
   return isAddress(value) && value !== ZeroAddress;
 }
 
-export function toAddress(value: string): Address {
+export function asAddress(value: string): Address {
   const address = value.toLowerCase();
 
   if (isAddress(address)) {

--- a/packages/sdk/src/internal/Utils/hex.ts
+++ b/packages/sdk/src/internal/Utils/hex.ts
@@ -1,6 +1,6 @@
 import { type Hex, isHex } from "viem";
 
-export function toHex(input: string): Hex {
+export function asHex(input: string): Hex {
   const hex = input.toLowerCase();
 
   if (isHex(hex)) {


### PR DESCRIPTION
... to avoid confusion with viem's `toHex` function.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming the `toHex` and `toAddress` functions to `asHex` and `asAddress` respectively in the `Utils` module.

### Detailed summary
- Renamed `toHex` function to `asHex` in `hex.ts` file.
- Renamed `toAddress` function to `asAddress` in `address.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->