### PR TITLE
chore: use viem constants

### DIFF
--- a/.changeset/cold-suns-rest.md
+++ b/.changeset/cold-suns-rest.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Use viem constants

--- a/packages/sdk/src/Relayer.ts
+++ b/packages/sdk/src/Relayer.ts
@@ -1,6 +1,6 @@
 import * as Abis from "@enzymefinance/abis";
-import { Constants, Viem } from "@enzymefinance/sdk/Utils";
-import { type Address, type PublicClient, isAddressEqual } from "viem";
+import { Viem } from "@enzymefinance/sdk/Utils";
+import { type Address, type PublicClient, isAddressEqual, zeroAddress } from "viem";
 
 export async function isRelayerEnabled(
   client: PublicClient,
@@ -14,7 +14,7 @@ export async function isRelayerEnabled(
     functionName: "getGasRelayPaymaster",
   });
 
-  return !isAddressEqual(address, Constants.ZeroAddress);
+  return !isAddressEqual(address, zeroAddress);
 }
 
 export function getRelayerBalance(

--- a/packages/sdk/src/internal/Extensions/Fees/Entrance.ts
+++ b/packages/sdk/src/internal/Extensions/Fees/Entrance.ts
@@ -1,5 +1,5 @@
-import { Constants, type Types } from "@enzymefinance/sdk/Utils";
-import { type Address, type Hex, decodeAbiParameters, encodeAbiParameters } from "viem";
+import { type Types } from "@enzymefinance/sdk/Utils";
+import { type Address, type Hex, decodeAbiParameters, encodeAbiParameters, zeroAddress } from "viem";
 
 //--------------------------------------------------------------------------------------------
 // CALCULATIONS
@@ -63,7 +63,7 @@ export type DirectFeeSettings = {
 
 export function encodeDirectFeeSettings({
   feeRateInBps,
-  feeRecipient = Constants.ZeroAddress,
+  feeRecipient = zeroAddress,
 }: Types.PartialPick<DirectFeeSettings, "feeRecipient">): Hex {
   return encodeAbiParameters(directFeeSettingsEncoding, [feeRateInBps, feeRecipient]);
 }

--- a/packages/sdk/src/internal/Extensions/Fees/Exit.ts
+++ b/packages/sdk/src/internal/Extensions/Fees/Exit.ts
@@ -1,5 +1,4 @@
-import { Constants } from "@enzymefinance/sdk/Utils";
-import { type Address, type Hex, decodeAbiParameters, encodeAbiParameters } from "viem";
+import { type Address, type Hex, decodeAbiParameters, encodeAbiParameters, zeroAddress } from "viem";
 
 //--------------------------------------------------------------------------------------------
 // CALCULATIONS
@@ -75,7 +74,7 @@ export type DirectFeeSettings = {
 export function encodeDirectFeeSettings({
   inKindRateInBps = 0n,
   specificAssetsRate = 0n,
-  feeRecipient = Constants.ZeroAddress,
+  feeRecipient = zeroAddress,
 }: Partial<DirectFeeSettings>): Hex {
   return encodeAbiParameters(directFeeSettingsEncoding, [inKindRateInBps, specificAssetsRate, feeRecipient]);
 }

--- a/packages/sdk/src/internal/Extensions/Fees/Management.ts
+++ b/packages/sdk/src/internal/Extensions/Fees/Management.ts
@@ -1,6 +1,6 @@
 import * as Abis from "@enzymefinance/abis";
-import { Constants, Rates, Viem } from "@enzymefinance/sdk/Utils";
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters } from "viem";
+import { Rates, Viem } from "@enzymefinance/sdk/Utils";
+import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters, zeroAddress } from "viem";
 
 //--------------------------------------------------------------------------------------------
 // CALCULATIONS
@@ -60,7 +60,7 @@ export type EncodeSettingsParams = {
 export function encodeSettings({
   scaledPerSecondRate,
   perAnnumRateInBps,
-  feeRecipient = Constants.ZeroAddress,
+  feeRecipient = zeroAddress,
 }: EncodeSettingsParams): Hex {
   const fee: bigint =
     scaledPerSecondRate !== undefined

--- a/packages/sdk/src/internal/Extensions/Fees/Performance.ts
+++ b/packages/sdk/src/internal/Extensions/Fees/Performance.ts
@@ -1,6 +1,6 @@
 import * as Abis from "@enzymefinance/abis";
-import { Constants, type Types, Viem } from "@enzymefinance/sdk/Utils";
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters } from "viem";
+import { type Types, Viem } from "@enzymefinance/sdk/Utils";
+import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters, zeroAddress } from "viem";
 
 //--------------------------------------------------------------------------------------------
 // SETTINGS
@@ -24,7 +24,7 @@ export type PerformanceFeeSettings = {
 
 export function encodePerformanceFeeSettings({
   feeRateInBps,
-  feeRecipient = Constants.ZeroAddress,
+  feeRecipient = zeroAddress,
 }: Types.PartialPick<PerformanceFeeSettings, "feeRecipient">): Hex {
   return encodeAbiParameters(performanceFeeSettingsEncoding, [feeRateInBps, feeRecipient]);
 }

--- a/packages/sdk/src/internal/Extensions/Policies/MinMaxInvestment.ts
+++ b/packages/sdk/src/internal/Extensions/Policies/MinMaxInvestment.ts
@@ -1,5 +1,4 @@
-import { Constants } from "@enzymefinance/sdk/Utils";
-import { type Hex, decodeAbiParameters, encodeAbiParameters } from "viem";
+import { type Hex, decodeAbiParameters, encodeAbiParameters, maxUint256 } from "viem";
 
 const settingsEncoding = [
   {
@@ -43,7 +42,7 @@ export type Settings = {
 export function encodeSettings(args: Partial<Settings>): Hex {
   return encodeAbiParameters(settingsEncoding, [
     args.minInvestmentAmount ?? 0n,
-    args.maxInvestmentAmount ?? Constants.MaxUint256,
+    args.maxInvestmentAmount ?? maxUint256,
   ]);
 }
 

--- a/packages/sdk/src/internal/Utils/address.ts
+++ b/packages/sdk/src/internal/Utils/address.ts
@@ -1,5 +1,4 @@
-import { type Address, getAddress, isAddress, isAddressEqual } from "viem";
-import { ZeroAddress } from "./constants";
+import { type Address, getAddress, isAddress, isAddressEqual, zeroAddress } from "viem";
 
 export function sameAddress(a: string, b: string) {
   return isAddressEqual(getAddress(a), getAddress(b));
@@ -14,7 +13,7 @@ export function safeSameAddress(a: Address | string | null | undefined, b: Addre
 }
 
 export function isNonZeroAddress(value: any): value is Address {
-  return isAddress(value) && value !== ZeroAddress;
+  return isAddress(value) && value !== zeroAddress;
 }
 
 export function asAddress(value: string): Address {

--- a/packages/sdk/src/internal/Utils/constants.ts
+++ b/packages/sdk/src/internal/Utils/constants.ts
@@ -1,6 +1,2 @@
 export const SharesUnit = 1_000_000_000_000_000_000n;
-export const MaxUint128 = 340_282_366_920_938_463_463_374_607_431_768_211_455n;
-export const MaxUint256 =
-  115_792_089_237_316_195_423_570_985_008_687_907_853_269_984_665_640_564_039_457_584_007_913_129_639_935n;
 export const EthAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
-export const ZeroAddress = "0x0000000000000000000000000000000000000000";


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the codebase to use the `viem` constants instead of the custom constants defined in the code.

### Detailed summary:
- Updated the code to use `viem` constants instead of custom constants in the following files:
  - `packages/sdk/src/internal/Utils/constants.ts`
  - `packages/sdk/src/internal/Extensions/Policies/MinMaxInvestment.ts`
  - `packages/sdk/src/Relayer.ts`
  - `packages/sdk/src/internal/Utils/address.ts`
  - `packages/sdk/src/internal/Extensions/Fees/Exit.ts`
  - `packages/sdk/src/internal/Extensions/Fees/Entrance.ts`
  - `packages/sdk/src/internal/Extensions/Fees/Management.ts`
  - `packages/sdk/src/internal/Extensions/Fees/Performance.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->