### PR TITLE
feat: add Aave v2 incentives read functions

### DIFF
--- a/packages/sdk/src/internal/Extensions/ExternalPositions/AaveV2Debt.ts
+++ b/packages/sdk/src/internal/Extensions/ExternalPositions/AaveV2Debt.ts
@@ -1,5 +1,6 @@
+import { Viem } from "@enzymefinance/sdk/Utils";
 import * as ExternalPositionManager from "@enzymefinance/sdk/internal/ExternalPositionManager";
-import { type Address, type Hex, decodeAbiParameters, encodeAbiParameters } from "viem";
+import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters } from "viem";
 
 export type Action = typeof Action[keyof typeof Action];
 export const Action = {
@@ -154,4 +155,59 @@ export function repayBorrowDecode(encoded: Hex): RepayBorrowArgs {
     underlyingTokens,
     amounts,
   };
+}
+
+//--------------------------------------------------------------------------------------------
+// EXTERNAL CONTRACT METHODS
+//--------------------------------------------------------------------------------------------
+
+const aaveIncentivesControllerAbi = [
+  {
+    inputs: [
+      { internalType: "address[]", name: "assets", type: "address[]" },
+      { internalType: "address", name: "user", type: "address" },
+    ],
+    name: "getRewardsBalance",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "_user", type: "address" }],
+    name: "getUserUnclaimedRewards",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+export async function getRewardsBalance(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    aaveIncentivesController: Address;
+    assets: Address[];
+    user: Address;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: aaveIncentivesControllerAbi,
+    functionName: "getRewardsBalance",
+    address: args.aaveIncentivesController,
+    args: [args.assets, args.user],
+  });
+}
+
+export async function getUserUnclaimedRewards(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    aaveIncentivesController: Address;
+    user: Address;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: aaveIncentivesControllerAbi,
+    functionName: "getUserUnclaimedRewards",
+    address: args.aaveIncentivesController,
+    args: [args.user],
+  });
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding two new methods (`getRewardsBalance` and `getUserUnclaimedRewards`) to the `AaveV2Debt.ts` file in the `sdk` package.

### Detailed summary:
- Added `type PublicClient` import from "viem" in `AaveV2Debt.ts` file.
- Added two new methods: `getRewardsBalance` and `getUserUnclaimedRewards` to interact with the Aave incentives controller contract.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->