### PR TITLE
feat: add missing Compound function getSupplyRatePerBlock

### DIFF
--- a/.changeset/sour-mugs-camp.md
+++ b/.changeset/sour-mugs-camp.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Add missing compound function getSupplyRatePerBlock

--- a/packages/sdk/src/internal/Extensions/IntegrationAdapters/CompoundV2.ts
+++ b/packages/sdk/src/internal/Extensions/IntegrationAdapters/CompoundV2.ts
@@ -187,6 +187,19 @@ export function getBorrowRatePerBlock(
   });
 }
 
+export function getSupplyRatePerBlock(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    cToken: Address;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: cTokenAbi,
+    functionName: "supplyRatePerBlock",
+    address: args.cToken,
+  });
+}
+
 export function getTotalSupply(
   client: PublicClient,
   args: Viem.ContractCallParameters<{


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
Add missing `getSupplyRatePerBlock` function to the CompoundV2 integration adapter.

### Detailed summary:
- Added `getSupplyRatePerBlock` function to the CompoundV2 integration adapter in `packages/sdk/src/internal/Extensions/IntegrationAdapters/CompoundV2.ts`
- The function retrieves the supply rate per block for a given cToken by making a contract call using the `Viem` library.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->