### PR TITLE
feat: compound v3 external calls

### DIFF
--- a/.changeset/thin-bikes-learn.md
+++ b/.changeset/thin-bikes-learn.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+External calls for Compound v3

--- a/packages/sdk/src/External.ts
+++ b/packages/sdk/src/External.ts
@@ -1,6 +1,7 @@
 export * as AaveV2 from "@enzymefinance/sdk/internal/External/AaveV2";
 export * as BalancerV2 from "@enzymefinance/sdk/internal/External/BalancerV2";
 export * as CompoundV2 from "@enzymefinance/sdk/internal/External/CompoundV2";
+export * as CompoundV3 from "@enzymefinance/sdk/internal/External/CompoundV3";
 export * as Convex from "@enzymefinance/sdk/internal/External/Convex";
 export * as Curve from "@enzymefinance/sdk/internal/External/Curve";
 export * as IdleV4 from "@enzymefinance/sdk/internal/External/IdleV4";

--- a/packages/sdk/src/internal/External/CompoundV3.ts
+++ b/packages/sdk/src/internal/External/CompoundV3.ts
@@ -1,0 +1,130 @@
+import { Viem } from "@enzymefinance/sdk/Utils";
+import type { Address, PublicClient } from "viem";
+
+// ABI from https://etherscan.io/address/0x7a1316220a46dce22fd5c6d55a39513367e6c967#code
+const cometAbi = [
+  {
+    inputs: [],
+    name: "getUtilization",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "utilization", type: "uint256" }],
+    name: "getSupplyRate",
+    outputs: [{ internalType: "uint64", name: "", type: "uint64" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "totalSupply",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "baseTrackingSupplySpeed",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+// ABI from https://etherscan.io/address/0x1b0e765f6224c21223aea2af16c1c46e38885a40#code
+const cometRewardsAbi = [
+  {
+    inputs: [
+      { internalType: "address", name: "comet", type: "address" },
+      { internalType: "address", name: "account", type: "address" },
+    ],
+    name: "getRewardOwed",
+    outputs: [
+      {
+        components: [
+          { internalType: "address", name: "token", type: "address" },
+          { internalType: "uint256", name: "owed", type: "uint256" },
+        ],
+        internalType: "struct CometRewards.RewardOwed",
+        name: "",
+        type: "tuple",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+] as const;
+
+export async function getUtilization(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    asset: Address;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: cometAbi,
+    functionName: "getUtilization",
+    address: args.asset,
+  });
+}
+
+export async function getSupplyRate(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    asset: Address;
+    utilization: bigint;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: cometAbi,
+    functionName: "getSupplyRate",
+    address: args.asset,
+    args: [args.utilization],
+  });
+}
+
+export async function getTotalSupply(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    asset: Address;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: cometAbi,
+    functionName: "totalSupply",
+    address: args.asset,
+  });
+}
+
+export async function getBaseTrackingSupplySpeed(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    asset: Address;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: cometAbi,
+    functionName: "baseTrackingSupplySpeed",
+    address: args.asset,
+  });
+}
+
+export async function getRewardOwed(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    cometRewards: Address;
+    asset: Address;
+    user: Address;
+  }>,
+) {
+  const { result } = await Viem.simulateContract(client, args, {
+    abi: cometRewardsAbi,
+    functionName: "getRewardOwed",
+    address: args.cometRewards,
+    args: [args.asset, args.user],
+  });
+
+  return result;
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added external calls for Compound v3 in `External.ts`
- Added `CompoundV3.ts` file with functions for interacting with Compound v3 contracts
- Imported `Viem` and `Address` types from `@enzymefinance/sdk/Utils` and `viem` respectively in `CompoundV3.ts`
- Added ABI for Comet and CometRewards contracts in `CompoundV3.ts`
- Added functions `getUtilization`, `getSupplyRate`, `getTotalSupply`, `getBaseTrackingSupplySpeed`, and `getRewardOwed` in `CompoundV3.ts` for making contract calls

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->