### PR TITLE
feat: external calls for Convex

### DIFF
--- a/.changeset/loud-snails-compete.md
+++ b/.changeset/loud-snails-compete.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+External calls for Convex

--- a/packages/sdk/src/internal/External/Convex.ts
+++ b/packages/sdk/src/internal/External/Convex.ts
@@ -2,28 +2,46 @@ import * as Abis from "@enzymefinance/abis";
 import { Assertion, Viem } from "@enzymefinance/sdk/Utils";
 import { type Address, type PublicClient } from "viem";
 
-const voteLockedConvexTokenAbi = [
+//--------------------------------------------------------------------------------------------
+// CVX MINING
+//--------------------------------------------------------------------------------------------
+
+const cvxMiningAbi = {
+  inputs: [{ internalType: "uint256", name: "_amount", type: "uint256" }],
+  name: "ConvertCrvToCvx",
+  outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+  stateMutability: "view",
+  type: "function",
+} as const;
+
+export async function convertCrvToCvx(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    cvxMining: Address;
+    amount: bigint;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: [cvxMiningAbi],
+    address: args.cvxMining,
+    functionName: "ConvertCrvToCvx",
+    args: [args.amount],
+  });
+}
+
+//--------------------------------------------------------------------------------------------
+// VOTE LOCKED CONVEX TOKEN
+//--------------------------------------------------------------------------------------------
+
+// ABI from https://etherscan.io/address/0x72a19342e8f1838460ebfccef09f6585e32db86e#code
+const cvxLockerV2Abi = [
   {
-    inputs: [
-      {
-        internalType: "address",
-        name: "_user",
-        type: "address",
-      },
-    ],
+    inputs: [{ internalType: "address", name: "_user", type: "address" }],
     name: "lockedBalances",
     outputs: [
       { internalType: "uint256", name: "total", type: "uint256" },
-      {
-        internalType: "uint256",
-        name: "unlockable",
-        type: "uint256",
-      },
-      {
-        internalType: "uint256",
-        name: "locked",
-        type: "uint256",
-      },
+      { internalType: "uint256", name: "unlockable", type: "uint256" },
+      { internalType: "uint256", name: "locked", type: "uint256" },
       {
         components: [
           { internalType: "uint112", name: "amount", type: "uint112" },
@@ -38,7 +56,101 @@ const voteLockedConvexTokenAbi = [
     stateMutability: "view",
     type: "function",
   },
+  {
+    inputs: [{ internalType: "address", name: "_account", type: "address" }],
+    name: "claimableRewards",
+    outputs: [
+      {
+        components: [
+          { internalType: "address", name: "token", type: "address" },
+          { internalType: "uint256", name: "amount", type: "uint256" },
+        ],
+        internalType: "struct CvxLockerV2.EarnedData[]",
+        name: "userRewards",
+        type: "tuple[]",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "", type: "address" },
+      { internalType: "uint256", name: "", type: "uint256" },
+    ],
+    name: "userLocks",
+    outputs: [
+      { internalType: "uint112", name: "amount", type: "uint112" },
+      { internalType: "uint112", name: "boosted", type: "uint112" },
+      { internalType: "uint32", name: "unlockTime", type: "uint32" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
 ] as const;
+
+export async function getVoteLockedBalances(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    voteLockedConvexToken: Address;
+    positionAddress: Address;
+  }>,
+) {
+  const [total, unlockable, locked, balancesData] = await Viem.readContract(client, args, {
+    abi: cvxLockerV2Abi,
+    address: args.voteLockedConvexToken,
+    functionName: "lockedBalances",
+    args: [args.positionAddress],
+  });
+
+  const lockedData = balancesData.map((data) => ({
+    amount: data.amount,
+    boosted: data.boosted,
+    unlockTime: data.unlockTime,
+  }));
+
+  return {
+    total,
+    unlockable,
+    locked,
+    lockedData,
+  };
+}
+
+export async function getClaimableRewards(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    voteLockedConvexToken: Address;
+    user: Address;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: cvxLockerV2Abi,
+    address: args.voteLockedConvexToken,
+    functionName: "claimableRewards",
+    args: [args.user],
+  });
+}
+
+export async function getUserLocks(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    voteLockedConvexToken: Address;
+    user: Address;
+    lockNumber: bigint;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: cvxLockerV2Abi,
+    address: args.voteLockedConvexToken,
+    functionName: "userLocks",
+    args: [args.user, args.lockNumber],
+  });
+}
+
+//--------------------------------------------------------------------------------------------
+// CVX BOOSTER
+//--------------------------------------------------------------------------------------------
 
 // ABI from https://etherscan.io/address/0xf403c135812408bfbe8713b5a23a04b3d48aae31#code
 const boosterAbi = [
@@ -86,19 +198,6 @@ const boosterAbi = [
   },
 ] as const;
 
-interface LockData {
-  amount: bigint;
-  boosted: bigint;
-  unlockTime: number;
-}
-
-interface LockedBalances {
-  total: bigint;
-  unlockable: bigint;
-  locked: bigint;
-  lockedData: LockData[];
-}
-
 export interface PoolInfo {
   lptoken: Address;
   token: Address;
@@ -106,143 +205,6 @@ export interface PoolInfo {
   crvRewards: Address;
   stash: Address;
   shutdown: boolean;
-}
-
-export async function getVoteLockedBalances(
-  client: PublicClient,
-  args: Viem.ContractCallParameters<{
-    voteLockedConvexToken: Address;
-    positionAddress: Address;
-  }>,
-) {
-  const [total, unlockable, locked, balancesData] = await Viem.readContract(client, args, {
-    abi: voteLockedConvexTokenAbi,
-    address: args.voteLockedConvexToken,
-    functionName: "lockedBalances",
-    args: [args.positionAddress],
-  });
-
-  const lockedData = balancesData.map((data) => {
-    return {
-      amount: data.amount,
-      boosted: data.boosted,
-      unlockTime: data.unlockTime,
-    };
-  });
-
-  const lockedBalancesData = {
-    total,
-    unlockable,
-    locked,
-    lockedData,
-  };
-
-  return lockedBalancesData;
-}
-
-export async function getAllVoteLockedBalances(
-  client: PublicClient,
-  args: Viem.ContractCallParameters<{
-    voteLockedConvexToken: Address;
-    positionAddresses: Address[];
-  }>,
-) {
-  const allLockedBalances = await Promise.all(
-    args.positionAddresses.map(async (position) => {
-      const lockedBalances = await getVoteLockedBalances(client, {
-        voteLockedConvexToken: args.voteLockedConvexToken,
-        positionAddress: position,
-      });
-
-      return { position, lockedBalances };
-    }),
-  );
-
-  const lockedBalancesMap: Record<Address, LockedBalances> = {};
-  for (const { position, lockedBalances } of allLockedBalances) {
-    lockedBalancesMap[position] = lockedBalances;
-  }
-
-  return lockedBalancesMap;
-}
-
-const convertCrvToCvxAbi = {
-  inputs: [{ internalType: "uint256", name: "_amount", type: "uint256" }],
-  name: "ConvertCrvToCvx",
-  outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-  stateMutability: "view",
-  type: "function",
-} as const;
-
-export async function convertCrvToCvx(
-  client: PublicClient,
-  args: Viem.ContractCallParameters<{
-    cvxMining: Address;
-    amount: bigint;
-  }>,
-) {
-  return Viem.readContract(client, args, {
-    abi: [convertCrvToCvxAbi],
-    address: args.cvxMining,
-    functionName: "ConvertCrvToCvx",
-    args: [args.amount],
-  });
-}
-
-export async function getEstimateRewards(
-  client: PublicClient,
-  args: Viem.ContractCallParameters<{
-    stakingWrapper: Address;
-    beneficiary: Address;
-  }>,
-) {
-  const {
-    result: [rewardTokens, claimedAmounts],
-  } = await Viem.simulateContract(client, args, {
-    abi: Abis.IConvexCurveLpStakingWrapperLib,
-    functionName: "claimRewardsFor",
-    address: args.stakingWrapper,
-    args: [args.beneficiary],
-  });
-
-  const tokenRewards: Record<Address, bigint> = {};
-  for (let i = 0; i < rewardTokens.length; i++) {
-    const rewardToken = rewardTokens[i];
-    const claimedAmount = claimedAmounts[i];
-    Assertion.invariant(rewardToken !== undefined, "Expected reward token to be defined.");
-    Assertion.invariant(claimedAmount !== undefined, "Expected claimed amount to be defined.");
-
-    tokenRewards[rewardToken] = claimedAmount;
-  }
-
-  return tokenRewards;
-}
-
-export async function getAllEstimateRewards(
-  client: PublicClient,
-  args: Viem.ContractCallParameters<{
-    stakingWrappers: Address[];
-    beneficiary: Address;
-  }>,
-) {
-  const tokenRewards = await Promise.all(
-    args.stakingWrappers.map(async (stakingWrapper) => {
-      const rewards = await getEstimateRewards(client, {
-        ...args,
-        stakingWrapper,
-      });
-
-      return { rewards, stakingWrapper };
-    }),
-  );
-
-  const tokenRewardsMap: Record<Address, Record<`0x${string}`, bigint> | undefined> = {};
-
-  for (const { rewards, stakingWrapper } of tokenRewards) {
-    tokenRewardsMap[stakingWrapper] = rewards;
-  }
-
-  return tokenRewardsMap;
 }
 
 export async function getPoolInfo(
@@ -312,4 +274,137 @@ export async function getPlatformFee(
     functionName: "platformFee",
     address: args.booster,
   });
+}
+
+//--------------------------------------------------------------------------------------------
+// CVX BOOSTER
+//--------------------------------------------------------------------------------------------
+
+// ABI from https://etherscan.io/address/0x3fe65692bfcd0e6cf84cb1e7d24108e434a7587e#code
+const cvxCrvRewards = [
+  {
+    inputs: [{ internalType: "address", name: "", type: "address" }],
+    name: "rewards",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "extraRewardsLength",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    name: "extraRewards",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+export async function getRewards(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    cvxCrvRewards: Address;
+    user: Address;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: cvxCrvRewards,
+    functionName: "rewards",
+    address: args.cvxCrvRewards,
+    args: [args.user],
+  });
+}
+
+export async function getExtraRewardsLength(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    cvxCrvRewards: Address;
+    user: Address;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: cvxCrvRewards,
+    functionName: "extraRewardsLength",
+    address: args.cvxCrvRewards,
+  });
+}
+
+export async function getExtraRewards(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    cvxCrvRewards: Address;
+    id: bigint;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: cvxCrvRewards,
+    functionName: "extraRewards",
+    address: args.cvxCrvRewards,
+    args: [args.id],
+  });
+}
+
+//--------------------------------------------------------------------------------------------
+// STAKING WRAPPER
+//--------------------------------------------------------------------------------------------
+
+export async function getEstimateRewards(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    stakingWrapper: Address;
+    beneficiary: Address;
+  }>,
+) {
+  const {
+    result: [rewardTokens, claimedAmounts],
+  } = await Viem.simulateContract(client, args, {
+    abi: Abis.IConvexCurveLpStakingWrapperLib,
+    functionName: "claimRewardsFor",
+    address: args.stakingWrapper,
+    args: [args.beneficiary],
+  });
+
+  const tokenRewards: Record<Address, bigint> = {};
+  for (let i = 0; i < rewardTokens.length; i++) {
+    const rewardToken = rewardTokens[i];
+    const claimedAmount = claimedAmounts[i];
+    Assertion.invariant(rewardToken !== undefined, "Expected reward token to be defined.");
+    Assertion.invariant(claimedAmount !== undefined, "Expected claimed amount to be defined.");
+
+    tokenRewards[rewardToken] = claimedAmount;
+  }
+
+  return tokenRewards;
+}
+
+export async function getAllEstimateRewards(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    stakingWrappers: Address[];
+    beneficiary: Address;
+  }>,
+) {
+  const tokenRewards = await Promise.all(
+    args.stakingWrappers.map(async (stakingWrapper) => {
+      const rewards = await getEstimateRewards(client, {
+        ...args,
+        stakingWrapper,
+      });
+
+      return { rewards, stakingWrapper };
+    }),
+  );
+
+  const tokenRewardsMap: Record<Address, Record<`0x${string}`, bigint> | undefined> = {};
+
+  for (const { rewards, stakingWrapper } of tokenRewards) {
+    tokenRewardsMap[stakingWrapper] = rewards;
+  }
+
+  return tokenRewardsMap;
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding new functions and updating ABIs for Convex integration in the SDK.

### Detailed summary
- Added `convertCrvToCvx` function in `Convex.ts` to convert CRV to CVX.
- Added `getVoteLockedBalances`, `getClaimableRewards`, and `getUserLocks` functions in `Convex.ts` to retrieve locked balances, claimable rewards, and user locks.
- Added `getPoolInfo`, `getLockIncentive`, `getStakerIncentive`, `getEarmarkIncentive`, and `getPlatformFee` functions in `Convex.ts` to retrieve pool information and incentives.
- Added `getRewards`, `getExtraRewardsLength`, and `getExtraRewards` functions in `Convex.ts` to retrieve CVX rewards.
- Updated `boosterAbi` and `cvxCrvRewards` ABIs in `Convex.ts`.

> The following files were skipped due to too many changes: `packages/sdk/src/internal/External/Convex.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->