### PR TITLE
feat: external calls for curve gauge

### DIFF
--- a/.changeset/young-garlics-retire.md
+++ b/.changeset/young-garlics-retire.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+External calls for curve gauge

--- a/packages/sdk/src/internal/External/Curve.ts
+++ b/packages/sdk/src/internal/External/Curve.ts
@@ -9,6 +9,10 @@ import {
   parseUnits,
 } from "viem";
 
+//--------------------------------------------------------------------------------------------
+// CURVE REGISTRY
+//--------------------------------------------------------------------------------------------
+
 const CURVE_REGISTRY = "0x0000000022d53366457f9d5e68ec105046fc4383" as const;
 
 const curveRegistryAbi = {
@@ -156,6 +160,10 @@ export async function getExpectedGaugeTokens(
   return result;
 }
 
+//--------------------------------------------------------------------------------------------
+// CURVE POOL
+//--------------------------------------------------------------------------------------------
+
 const curvePoolAbi = [
   {
     stateMutability: "view",
@@ -288,4 +296,25 @@ export async function getExpectedWithdrawalTokens(
   });
 
   return { expectedTokens, singleTokenAllowed };
+}
+
+//--------------------------------------------------------------------------------------------
+// GAUGE
+//--------------------------------------------------------------------------------------------
+
+export async function getClaimableTokens(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    curveGauge: Address;
+    user: Address;
+  }>,
+) {
+  const { result } = await Viem.simulateContract(client, args, {
+    abi: parseAbi(["function claimable_tokens(address addr) nonpayable returns (uint256)"]),
+    functionName: "claimable_tokens",
+    address: args.curveGauge,
+    args: [args.user],
+  });
+
+  return result;
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- This PR focuses on adding external calls for curve gauge in the `Curve.ts` file.
- It introduces the `CURVE_REGISTRY` constant and its ABI.
- It adds the `getExpectedGaugeTokens` function to retrieve expected gauge tokens.
- It adds the `curvePoolAbi` constant for Curve pool.
- It adds the `getExpectedWithdrawalTokens` function to retrieve expected withdrawal tokens.
- It introduces the `getClaimableTokens` function to retrieve claimable tokens for a curve gauge and user.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->