### PR TITLE
fix: paraswap-route-encoding

### DIFF
--- a/.changeset/poor-baboons-shake.md
+++ b/.changeset/poor-baboons-shake.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Fix ParaSwapV5 route encoding

--- a/packages/sdk/src/internal/Extensions/IntegrationAdapters/ParaswapV5.ts
+++ b/packages/sdk/src/internal/Extensions/IntegrationAdapters/ParaswapV5.ts
@@ -43,12 +43,12 @@ const takeOrderEncoding = [
 const routeEncoding = {
   components: [
     {
-      name: "targetExchange",
-      type: "address",
-    },
-    {
       name: "index",
       type: "uint256",
+    },
+    {
+      name: "targetExchange",
+      type: "address",
     },
     {
       name: "percent",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing the route encoding in the ParaSwapV5 integration adapter. 

### Detailed summary
- Updated the order of components in the route encoding object.
- Added a new component for the target exchange address.
- Updated the order of the target exchange address component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->