### PR TITLE
feat: refactor external calls for Idle

### DIFF
--- a/.changeset/new-impalas-tell.md
+++ b/.changeset/new-impalas-tell.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Refactor Idle

--- a/packages/sdk/src/External.ts
+++ b/packages/sdk/src/External.ts
@@ -5,7 +5,7 @@ export * as CompoundV3 from "@enzymefinance/sdk/internal/External/CompoundV3";
 export * as Convex from "@enzymefinance/sdk/internal/External/Convex";
 export * as Curve from "@enzymefinance/sdk/internal/External/Curve";
 export * as DelegateVotes from "@enzymefinance/sdk/internal/External/DelegateVotes";
-export * as IdleV4 from "@enzymefinance/sdk/internal/External/IdleV4";
+export * as Idle from "@enzymefinance/sdk/internal/External/Idle";
 export * as Liquity from "@enzymefinance/sdk/internal/External/AaveV2";
 export * as Maple from "@enzymefinance/sdk/internal/External/Maple";
 export * as TheGraph from "@enzymefinance/sdk/internal/External/TheGraph";

--- a/packages/sdk/src/internal/External/Idle.ts
+++ b/packages/sdk/src/internal/External/Idle.ts
@@ -15,10 +15,12 @@ export async function getGovTokensAmounts(
     args: [args.tokensOwner],
   });
 
+  const govTokensAbi = parseAbi(["function govTokens(uint256) view returns (address)"]);
+
   const tokensAmounts = await Promise.all(
     amounts.map(async (amount, index) => {
       const token = await Viem.readContract(client, args, {
-        abi: parseAbi(["function govTokens(uint256) view returns (address)"]),
+        abi: govTokensAbi,
         functionName: "govTokens",
         address: args.pool,
         args: [BigInt(index)],

--- a/packages/sdk/src/internal/External/Idle.ts
+++ b/packages/sdk/src/internal/External/Idle.ts
@@ -1,26 +1,5 @@
 import { Viem } from "@enzymefinance/sdk/Utils";
-import { type Address, type PublicClient } from "viem";
-
-const getGovTokensAmountsAbi = [
-  {
-    constant: true,
-    inputs: [{ internalType: "address", name: "_usr", type: "address" }],
-    name: "getGovTokensAmounts",
-    outputs: [{ internalType: "uint256[]", name: "_amounts", type: "uint256[]" }],
-    payable: false,
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    constant: true,
-    inputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    name: "govTokens",
-    outputs: [{ internalType: "address", name: "", type: "address" }],
-    payable: false,
-    stateMutability: "view",
-    type: "function",
-  },
-] as const;
+import { type Address, type PublicClient, parseAbi } from "viem";
 
 export async function getGovTokensAmounts(
   client: PublicClient,
@@ -30,7 +9,7 @@ export async function getGovTokensAmounts(
   }>,
 ) {
   const amounts = await Viem.readContract(client, args, {
-    abi: getGovTokensAmountsAbi,
+    abi: parseAbi(["function getGovTokensAmounts(address _usr) view returns (uint256[] _amounts)"]),
     functionName: "getGovTokensAmounts",
     address: args.pool,
     args: [args.tokensOwner],
@@ -39,7 +18,7 @@ export async function getGovTokensAmounts(
   const tokensAmounts = await Promise.all(
     amounts.map(async (amount, index) => {
       const token = await Viem.readContract(client, args, {
-        abi: getGovTokensAmountsAbi,
+        abi: parseAbi(["function govTokens(uint256) view returns (address)"]),
         functionName: "govTokens",
         address: args.pool,
         args: [BigInt(index)],
@@ -60,14 +39,6 @@ export async function getGovTokensAmounts(
   return tokensAmountsMap;
 }
 
-const idleSpeedsAbi = {
-  inputs: [{ internalType: "address", name: "", type: "address" }],
-  name: "idleSpeeds",
-  outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-  stateMutability: "view",
-  type: "function",
-} as const;
-
 export function getSpeeds(
   client: PublicClient,
   args: Viem.ContractCallParameters<{
@@ -76,7 +47,7 @@ export function getSpeeds(
   }>,
 ) {
   return Viem.readContract(client, args, {
-    abi: [idleSpeedsAbi],
+    abi: parseAbi(["function idleSpeeds(address) view returns (uint256)"]),
     functionName: "idleSpeeds",
     address: args.idleController,
     args: [args.idlePool],


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
Refactoring the `IdleV4` module in the `@enzymefinance/sdk` package.

### Detailed summary:
- Renamed `IdleV4.ts` file to `Idle.ts`.
- Updated imports and exports in `External.ts` to reflect the renaming.
- Removed unused code related to `getGovTokensAmountsAbi` and `idleSpeedsAbi`.
- Updated the `getGovTokensAmounts` function to use dynamically generated ABI.
- Updated the `getSpeeds` function to use dynamically generated ABI.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->