### PR TITLE
feat: add aave v3 external utils

### DIFF
--- a/.changeset/giant-jokes-obey.md
+++ b/.changeset/giant-jokes-obey.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Add aave v3 external utils

--- a/packages/sdk/src/External.ts
+++ b/packages/sdk/src/External.ts
@@ -1,4 +1,5 @@
 export * as AaveV2 from "@enzymefinance/sdk/internal/External/AaveV2";
+export * as AaveV3 from "@enzymefinance/sdk/internal/External/AaveV3";
 export * as BalancerV2 from "@enzymefinance/sdk/internal/External/BalancerV2";
 export * as CompoundV2 from "@enzymefinance/sdk/internal/External/CompoundV2";
 export * as CompoundV3 from "@enzymefinance/sdk/internal/External/CompoundV3";
@@ -6,7 +7,7 @@ export * as Convex from "@enzymefinance/sdk/internal/External/Convex";
 export * as Curve from "@enzymefinance/sdk/internal/External/Curve";
 export * as DelegateVotes from "@enzymefinance/sdk/internal/External/DelegateVotes";
 export * as Idle from "@enzymefinance/sdk/internal/External/Idle";
-export * as Liquity from "@enzymefinance/sdk/internal/External/AaveV2";
+export * as Liquity from "@enzymefinance/sdk/internal/External/Liquity";
 export * as Maple from "@enzymefinance/sdk/internal/External/Maple";
 export * as TheGraph from "@enzymefinance/sdk/internal/External/TheGraph";
 export * as UniswapV2 from "@enzymefinance/sdk/internal/External/UniswapV2";

--- a/packages/sdk/src/internal/External/AaveV3.ts
+++ b/packages/sdk/src/internal/External/AaveV3.ts
@@ -51,13 +51,13 @@ export async function getEModeCategoryData(
   client: PublicClient,
   args: Viem.ContractCallParameters<{
     pool: Address;
-    catoegoryId: number;
+    categoryId: number;
   }>,
 ) {
   return Viem.readContract(client, args, {
     abi: poolAbi,
     functionName: "getEModeCategoryData",
     address: args.pool,
-    args: [args.catoegoryId],
+    args: [args.categoryId],
   });
 }

--- a/packages/sdk/src/internal/External/AaveV3.ts
+++ b/packages/sdk/src/internal/External/AaveV3.ts
@@ -1,0 +1,63 @@
+import { Viem } from "@enzymefinance/sdk/Utils";
+import { type Address, type PublicClient } from "viem";
+
+const poolAddressProviderAbi = [
+  {
+    inputs: [],
+    name: "getPool",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+const poolAbi = [
+  {
+    inputs: [{ internalType: "uint8", name: "id", type: "uint8" }],
+    name: "getEModeCategoryData",
+    outputs: [
+      {
+        components: [
+          { internalType: "uint16", name: "ltv", type: "uint16" },
+          { internalType: "uint16", name: "liquidationThreshold", type: "uint16" },
+          { internalType: "uint16", name: "liquidationBonus", type: "uint16" },
+          { internalType: "address", name: "priceSource", type: "address" },
+          { internalType: "string", name: "label", type: "string" },
+        ],
+        internalType: "struct DataTypes.EModeCategory",
+        name: "",
+        type: "tuple",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+export async function getPool(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    poolAddressProvider: Address;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: poolAddressProviderAbi,
+    functionName: "getPool",
+    address: args.poolAddressProvider,
+  });
+}
+
+export async function getEModeCategoryData(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    pool: Address;
+    catoegoryId: number;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: poolAbi,
+    functionName: "getEModeCategoryData",
+    address: args.pool,
+    args: [args.catoegoryId],
+  });
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding Aave v3 external utilities to the SDK.

### Detailed summary:
- Added Aave v3 external utils to the SDK.
- Exported AaveV3 from `@enzymefinance/sdk/internal/External/AaveV3`.
- Updated Liquity import in `External.ts` from `AaveV2` to `Liquity`.
- Added new module `AaveV3` in `External.ts`.
- Added new file `AaveV3.ts` in `internal/External` folder.
- Imported `Viem` from `@enzymefinance/sdk/Utils` in `AaveV3.ts`.
- Imported `Address` and `PublicClient` from `viem` in `AaveV3.ts`.
- Added `poolAddressProviderAbi` and `poolAbi` constants in `AaveV3.ts`.
- Added `getPool` and `getEModeCategoryData` functions in `AaveV3.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->