### PR TITLE
feat: add additional liquity external calls

### DIFF
--- a/.changeset/nine-rabbits-stare.md
+++ b/.changeset/nine-rabbits-stare.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Additional external calls for Liquity

--- a/packages/sdk/src/internal/External/Kiln.ts
+++ b/packages/sdk/src/internal/External/Kiln.ts
@@ -35,7 +35,6 @@ export async function getGlobalFee(
   client: PublicClient,
   args: Viem.ContractCallParameters<{
     kilnStaking: Address;
-    validatorPublicKey: Hex;
   }>,
 ) {
   return Viem.readContract(client, args, {

--- a/packages/sdk/src/internal/External/Liquity.ts
+++ b/packages/sdk/src/internal/External/Liquity.ts
@@ -218,7 +218,7 @@ const sortedTrovesAbi = [
   },
 ] as const;
 
-export function getSize(
+export function getSortedTrovesSize(
   client: PublicClient,
   args: Viem.ContractCallParameters<{
     sortedTroves: Address;

--- a/packages/sdk/src/internal/External/Liquity.ts
+++ b/packages/sdk/src/internal/External/Liquity.ts
@@ -1,45 +1,83 @@
 import { Viem } from "@enzymefinance/sdk/Utils";
 import { type Address, type PublicClient } from "viem";
 
-const troveManagerAbi = {
-  inputs: [
-    {
-      internalType: "address",
-      name: "",
-      type: "address",
-    },
-  ],
-  name: "Troves",
-  outputs: [
-    {
-      internalType: "uint256",
-      name: "debt",
-      type: "uint256",
-    },
-    {
-      internalType: "uint256",
-      name: "coll",
-      type: "uint256",
-    },
-    {
-      internalType: "uint256",
-      name: "stake",
-      type: "uint256",
-    },
-    {
-      internalType: "enum TroveManager.Status",
-      name: "status",
-      type: "uint8",
-    },
-    {
-      internalType: "uint128",
-      name: "arrayIndex",
-      type: "uint128",
-    },
-  ],
-  stateMutability: "view",
-  type: "function",
-} as const;
+//--------------------------------------------------------------------------------------------
+// TROVE MANAGER
+//--------------------------------------------------------------------------------------------
+
+const troveManagerAbi = [
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    name: "Troves",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "debt",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "coll",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "stake",
+        type: "uint256",
+      },
+      {
+        internalType: "enum TroveManager.Status",
+        name: "status",
+        type: "uint8",
+      },
+      {
+        internalType: "uint128",
+        name: "arrayIndex",
+        type: "uint128",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "LUSD_GAS_COMPENSATION",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_LUSDDebt",
+        type: "uint256",
+      },
+    ],
+    name: "getBorrowingFeeWithDecay",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
 
 type Trove = {
   debt: bigint;
@@ -52,14 +90,14 @@ type Trove = {
 export async function getTrove(
   client: PublicClient,
   args: Viem.ContractCallParameters<{
-    liquityTroveManager: Address;
+    troveManager: Address;
     debtPosition: Address;
   }>,
 ) {
   const [debt, collateral, stake, status, arrayIndex] = await Viem.readContract(client, args, {
-    abi: [troveManagerAbi],
+    abi: troveManagerAbi,
     functionName: "Troves",
-    address: args.liquityTroveManager,
+    address: args.troveManager,
     args: [args.debtPosition],
   });
 
@@ -75,7 +113,7 @@ export async function getTrove(
 export async function getTroves(
   client: PublicClient,
   args: Viem.ContractCallParameters<{
-    liquityTroveManager: Address;
+    troveManager: Address;
     debtPositions: [Address];
   }>,
 ) {
@@ -96,4 +134,179 @@ export async function getTroves(
   }
 
   return troveMap;
+}
+
+export async function getLusdGasCompensation(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    troveManager: Address;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: troveManagerAbi,
+    functionName: "LUSD_GAS_COMPENSATION",
+    address: args.troveManager,
+  });
+}
+
+export async function getBorrowingFeeWithDecay(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    troveManager: Address;
+    lusdAmount: bigint;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: troveManagerAbi,
+    functionName: "getBorrowingFeeWithDecay",
+    address: args.troveManager,
+    args: [args.lusdAmount],
+  });
+}
+
+//--------------------------------------------------------------------------------------------
+// SORTED TROVES
+//--------------------------------------------------------------------------------------------
+
+const sortedTrovesAbi = [
+  {
+    inputs: [],
+    name: "getSize",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_NICR",
+        type: "uint256",
+      },
+      {
+        internalType: "address",
+        name: "_prevId",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "_nextId",
+        type: "address",
+      },
+    ],
+    name: "findInsertPosition",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+export async function getSize(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    sortedTroves: Address;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: sortedTrovesAbi,
+    functionName: "getSize",
+    address: args.sortedTroves,
+  });
+}
+
+export async function findInsertPosition(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    sortedTroves: Address;
+    nicr: bigint;
+    prevId: Address;
+    nextId: Address;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: sortedTrovesAbi,
+    functionName: "findInsertPosition",
+    address: args.sortedTroves,
+    args: [args.nicr, args.prevId, args.nextId],
+  });
+}
+
+//--------------------------------------------------------------------------------------------
+// HINT HELPERS
+//--------------------------------------------------------------------------------------------
+
+const hintHelpersAbi = [
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_CR",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "_numTrials",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "_inputRandomSeed",
+        type: "uint256",
+      },
+    ],
+    name: "getApproxHint",
+    outputs: [
+      {
+        internalType: "address",
+        name: "hintAddress",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "diff",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "latestRandomSeed",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+export async function getApproxHint(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    hintHelpers: Address;
+    nicr: bigint;
+    numTrials: bigint;
+    inputRandomSeed: bigint;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: hintHelpersAbi,
+    functionName: "getApproxHint",
+    address: args.hintHelpers,
+    args: [args.nicr, args.numTrials, args.inputRandomSeed],
+  });
 }

--- a/packages/sdk/src/internal/External/Liquity.ts
+++ b/packages/sdk/src/internal/External/Liquity.ts
@@ -218,7 +218,7 @@ const sortedTrovesAbi = [
   },
 ] as const;
 
-export async function getSize(
+export function getSize(
   client: PublicClient,
   args: Viem.ContractCallParameters<{
     sortedTroves: Address;
@@ -240,12 +240,14 @@ export async function findInsertPosition(
     nextId: Address;
   }>,
 ) {
-  return Viem.readContract(client, args, {
+  const [upperHint, lowerHint] = await Viem.readContract(client, args, {
     abi: sortedTrovesAbi,
     functionName: "findInsertPosition",
     address: args.sortedTroves,
     args: [args.nicr, args.prevId, args.nextId],
   });
+
+  return { upperHint, lowerHint };
 }
 
 //--------------------------------------------------------------------------------------------
@@ -303,10 +305,12 @@ export async function getApproxHint(
     inputRandomSeed: bigint;
   }>,
 ) {
-  return Viem.readContract(client, args, {
+  const [hintAddress, diff, latestRandomSeed] = await Viem.readContract(client, args, {
     abi: hintHelpersAbi,
     functionName: "getApproxHint",
     address: args.hintHelpers,
     args: [args.nicr, args.numTrials, args.inputRandomSeed],
   });
+
+  return { hintAddress, diff, latestRandomSeed };
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added additional external calls for Liquity
- Updated the `troveManagerAbi` to include new functions and changed it from an object to an array
- Renamed the `liquityTroveManager` parameter to `troveManager` in the `getTrove` and `getTroves` functions
- Added new functions for sorted troves and hint helpers in the Liquity module

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->