### PR TITLE
feat: liquity external calls simplification

### DIFF
--- a/packages/sdk/src/internal/External/Liquity.ts
+++ b/packages/sdk/src/internal/External/Liquity.ts
@@ -79,14 +79,6 @@ const troveManagerAbi = [
   },
 ] as const;
 
-type Trove = {
-  debt: bigint;
-  collateral: bigint;
-  stake: bigint;
-  status: number;
-  arrayIndex: bigint;
-};
-
 export async function getTrove(
   client: PublicClient,
   args: Viem.ContractCallParameters<{
@@ -108,32 +100,6 @@ export async function getTrove(
     status,
     arrayIndex,
   };
-}
-
-export async function getTroves(
-  client: PublicClient,
-  args: Viem.ContractCallParameters<{
-    troveManager: Address;
-    debtPositions: [Address];
-  }>,
-) {
-  const troves = await Promise.all(
-    args.debtPositions.map(async (position) => {
-      const trove = await getTrove(client, {
-        ...args,
-        debtPosition: position,
-      });
-
-      return { position, trove };
-    }),
-  );
-
-  const troveMap: Record<Address, Trove> = {};
-  for (const { position, trove } of troves) {
-    troveMap[position] = trove;
-  }
-
-  return troveMap;
 }
 
 export async function getLusdGasCompensation(


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- The `getTroves` function has been removed from `Liquity.ts` file.
- The `Trove` type has been removed from `Liquity.ts` file.
- The `getTrove` function has been modified in `Liquity.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->