### PR TITLE
feat: add additional external calls for The Graph

### DIFF
--- a/.changeset/dirty-cobras-rush.md
+++ b/.changeset/dirty-cobras-rush.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Additional external calls for The Graph

--- a/packages/sdk/src/internal/External/TheGraph.ts
+++ b/packages/sdk/src/internal/External/TheGraph.ts
@@ -1,20 +1,5 @@
 import { Viem } from "@enzymefinance/sdk/Utils";
-import { type Address, type PublicClient } from "viem";
-
-const delegationPoolsAbi = {
-  inputs: [{ internalType: "address", name: "", type: "address" }],
-  name: "delegationPools",
-  outputs: [
-    { internalType: "uint32", name: "cooldownBlocks", type: "uint32" },
-    { internalType: "uint32", name: "indexingRewardCut", type: "uint32" },
-    { internalType: "uint32", name: "queryFeeCut", type: "uint32" },
-    { internalType: "uint256", name: "updatedAtBlock", type: "uint256" },
-    { internalType: "uint256", name: "tokens", type: "uint256" },
-    { internalType: "uint256", name: "shares", type: "uint256" },
-  ],
-  stateMutability: "view",
-  type: "function",
-} as const;
+import { type Address, type PublicClient, parseAbi } from "viem";
 
 export async function getDelegationPool(
   client: PublicClient,
@@ -27,7 +12,9 @@ export async function getDelegationPool(
     client,
     args,
     {
-      abi: [delegationPoolsAbi],
+      abi: parseAbi([
+        "function delegationPools(address indexer) view returns (uint32 cooldownBlocks, uint32 indexingRewardCut, uint32 queryFeeCut, uint256 updatedAtBlock, uint256 tokens, uint256 shares)",
+      ]),
       functionName: "delegationPools",
       address: args.stakingContract,
       args: [args.indexer],
@@ -35,4 +22,30 @@ export async function getDelegationPool(
   );
 
   return { cooldownBlocks, indexingRewardCut, queryFeeCut, updatedAtBlock, tokens, shares };
+}
+
+export function getClaimableTokens(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    stakingContract: Address;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: parseAbi(["function delegationTaxPercentage() view returns (uint32)"]),
+    functionName: "delegationTaxPercentage",
+    address: args.stakingContract,
+  });
+}
+
+export function getCurrentEpoch(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    epochManager: Address;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: parseAbi(["function currentEpoch() view returns (uint256)"]),
+    functionName: "currentEpoch",
+    address: args.epochManager,
+  });
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding additional external calls for The Graph in the SDK.

### Detailed summary:
- Added `parseAbi` import from `viem`
- Updated `getDelegationPool` function to use parsed ABI for `delegationPools`
- Added `getClaimableTokens` function for reading contract data
- Added `getCurrentEpoch` function for reading contract data

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->