### PR TITLE
feat: add stakewise external functions

### DIFF
--- a/.changeset/many-buckets-study.md
+++ b/.changeset/many-buckets-study.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Add StakeWise sharesBalance and stakedEthBalance helpers

--- a/packages/sdk/src/External.ts
+++ b/packages/sdk/src/External.ts
@@ -12,6 +12,7 @@ export * as Liquity from "@enzymefinance/sdk/internal/External/Liquity";
 export * as Maker from "@enzymefinance/sdk/internal/External/Maker";
 export * as Maple from "@enzymefinance/sdk/internal/External/Maple";
 export * as Morpho from "@enzymefinance/sdk/internal/External/Morpho";
+export * as StakeWiseV3 from "@enzymefinance/sdk/internal/External/StakeWiseV3";
 export * as TheGraph from "@enzymefinance/sdk/internal/External/TheGraph";
 export * as UniswapV2 from "@enzymefinance/sdk/internal/External/UniswapV2";
 export * as UniswapV3 from "@enzymefinance/sdk/internal/External/UniswapV3";

--- a/packages/sdk/src/internal/External/StakeWiseV3.ts
+++ b/packages/sdk/src/internal/External/StakeWiseV3.ts
@@ -1,0 +1,36 @@
+import { Viem } from "@enzymefinance/sdk/Utils";
+import { type Address, type PublicClient, parseAbi } from "viem";
+
+export async function getSharesBalance(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    account: Address;
+    stakeWiseVaultAddress: Address;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: parseAbi(["function balanceOf(address _account) view returns (uint256 balance_)"]),
+    functionName: "balanceOf",
+    address: args.stakeWiseVaultAddress,
+    args: [args.account]
+  });
+}
+
+export async function getStakedEthBalance(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    account: Address;
+    stakeWiseVaultAddress: Address;
+  }>,
+) {
+  const sharesBalance = await getSharesBalance(client, args);
+
+  return Viem.readContract(client, args, {
+    abi: parseAbi(["function convertToAssets(uint256 _shares) view returns (uint256 assets_)"]),
+    functionName: "convertToAssets",
+    address: args.stakeWiseVaultAddress,
+    args: [sharesBalance]
+  });
+}
+
+

--- a/packages/sdk/src/internal/External/StakeWiseV3.ts
+++ b/packages/sdk/src/internal/External/StakeWiseV3.ts
@@ -12,7 +12,7 @@ export async function getSharesBalance(
     abi: parseAbi(["function balanceOf(address _account) view returns (uint256 balance_)"]),
     functionName: "balanceOf",
     address: args.stakeWiseVaultAddress,
-    args: [args.account]
+    args: [args.account],
   });
 }
 
@@ -29,8 +29,6 @@ export async function getStakedEthBalance(
     abi: parseAbi(["function convertToAssets(uint256 _shares) view returns (uint256 assets_)"]),
     functionName: "convertToAssets",
     address: args.stakeWiseVaultAddress,
-    args: [sharesBalance]
+    args: [sharesBalance],
   });
 }
-
-

--- a/packages/sdk/src/internal/External/StakeWiseV3.ts
+++ b/packages/sdk/src/internal/External/StakeWiseV3.ts
@@ -1,20 +1,6 @@
+import { getBalanceOf } from "@enzymefinance/sdk/Assets";
 import { Viem } from "@enzymefinance/sdk/Utils";
 import { type Address, type PublicClient, parseAbi } from "viem";
-
-export async function getSharesBalance(
-  client: PublicClient,
-  args: Viem.ContractCallParameters<{
-    account: Address;
-    stakeWiseVaultAddress: Address;
-  }>,
-) {
-  return Viem.readContract(client, args, {
-    abi: parseAbi(["function balanceOf(address _account) view returns (uint256 balance_)"]),
-    functionName: "balanceOf",
-    address: args.stakeWiseVaultAddress,
-    args: [args.account],
-  });
-}
 
 export async function getStakedEthBalance(
   client: PublicClient,
@@ -23,7 +9,7 @@ export async function getStakedEthBalance(
     stakeWiseVaultAddress: Address;
   }>,
 ) {
-  const sharesBalance = await getSharesBalance(client, args);
+  const sharesBalance = await getBalanceOf(client, { asset: args.stakeWiseVaultAddress, owner: args.account });
 
   return Viem.readContract(client, args, {
     abi: parseAbi(["function convertToAssets(uint256 _shares) view returns (uint256 assets_)"]),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding helpers for StakeWise sharesBalance and stakedEthBalance.

### Detailed summary:
- Added `StakeWiseV3` export in `External.ts`
- Added `getStakedEthBalance` function in `StakeWiseV3.ts`
- Imported `getBalanceOf` from `Assets` in `StakeWiseV3.ts`
- Imported `Viem` from `Utils` in `StakeWiseV3.ts`
- Imported `Address`, `PublicClient`, and `parseAbi` from `viem` in `StakeWiseV3.ts`
- Added `getStakedEthBalance` function to calculate staked ETH balance based on shares balance in `StakeWiseV3.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->