### PR TITLE
feat: add lido withdrawals exports

### DIFF
--- a/.changeset/wet-peaches-draw.md
+++ b/.changeset/wet-peaches-draw.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Add Lido Withdrawals exports

--- a/packages/sdk/src/External.ts
+++ b/packages/sdk/src/External.ts
@@ -8,6 +8,7 @@ export * as Curve from "@enzymefinance/sdk/internal/External/Curve";
 export * as DelegateVotes from "@enzymefinance/sdk/internal/External/DelegateVotes";
 export * as Idle from "@enzymefinance/sdk/internal/External/Idle";
 export * as Kiln from "@enzymefinance/sdk/internal/External/Kiln";
+export * as LidoWithdrawals from "@enzymefinance/sdk/internal/External/LidoWithdrawals";
 export * as Liquity from "@enzymefinance/sdk/internal/External/Liquity";
 export * as Maker from "@enzymefinance/sdk/internal/External/Maker";
 export * as Maple from "@enzymefinance/sdk/internal/External/Maple";

--- a/packages/sdk/src/internal/Extensions/ExternalPositions.ts
+++ b/packages/sdk/src/internal/Extensions/ExternalPositions.ts
@@ -8,6 +8,7 @@ export * as ArbitraryLoan from "@enzymefinance/sdk/internal/Extensions/ExternalP
 export * as CompoundV2Debt from "@enzymefinance/sdk/internal/Extensions/ExternalPositions/CompoundV2Debt";
 export * as ConvexVoting from "@enzymefinance/sdk/internal/Extensions/ExternalPositions/ConvexVoting";
 export * as Kiln from "@enzymefinance/sdk/internal/Extensions/ExternalPositions/Kiln";
+export * as LidoWithdrawals from "@enzymefinance/sdk/internal/Extensions/ExternalPositions/LidoWithdrawals";
 export * as Liquity from "@enzymefinance/sdk/internal/Extensions/ExternalPositions/Liquity";
 export * as MapleLiquidity from "@enzymefinance/sdk/internal/Extensions/ExternalPositions/MapleLiquidity";
 export * as StakeWise from "@enzymefinance/sdk/internal/Extensions/ExternalPositions/StakeWise";


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for Lido Withdrawals in the Enzyme Finance SDK.

### Detailed summary
- Added Lido Withdrawals exports in `External.ts` and `ExternalPositions.ts` files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->