### PR TITLE
fix: fix input scale for convertRateToScaledPerSecondRate()

### DIFF
--- a/.changeset/fuzzy-nails-peel.md
+++ b/.changeset/fuzzy-nails-peel.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Fix per second rate input

--- a/packages/sdk/src/internal/Extensions/Fees/Management.ts
+++ b/packages/sdk/src/internal/Extensions/Fees/Management.ts
@@ -48,25 +48,25 @@ export type EncodeSettingsParams = {
   recipient?: Address;
 } & (
   | {
-      perAnnumRateInBps?: never;
+      perAnnumRate?: never;
       scaledPerSecondRate: bigint;
     }
   | {
-      perAnnumRateInBps: bigint;
+      perAnnumRate: bigint;
       scaledPerSecondRate?: never;
     }
 );
 
 export function encodeSettings({
   scaledPerSecondRate,
-  perAnnumRateInBps,
+  perAnnumRate,
   recipient = zeroAddress,
 }: EncodeSettingsParams): Hex {
   const fee: bigint =
     scaledPerSecondRate !== undefined
       ? scaledPerSecondRate
       : Rates.convertRateToScaledPerSecondRate({
-          perAnnumRateInBps,
+          perAnnumRate,
           adjustInflation: true,
         });
 

--- a/packages/sdk/src/internal/Utils/rates.ts
+++ b/packages/sdk/src/internal/Utils/rates.ts
@@ -4,6 +4,9 @@ import { parseEther } from "viem";
 
 const LocalDecimal = Decimal.clone({ precision: 2 * 27 });
 
+const rateScale = 10n ** 18n;
+const rateScaleDecimal = new LocalDecimal(`${rateScale}`);
+
 const scaledPerSecondRateScale = 10n ** 27n;
 const scaledPerSecondRateScaleDecimal = new LocalDecimal(`${scaledPerSecondRateScale}`);
 
@@ -23,13 +26,13 @@ export function calculateAmountDueForScaledPerSecondRate({
 }
 
 export function convertRateToScaledPerSecondRate({
-  perAnnumRateInBps,
+  perAnnumRate,
   adjustInflation,
 }: {
-  perAnnumRateInBps: bigint;
+  perAnnumRate: bigint;
   adjustInflation: boolean;
 }) {
-  const rateDecimal = new LocalDecimal(`${perAnnumRateInBps}`).div(10000);
+  const rateDecimal = new LocalDecimal(`${perAnnumRate}`).div(rateScaleDecimal);
   const effectiveRate = adjustInflation ? rateDecimal.div(new LocalDecimal(1).minus(rateDecimal)) : rateDecimal;
   const scaledRate = new LocalDecimal(1)
     .plus(effectiveRate)

--- a/packages/sdk/test/tests/Utils/rates.test.ts
+++ b/packages/sdk/test/tests/Utils/rates.test.ts
@@ -53,14 +53,14 @@ test("convertScaledPerSecondRateToRate should work correctly", () => {
 test("convertRateToScaledPerSecondRate should work correctly", () => {
   expect(
     Rates.convertRateToScaledPerSecondRate({
-      perAnnumRateInBps: Conversion.toBps(0.123),
+      perAnnumRate: Conversion.toWei(0.123),
       adjustInflation: true,
     }),
   ).toMatchInlineSnapshot("1000000004159007240185733350n");
 
   expect(
     Rates.convertRateToScaledPerSecondRate({
-      perAnnumRateInBps: Conversion.toBps(0.123),
+      perAnnumRate: Conversion.toWei(0.123),
       adjustInflation: false,
     }),
   ).toMatchInlineSnapshot("1000000003675934670872217630n");


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
Fixing the per second rate input in the `@enzymefinance/sdk`.

### Detailed summary:
- Fixed the per second rate input in `Rates.convertRateToScaledPerSecondRate` function.
- Updated the parameter names `perAnnumRateInBps` to `perAnnumRate` in multiple files.
- Updated the logic in `encodeSettings` function to use `perAnnumRate` instead of `perAnnumRateInBps`.
- Added `rateScale` and `rateScaleDecimal` constants in `rates.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->