### PR TITLE
fix: multiply by slippage

### DIFF
--- a/.changeset/fresh-phones-bow.md
+++ b/.changeset/fresh-phones-bow.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Fix multiplyBySlippage

--- a/packages/sdk/src/internal/Utils/slippage.ts
+++ b/packages/sdk/src/internal/Utils/slippage.ts
@@ -1,7 +1,10 @@
-export function multiplyBySlippage({ amount, slippage }: { amount: bigint; slippage: number }) {
+export function multiplyBySlippage({ value, slippage }: { value: bigint; slippage?: number }) {
+  if (!slippage) {
+    return value;
+  }
   const slippageInBps = convertFromRatioToBps(slippage);
 
-  return applySlippage(amount, slippageInBps);
+  return applySlippage(value, slippageInBps);
 }
 
 export function applySlippage(value: bigint, slippageInBps: bigint) {

--- a/packages/sdk/src/internal/Utils/slippage.ts
+++ b/packages/sdk/src/internal/Utils/slippage.ts
@@ -1,7 +1,7 @@
-export function multiplyBySlippage({ amount, slippage }: { amount: bigint; slippage: bigint }) {
-  const slippageFactor = 100n;
+export function multiplyBySlippage({ amount, slippage }: { amount: bigint; slippage: number }) {
+  const slippageInBps = convertFromRatioToBps(slippage);
 
-  return (amount * (slippageFactor - slippage)) / slippageFactor;
+  return applySlippage(amount, slippageInBps);
 }
 
 export function applySlippage(value: bigint, slippageInBps: bigint) {

--- a/packages/sdk/test/tests/Utils/slippage.test.ts
+++ b/packages/sdk/test/tests/Utils/slippage.test.ts
@@ -4,14 +4,14 @@ import { expect, test } from "vitest";
 test("multiplyBySlippage should work correctly", () => {
   expect(
     Slippage.multiplyBySlippage({
-      amount: 250n,
+      value: 250n,
       slippage: 0.01,
     }),
   ).toMatchInlineSnapshot("248n");
 
   expect(
     Slippage.multiplyBySlippage({
-      amount: 2432n,
+      value: 2432n,
       slippage: 0.13,
     }),
   ).toMatchInlineSnapshot("2116n");

--- a/packages/sdk/test/tests/Utils/slippage.test.ts
+++ b/packages/sdk/test/tests/Utils/slippage.test.ts
@@ -5,16 +5,16 @@ test("multiplyBySlippage should work correctly", () => {
   expect(
     Slippage.multiplyBySlippage({
       amount: 250n,
-      slippage: 1n,
+      slippage: 0.01,
     }),
-  ).toMatchInlineSnapshot("247n");
+  ).toMatchInlineSnapshot("248n");
 
   expect(
     Slippage.multiplyBySlippage({
       amount: 2432n,
-      slippage: 13n,
+      slippage: 0.13,
     }),
-  ).toMatchInlineSnapshot("2115n");
+  ).toMatchInlineSnapshot("2116n");
 });
 
 test.each([


### PR DESCRIPTION
Fixes `multiplyBySlippage`, which would previously only allow whole percentage inputs. Now, the slippage parameter is a ratio (e.g. 0.012 corresponds to 1.2%).

This is also consistent with what is used in the frontend (for easy migration).

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
Fixing the `multiplyBySlippage` function in the `@enzymefinance/sdk` package.

### Detailed summary:
- Updated the `multiplyBySlippage` function to accept a `value` and `slippage` parameter.
- Added a check for the `slippage` parameter and return `value` if it is not provided.
- Converted the `slippage` parameter from a ratio to basis points (bps).
- Refactored the calculation in the `multiplyBySlippage` function to use the new `applySlippage` function.
- Added the `applySlippage` function to calculate the slippage-adjusted value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->