### PR TITLE
feat: add BalancerVault read function

### DIFF
--- a/.changeset/selfish-parrots-lick.md
+++ b/.changeset/selfish-parrots-lick.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Add BalancerVault read function

--- a/packages/sdk/src/internal/External/Curve.ts
+++ b/packages/sdk/src/internal/External/Curve.ts
@@ -205,7 +205,7 @@ export async function getExpectedWithdrawalTokens(
   let singleTokenAllowed = true;
   let expectedSingleToken;
 
-  // Some curve pools doesn't allow to withdraw single token.
+  // Some curve pools don't allow to withdraw single token.
   // We try to determine here which ones allows that.
   try {
     expectedSingleToken = await Viem.readContract(client, args, {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
Add BalancerVault read function

### Detailed summary:
- Add BalancerVault read function to the SDK
- Import necessary types and functions
- Define minterAbi, gaugeAbi, BalancerV2SwapKind, BalancerV2BatchSwapStep, FundManagement interfaces
- Implement getMinterRewards, getClaimableRewards, and queryBatchSwap functions for the BalancerV2 contract

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->