### PR TITLE
feat: accrued continuous fees

### DIFF
--- a/.changeset/sweet-horses-knock.md
+++ b/.changeset/sweet-horses-knock.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Add getAccruedContinuousFees


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
Addition of the `getAccruedContinuousFees` function to the SDK.

### Detailed summary:
- Added `getAccruedContinuousFees` function to `Fees.ts` in the SDK.
- Imported `isAddressEqual` from `viem`.
- Imported `getInfo` from `./internal/Extensions/Fees/Performance.js`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->