### PR TITLE
feat: add Uniswap v3 pool liquidity

### DIFF
--- a/.changeset/hungry-beds-sing.md
+++ b/.changeset/hungry-beds-sing.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Add Uniswap v3 pool liquidity

--- a/packages/sdk/src/internal/External/UniswapV3.ts
+++ b/packages/sdk/src/internal/External/UniswapV3.ts
@@ -10,13 +10,41 @@ const v3PoolAbi = [
     inputs: [],
     name: "slot0",
     outputs: [
-      { internalType: "uint160", name: "sqrtPriceX96", type: "uint160" },
-      { internalType: "int24", name: "tick", type: "int24" },
-      { internalType: "uint16", name: "observationIndex", type: "uint16" },
-      { internalType: "uint16", name: "observationCardinality", type: "uint16" },
-      { internalType: "uint16", name: "observationCardinalityNext", type: "uint16" },
-      { internalType: "uint8", name: "feeProtocol", type: "uint8" },
-      { internalType: "bool", name: "unlocked", type: "bool" },
+      {
+        internalType: "uint160",
+        name: "sqrtPriceX96",
+        type: "uint160",
+      },
+      {
+        internalType: "int24",
+        name: "tick",
+        type: "int24",
+      },
+      {
+        internalType: "uint16",
+        name: "observationIndex",
+        type: "uint16",
+      },
+      {
+        internalType: "uint16",
+        name: "observationCardinality",
+        type: "uint16",
+      },
+      {
+        internalType: "uint16",
+        name: "observationCardinalityNext",
+        type: "uint16",
+      },
+      {
+        internalType: "uint8",
+        name: "feeProtocol",
+        type: "uint8",
+      },
+      {
+        internalType: "bool",
+        name: "unlocked",
+        type: "bool",
+      },
     ],
     stateMutability: "view",
     type: "function",

--- a/packages/sdk/src/internal/External/UniswapV3.ts
+++ b/packages/sdk/src/internal/External/UniswapV3.ts
@@ -10,42 +10,21 @@ const v3PoolAbi = [
     inputs: [],
     name: "slot0",
     outputs: [
-      {
-        internalType: "uint160",
-        name: "sqrtPriceX96",
-        type: "uint160",
-      },
-      {
-        internalType: "int24",
-        name: "tick",
-        type: "int24",
-      },
-      {
-        internalType: "uint16",
-        name: "observationIndex",
-        type: "uint16",
-      },
-      {
-        internalType: "uint16",
-        name: "observationCardinality",
-        type: "uint16",
-      },
-      {
-        internalType: "uint16",
-        name: "observationCardinalityNext",
-        type: "uint16",
-      },
-      {
-        internalType: "uint8",
-        name: "feeProtocol",
-        type: "uint8",
-      },
-      {
-        internalType: "bool",
-        name: "unlocked",
-        type: "bool",
-      },
+      { internalType: "uint160", name: "sqrtPriceX96", type: "uint160" },
+      { internalType: "int24", name: "tick", type: "int24" },
+      { internalType: "uint16", name: "observationIndex", type: "uint16" },
+      { internalType: "uint16", name: "observationCardinality", type: "uint16" },
+      { internalType: "uint16", name: "observationCardinalityNext", type: "uint16" },
+      { internalType: "uint8", name: "feeProtocol", type: "uint8" },
+      { internalType: "bool", name: "unlocked", type: "bool" },
     ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "liquidity",
+    outputs: [{ internalType: "uint128", name: "", type: "uint128" }],
     stateMutability: "view",
     type: "function",
   },
@@ -80,6 +59,19 @@ export async function getSlot0(
     feeProtocol,
     unlocked,
   };
+}
+
+export function getLiquidity(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    pool: Address;
+  }>,
+) {
+  return Viem.readContract(client, args, {
+    abi: v3PoolAbi,
+    functionName: "liquidity",
+    address: args.pool,
+  });
 }
 
 //--------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
Add Uniswap v3 pool liquidity

### Detailed summary:
- Added a new function `getLiquidity` in the `UniswapV3.ts` file.
- The `getLiquidity` function retrieves the liquidity of a Uniswap v3 pool.
- The function takes a `client` and `args` as inputs and returns the liquidity value.
- The `args` parameter includes the `pool` address.
- The function uses the `Viem.readContract` method to read the contract and retrieve the liquidity value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->