### PR TITLE
feat: add arrakis v2 burn helper

### DIFF
--- a/.changeset/chilly-dingos-attack.md
+++ b/.changeset/chilly-dingos-attack.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Add arrakis v2 burn helper

--- a/packages/sdk/src/internal/External/ArrakisV2.ts
+++ b/packages/sdk/src/internal/External/ArrakisV2.ts
@@ -74,3 +74,42 @@ export async function totalUnderlying(
     amount1,
   };
 }
+
+const vaultAbi = [
+  {
+    inputs: [
+      { internalType: "uint256", name: "burnAmount_", type: "uint256" },
+      { internalType: "address", name: "receiver_", type: "address" },
+    ],
+    name: "burn",
+    outputs: [
+      { internalType: "uint256", name: "amount0", type: "uint256" },
+      { internalType: "uint256", name: "amount1", type: "uint256" },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+] as const;
+
+export async function burn(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    arrakisVault: Address;
+    receiver: Address;
+    burnAmount: bigint;
+  }>,
+) {
+  const {
+    result: [amount0, amount1],
+  } = await Viem.simulateContract(client, args, {
+    abi: vaultAbi,
+    functionName: "burn",
+    address: args.arrakisVault,
+    args: [args.burnAmount, args.receiver],
+  });
+
+  return {
+    amount0,
+    amount1,
+  };
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new helper function `burn()` to the `ArrakisV2` module in the `@enzymefinance/sdk` package. It allows for burning tokens in the ArrakisV2 vault and returns the amounts burned. 

### Detailed summary
- Added `burn()` function to `ArrakisV2.ts` module
- Function takes `client` and `args` parameters
- Uses `Viem.simulateContract()` to simulate the burn transaction
- Returns the amounts burned

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->