### PR TITLE
fix: address list encoding

### DIFF
--- a/.changeset/thick-months-bathe.md
+++ b/.changeset/thick-months-bathe.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Fix address list encoding

--- a/packages/sdk/src/Configuration/Policies/utils/AddressListRegistryPolicies.ts
+++ b/packages/sdk/src/Configuration/Policies/utils/AddressListRegistryPolicies.ts
@@ -2,7 +2,7 @@ import { type Address, type Hex, decodeAbiParameters, encodeAbiParameters } from
 
 const settingsEncoding = [
   {
-    type: "address[]",
+    type: "uint256[]",
     name: "existingListIds",
   },
   {
@@ -23,7 +23,7 @@ const newAddressListArgsEncoding = [
 ] as const;
 
 export interface AddressListRegistryPolicySettings {
-  existingListIds: ReadonlyArray<Address>;
+  existingListIds: ReadonlyArray<bigint>;
   newListsArgs: ReadonlyArray<{
     updateType: bigint;
     initialItems: ReadonlyArray<Address>;

--- a/packages/sdk/src/Configuration/Policies/utils/UintListRegistryPolicies.ts
+++ b/packages/sdk/src/Configuration/Policies/utils/UintListRegistryPolicies.ts
@@ -1,8 +1,8 @@
-import { type Address, type Hex, decodeAbiParameters, encodeAbiParameters } from "viem";
+import { type Hex, decodeAbiParameters, encodeAbiParameters } from "viem";
 
 const settingsEncoding = [
   {
-    type: "address[]",
+    type: "uint256[]",
     name: "existingListIds",
   },
   {
@@ -23,7 +23,7 @@ const newUintListArgsEncoding = [
 ] as const;
 
 export interface UintListRegistryPolicySettings {
-  existingListIds: ReadonlyArray<Address>;
+  existingListIds: ReadonlyArray<bigint>;
   newListsArgs: ReadonlyArray<{
     updateType: bigint;
     initialItems: ReadonlyArray<bigint>;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
Fixing address list encoding in the `AddressListRegistryPolicies` and `UintListRegistryPolicies` files.

### Detailed summary:
- Changed the `existingListIds` type from `ReadonlyArray<Address>` to `ReadonlyArray<bigint>` in `AddressListRegistryPolicies.ts` and `UintListRegistryPolicies.ts` files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->