### PR TITLE
fix: shares wrapper factory

### DIFF
--- a/.changeset/grumpy-dragons-sip.md
+++ b/.changeset/grumpy-dragons-sip.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Fix shares wrapper factory

--- a/packages/sdk/src/Tools/SharesWrapperFactory.ts
+++ b/packages/sdk/src/Tools/SharesWrapperFactory.ts
@@ -8,9 +8,9 @@ export const DepositMode = {
   Request: 1,
 } as const;
 
-export function setUseDepositApprovals(
+export function deploy(
   args: Viem.ContractCallParameters<{
-    sharesWrapper: Address;
+    sharesWrapperFactory: Address;
     vaultProxy: Address;
     managers: Address[];
     redemptionAsset: Address;
@@ -29,7 +29,7 @@ export function setUseDepositApprovals(
   return new Viem.PopulatedTransaction({
     abi: Abis.IGatedRedemptionQueueSharesWrapperFactory,
     functionName: "deploy",
-    address: args.sharesWrapper,
+    address: args.sharesWrapperFactory,
     args: [
       args.vaultProxy,
       args.managers,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- The focus of this PR is to fix the shares wrapper factory.
- The `setUseDepositApprovals` function has been renamed to `deploy`.
- The `sharesWrapper` parameter has been renamed to `sharesWrapperFactory`.
- The `address` argument in the `Viem.PopulatedTransaction` has been updated accordingly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->