### PR TITLE
feat: remaining functions for shares wrapper

### DIFF
--- a/.changeset/lemon-planes-roll.md
+++ b/.changeset/lemon-planes-roll.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Remaining functions for Shares Wrapper

--- a/packages/sdk/src/Tools/GatedRedemptionQueueSharesWrapper.ts
+++ b/packages/sdk/src/Tools/GatedRedemptionQueueSharesWrapper.ts
@@ -12,6 +12,13 @@ export const DepositMode = {
   Request: 1,
 } as const;
 
+export type RedemptionWindowConfig = {
+  firstWindowStart: bigint;
+  duration: number;
+  frequency: number;
+  relativeSharesCap: bigint;
+};
+
 export function deploy(args: {
   sharesWrapperFactory: Address;
   vaultProxy: Address;
@@ -21,12 +28,7 @@ export function deploy(args: {
   useRedemptionApproval: boolean;
   useTransferApproval: boolean;
   depositMode: DepositMode;
-  windowConfig: {
-    firstWindowStart: bigint;
-    duration: number;
-    frequency: number;
-    relativeSharesCap: bigint;
-  };
+  windowConfig: RedemptionWindowConfig;
 }) {
   return new Viem.PopulatedTransaction({
     abi: Abis.IGatedRedemptionQueueSharesWrapperFactory,
@@ -206,6 +208,42 @@ export function redeemFromQueue(args: {
     functionName: "redeemFromQueue",
     address: args.sharesWrapper,
     args: [args.startIndex, args.lastIndex],
+  });
+}
+
+export function setDepositMode(args: {
+  sharesWrapper: Address;
+  depositMode: DepositMode;
+}) {
+  return new Viem.PopulatedTransaction({
+    abi: Abis.IGatedRedemptionQueueSharesWrapperLib,
+    functionName: "setDepositMode",
+    address: args.sharesWrapper,
+    args: [args.depositMode],
+  });
+}
+
+export function setRedemptionWindowConfig(args: {
+  sharesWrapper: Address;
+  windowConfig: RedemptionWindowConfig;
+}) {
+  return new Viem.PopulatedTransaction({
+    abi: Abis.IGatedRedemptionQueueSharesWrapperLib,
+    functionName: "setRedemptionWindowConfig",
+    address: args.sharesWrapper,
+    args: [args.windowConfig],
+  });
+}
+
+export function setRedemptionAsset(args: {
+  sharesWrapper: Address;
+  asset: Address;
+}) {
+  return new Viem.PopulatedTransaction({
+    abi: Abis.IGatedRedemptionQueueSharesWrapperLib,
+    functionName: "setRedemptionAsset",
+    address: args.sharesWrapper,
+    args: [args.asset],
   });
 }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added `RedemptionWindowConfig` type for configuring redemption windows
- Added `setDepositMode` function to set the deposit mode for the shares wrapper
- Added `setRedemptionWindowConfig` function to set the redemption window configuration for the shares wrapper
- Added `setRedemptionAsset` function to set the redemption asset for the shares wrapper

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->