### PR TITLE
chore: change ep make use type

### DIFF
--- a/.changeset/rich-meals-rule.md
+++ b/.changeset/rich-meals-rule.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Change ep make use type

--- a/packages/sdk/src/_internal/ExternalPositionManager.ts
+++ b/packages/sdk/src/_internal/ExternalPositionManager.ts
@@ -29,7 +29,7 @@ export type UseParams<TArgs> = {
   callArgs: TArgs;
 };
 
-export function makeUse(action: bigint): (args: UseParams<never>) => PopulatedExtensionCall;
+export function makeUse(action: bigint): (args: Omit<UseParams<never>, "callArgs">) => PopulatedExtensionCall;
 export function makeUse<TArgs>(
   action: bigint,
   encoder: (args: TArgs) => Hex,


### PR DESCRIPTION
Change make use type so we don't have to pass `callArgs` with `never` type when action has no call args

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- This PR updates the `makeUse` function in `ExternalPositionManager.ts` to use `Omit<UseParams<never>, "callArgs">` instead of `UseParams<never>`.
- The change is made to improve the type safety and correctness of the function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->