### PR TITLE
chore: update redeemDecode naming

### DIFF
--- a/.changeset/yellow-keys-ring.md
+++ b/.changeset/yellow-keys-ring.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Adjust naming of redeemDecode

--- a/packages/sdk/src/Portfolio/Integrations/StakeWiseV3.ts
+++ b/packages/sdk/src/Portfolio/Integrations/StakeWiseV3.ts
@@ -74,7 +74,7 @@ export function redeemEncode(args: RedeemArgs): Hex {
   return encodeAbiParameters(redeemEncoding, [args.stakeWiseVault, args.sharesAmount]);
 }
 
-export function claimFeesDecode(encoded: Hex): RedeemArgs {
+export function redeemDecode(encoded: Hex): RedeemArgs {
   const [stakeWiseVault, sharesAmount] = decodeAbiParameters(redeemEncoding, encoded);
 
   return {

--- a/packages/sdk/src/Portfolio/Integrations/StakeWiseV3.ts
+++ b/packages/sdk/src/Portfolio/Integrations/StakeWiseV3.ts
@@ -22,7 +22,7 @@ export const createAndStake = ExternalPositionManager.makeCreateAndUse(Action.St
 const stakeEncoding = [
   {
     type: "address",
-    name: "stakeWiseVaultAddress",
+    name: "stakeWiseVault",
   },
   {
     name: "assetAmount",
@@ -57,7 +57,7 @@ export const redeem = ExternalPositionManager.makeUse(Action.Redeem, redeemEncod
 const redeemEncoding = [
   {
     type: "address",
-    name: "stakeWiseVaultAddress",
+    name: "stakeWiseVault",
   },
   {
     name: "shareAmount",
@@ -92,7 +92,7 @@ export const enterExitQueue = ExternalPositionManager.makeUse(Action.EnterExitQu
 const enterExitQueueEncoding = [
   {
     type: "address",
-    name: "stakeWiseVaultAddress",
+    name: "stakeWiseVault",
   },
   {
     name: "sharesAmount",
@@ -127,7 +127,7 @@ export const claimExitedAssets = ExternalPositionManager.makeUse(Action.ClaimExi
 const claimExitedAssetsEncoding = [
   {
     type: "address",
-    name: "stakeWiseVaultAddress",
+    name: "stakeWiseVault",
   },
   {
     name: "positionTicket",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
Adjust naming of `redeemDecode` function in the `StakeWiseV3` integration file.

### Detailed summary:
- Renamed the `redeemDecode` function to `redeemDecode` in the `StakeWiseV3` integration file.
- Adjusted the naming of the `stakeWiseVaultAddress` parameter to `stakeWiseVault` in multiple places in the `StakeWiseV3` integration file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->