### PR TITLE
fix: zero address encoding

### DIFF
--- a/.changeset/itchy-masks-design.md
+++ b/.changeset/itchy-masks-design.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Fix zeroAddress encoding in ExternalPositionManager

--- a/packages/sdk/src/_internal/ExternalPositionManager.ts
+++ b/packages/sdk/src/_internal/ExternalPositionManager.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, decodeAbiParameters, encodeAbiParameters } from "viem";
+import { type Address, type Hex, decodeAbiParameters, encodeAbiParameters, zeroAddress } from "viem";
 import type { Types } from "../Utils.js";
 import { type PopulatedExtensionCall, callExtension } from "./Extensions.js";
 
@@ -86,7 +86,7 @@ export function makeCreateAndUse<TArgs>(action: bigint, encoder?: (args: TArgs) 
       callArgs: callEncode({
         actionId: action,
         actionArgs: encoded,
-        externalPositionProxy: "0x",
+        externalPositionProxy: zeroAddress,
       }),
     });
   };


### PR DESCRIPTION
This PR fixes an issue where the `0x` string would error when encoded as an address (probably differs from ethers behavior that I assume encoded it as the zeroAddress)

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on fixing the encoding of the zeroAddress in the ExternalPositionManager.

### Detailed summary:
- Import `zeroAddress` from "viem" library.
- Update the `externalPositionProxy` value to `zeroAddress` in the `makeCreateAndUse` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->