### PR TITLE
fix: curve redeem type check

### DIFF
--- a/.changeset/cuddly-bobcats-cry.md
+++ b/.changeset/cuddly-bobcats-cry.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Fix curve redeem type check

--- a/packages/sdk/src/Portfolio/Integrations/BalancerV2.ts
+++ b/packages/sdk/src/Portfolio/Integrations/BalancerV2.ts
@@ -310,9 +310,7 @@ export function isValidSwapKind(kind: number): kind is SwapKind {
 export function takeOrderDecode(encoded: Hex): TakeOrderArgs {
   const [kind, swaps, assets, limits, stakingTokens] = decodeAbiParameters(takeOrderEncoding, encoded);
 
-  if (!isValidSwapKind(kind)) {
-    Assertion.invariant(false, "Invalid swap kind");
-  }
+  Assertion.invariant(isValidSwapKind(kind), `Invalid swap kind ${kind}`);
 
   return { kind, swaps, assets, limits, stakingTokens };
 }

--- a/packages/sdk/src/Portfolio/Integrations/Curve.ts
+++ b/packages/sdk/src/Portfolio/Integrations/Curve.ts
@@ -266,7 +266,7 @@ export function redeemEncode(args: RedeemArgs): Hex {
 }
 
 export function isValidRedeemType(value: number): value is RedeemType {
-  return !Object.values(RedeemType).includes(value as RedeemType);
+  return Object.values(RedeemType).includes(value as RedeemType);
 }
 
 export function redeemDecode(encoded: Hex): RedeemArgs {
@@ -527,7 +527,7 @@ export function unstakeAndRedeemDecode(encoded: Hex): UnstakeAndRedeemArgs {
   const [pool, outgoingStakingToken, outgoingStakingTokenAmount, useUnderlyings, redeemType, incomingAssetsData] =
     decodeAbiParameters(unstakeAndRedeemEncoding, encoded);
 
-  Assertion.invariant(isValidRedeemType(redeemType), "Invalid redeem type");
+  Assertion.invariant(isValidRedeemType(redeemType), `Invalid redeem type ${redeemType}`);
 
   switch (redeemType) {
     case RedeemType.Standard: {

--- a/packages/sdk/src/Portfolio/Integrations/Kiln.ts
+++ b/packages/sdk/src/Portfolio/Integrations/Kiln.ts
@@ -96,9 +96,7 @@ export function isValidClaimType(value: number): value is ClaimType {
 export function claimFeesDecode(encoded: Hex): ClaimFeesArgs {
   const [stakingContract, publicKeys, claimFeeType] = decodeAbiParameters(claimFeesEncoding, encoded);
 
-  if (!isValidClaimType(claimFeeType)) {
-    Assertion.invariant(false, "Invalid claim fee type");
-  }
+  Assertion.invariant(isValidClaimType(claimFeeType), `Invalid claim fee type ${claimFeeType}`);
 
   return {
     stakingContract,

--- a/packages/sdk/src/Portfolio/Integrations/ZeroExV4.ts
+++ b/packages/sdk/src/Portfolio/Integrations/ZeroExV4.ts
@@ -299,9 +299,7 @@ export function isValidSignatureType(value: number): value is SignatureType {
 export function takeOrderDecode(encoded: Hex): TakeOrderArgs {
   const [encodedZeroExOrderArgs, takerAssetFillAmount, orderType] = decodeAbiParameters(takeOrderEncoding, encoded);
 
-  if (!isValidOrderType(orderType)) {
-    Assertion.invariant(false, "Invalid order type");
-  }
+  Assertion.invariant(isValidOrderType(orderType), `Invalid order type ${orderType}`);
 
   switch (orderType) {
     case OrderType.Limit: {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing type checks and assertion messages in various integration files within the `sdk` package.

### Detailed summary
- Fixed type check for `claimFeeType` in `Kiln.ts`
- Improved assertion message for `kind` in `BalancerV2.ts`
- Enhanced assertion message for `orderType` in `ZeroExV4.ts`
- Refactored `isValidRedeemType` function in `Curve.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->