### PR TITLE
feat: add composable stable v5 pools for balancer

### DIFF
--- a/.changeset/fast-mails-remember.md
+++ b/.changeset/fast-mails-remember.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Add composable stable v5 pool for balancer

--- a/packages/sdk/src/Portfolio/Integrations/BalancerV2.ts
+++ b/packages/sdk/src/Portfolio/Integrations/BalancerV2.ts
@@ -582,76 +582,17 @@ export function stablePoolsUserDataTokenInForExactBptOut({
 }
 
 //--------------------------------------------------------------------------------------------
-// COMPOSABLE STABLE POOLS - V1
+// COMPOSABLE STABLE POOLS - V5
 //--------------------------------------------------------------------------------------------
 
-export enum ComposableStableV1PoolJoinKind {
+export enum ComposableStableV5PoolJoinKind {
   INIT = 0,
   EXACT_TOKENS_IN_FOR_BPT_OUT = 1,
   TOKEN_IN_FOR_EXACT_BPT_OUT = 2,
   ALL_TOKENS_IN_FOR_EXACT_BPT_OUT = 3,
 }
 
-export enum ComposableStableV1PoolExitKind {
-  EXACT_BPT_IN_FOR_ONE_TOKEN_OUT = 0,
-  BPT_IN_FOR_EXACT_TOKENS_OUT = 1,
-}
-
-// joins
-
-export function composableStableV1PoolsUserDataExactTokensInForBptOut({
-  amountsIn,
-  bptOut,
-}: {
-  amountsIn: bigint[];
-  bptOut: bigint;
-}) {
-  return encodeAbiParameters(parseAbiParameters(["uint8, uint256[], uint256"]), [
-    ComposableStableV1PoolJoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT,
-    amountsIn,
-    bptOut,
-  ]);
-}
-
-// exits
-
-export function composableStableV1PoolsUserDataExactBptInForOneTokenOut({
-  bptAmountIn,
-  tokenIndex,
-}: {
-  bptAmountIn: bigint;
-  tokenIndex: bigint;
-}) {
-  return encodeAbiParameters(parseAbiParameters(["uint8, uint256, uint256"]), [
-    ComposableStableV1PoolExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT,
-    bptAmountIn,
-    tokenIndex,
-  ]);
-}
-
-export function composableStableV1PoolsUserDataBptInForExactTokensOut({
-  bptAmountIn,
-}: {
-  bptAmountIn: bigint;
-}) {
-  return encodeAbiParameters(parseAbiParameters(["uint8, uint256"]), [
-    ComposableStableV1PoolExitKind.BPT_IN_FOR_EXACT_TOKENS_OUT,
-    bptAmountIn,
-  ]);
-}
-
-//--------------------------------------------------------------------------------------------
-// COMPOSABLE STABLE POOLS - V2
-//--------------------------------------------------------------------------------------------
-
-export enum ComposableStableV2PoolJoinKind {
-  INIT = 0,
-  EXACT_TOKENS_IN_FOR_BPT_OUT = 1,
-  TOKEN_IN_FOR_EXACT_BPT_OUT = 2,
-  ALL_TOKENS_IN_FOR_EXACT_BPT_OUT = 3,
-}
-
-export enum ComposableStableV2PoolExitKind {
+export enum ComposableStableV5PoolExitKind {
   EXACT_BPT_IN_FOR_ONE_TOKEN_OUT = 0,
   BPT_IN_FOR_EXACT_TOKENS_OUT = 1,
   EXACT_BPT_IN_FOR_ALL_TOKENS_OUT = 2,
@@ -659,7 +600,7 @@ export enum ComposableStableV2PoolExitKind {
 
 // joins
 
-export function composableStableV2PoolsUserDataExactTokensInForBptOut({
+export function composableStableV5PoolsUserDataExactTokensInForBptOut({
   amountsIn,
   bptOut,
 }: {
@@ -667,7 +608,7 @@ export function composableStableV2PoolsUserDataExactTokensInForBptOut({
   bptOut: bigint;
 }) {
   return encodeAbiParameters(parseAbiParameters(["uint8, uint256[], uint256"]), [
-    ComposableStableV2PoolJoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT,
+    ComposableStableV5PoolJoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT,
     amountsIn,
     bptOut,
   ]);
@@ -675,7 +616,7 @@ export function composableStableV2PoolsUserDataExactTokensInForBptOut({
 
 // exits
 
-export function composableStableV2PoolsUserDataExactBptInForOneTokenOut({
+export function composableStableV5PoolsUserDataExactBptInForOneTokenOut({
   bptAmountIn,
   tokenIndex,
 }: {
@@ -683,19 +624,19 @@ export function composableStableV2PoolsUserDataExactBptInForOneTokenOut({
   tokenIndex: bigint;
 }) {
   return encodeAbiParameters(parseAbiParameters(["uint8, uint256, uint256"]), [
-    ComposableStableV2PoolExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT,
+    ComposableStableV5PoolExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT,
     bptAmountIn,
     tokenIndex,
   ]);
 }
 
-export function composableStableV2PoolsUserDataExactBptInForTokensOut({
+export function composableStableV5PoolsUserDataExactBptInForTokensOut({
   bptAmountIn,
 }: {
   bptAmountIn: bigint;
 }) {
   return encodeAbiParameters(parseAbiParameters(["uint8, uint256"]), [
-    ComposableStableV2PoolExitKind.EXACT_BPT_IN_FOR_ALL_TOKENS_OUT,
+    ComposableStableV5PoolExitKind.EXACT_BPT_IN_FOR_ALL_TOKENS_OUT,
     bptAmountIn,
   ]);
 }

--- a/packages/sdk/src/Portfolio/Integrations/BalancerV2.ts
+++ b/packages/sdk/src/Portfolio/Integrations/BalancerV2.ts
@@ -582,17 +582,17 @@ export function stablePoolsUserDataTokenInForExactBptOut({
 }
 
 //--------------------------------------------------------------------------------------------
-// COMPOSABLE STABLE POOLS - V5
+// COMPOSABLE STABLE POOLS
 //--------------------------------------------------------------------------------------------
 
-export enum ComposableStableV5PoolJoinKind {
+export enum ComposableStablePoolJoinKind {
   INIT = 0,
   EXACT_TOKENS_IN_FOR_BPT_OUT = 1,
   TOKEN_IN_FOR_EXACT_BPT_OUT = 2,
   ALL_TOKENS_IN_FOR_EXACT_BPT_OUT = 3,
 }
 
-export enum ComposableStableV5PoolExitKind {
+export enum ComposableStablePoolExitKind {
   EXACT_BPT_IN_FOR_ONE_TOKEN_OUT = 0,
   BPT_IN_FOR_EXACT_TOKENS_OUT = 1,
   EXACT_BPT_IN_FOR_ALL_TOKENS_OUT = 2,
@@ -600,7 +600,7 @@ export enum ComposableStableV5PoolExitKind {
 
 // joins
 
-export function composableStableV5PoolsUserDataExactTokensInForBptOut({
+export function composableStablePoolsUserDataExactTokensInForBptOut({
   amountsIn,
   bptOut,
 }: {
@@ -608,7 +608,7 @@ export function composableStableV5PoolsUserDataExactTokensInForBptOut({
   bptOut: bigint;
 }) {
   return encodeAbiParameters(parseAbiParameters(["uint8, uint256[], uint256"]), [
-    ComposableStableV5PoolJoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT,
+    ComposableStablePoolJoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT,
     amountsIn,
     bptOut,
   ]);
@@ -616,7 +616,7 @@ export function composableStableV5PoolsUserDataExactTokensInForBptOut({
 
 // exits
 
-export function composableStableV5PoolsUserDataExactBptInForOneTokenOut({
+export function composableStablePoolsUserDataExactBptInForOneTokenOut({
   bptAmountIn,
   tokenIndex,
 }: {
@@ -624,19 +624,19 @@ export function composableStableV5PoolsUserDataExactBptInForOneTokenOut({
   tokenIndex: bigint;
 }) {
   return encodeAbiParameters(parseAbiParameters(["uint8, uint256, uint256"]), [
-    ComposableStableV5PoolExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT,
+    ComposableStablePoolExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT,
     bptAmountIn,
     tokenIndex,
   ]);
 }
 
-export function composableStableV5PoolsUserDataExactBptInForTokensOut({
+export function composableStablePoolsUserDataExactBptInForTokensOut({
   bptAmountIn,
 }: {
   bptAmountIn: bigint;
 }) {
   return encodeAbiParameters(parseAbiParameters(["uint8, uint256"]), [
-    ComposableStableV5PoolExitKind.EXACT_BPT_IN_FOR_ALL_TOKENS_OUT,
+    ComposableStablePoolExitKind.EXACT_BPT_IN_FOR_ALL_TOKENS_OUT,
     bptAmountIn,
   ]);
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to enhance the composable stable pools feature by updating pool enum names and functions for better clarity and consistency.

### Detailed summary
- Renamed `ComposableStableV1PoolJoinKind` and `ComposableStableV1PoolExitKind` to `ComposableStablePoolJoinKind` and `ComposableStablePoolExitKind` respectively
- Updated functions related to pool joins and exits to reflect the changes
- Removed `ComposableStableV2PoolJoinKind` and `ComposableStableV2PoolExitKind` as they are no longer needed

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->