### PR TITLE
refactor: use readonly array

### DIFF
--- a/.changeset/angry-sheep-shop.md
+++ b/.changeset/angry-sheep-shop.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Use `ReadonlyArray` where applicable

--- a/packages/sdk/src/Asset.ts
+++ b/packages/sdk/src/Asset.ts
@@ -137,7 +137,7 @@ export async function getBalancesOf(
   client: PublicClient,
   args: Viem.ContractCallParameters<{
     owner: Address;
-    assets: Address[];
+    assets: ReadonlyArray<Address>;
   }>,
 ) {
   return Promise.all(

--- a/packages/sdk/src/Depositor.ts
+++ b/packages/sdk/src/Depositor.ts
@@ -83,8 +83,8 @@ export type RedeemSharesForSpecificAssetsParams = {
   comptrollerProxy: Address;
   recipient: Address;
   sharesQuantity: bigint;
-  payoutAssets: Address[];
-  payoutPercentages: bigint[];
+  payoutAssets: ReadonlyArray<Address>;
+  payoutPercentages: ReadonlyArray<bigint>;
 };
 
 export async function getSpecificAssetsRedemptionExpectedAmounts(
@@ -128,8 +128,8 @@ export function redeemSharesInKind(
     comptrollerProxy: Address;
     recipient: Address;
     sharesQuantity: bigint;
-    additionalAssets: Address[];
-    assetsToSkip: Address[];
+    additionalAssets: ReadonlyArray<Address>;
+    assetsToSkip: ReadonlyArray<Address>;
   }>,
 ) {
   return new Viem.PopulatedTransaction({

--- a/packages/sdk/src/Performance.ts
+++ b/packages/sdk/src/Performance.ts
@@ -153,8 +153,8 @@ export async function calcCanonicalAssetsTotalValue(
   client: PublicClient,
   args: Viem.ContractCallParameters<{
     valueInterpreter: Address;
-    baseAssets: Address[];
-    amounts: bigint[];
+    baseAssets: ReadonlyArray<Address>;
+    amounts: ReadonlyArray<bigint>;
     quoteAsset: Address;
   }>,
 ) {

--- a/packages/sdk/src/Portfolio/Integrations/AaveV2.ts
+++ b/packages/sdk/src/Portfolio/Integrations/AaveV2.ts
@@ -288,7 +288,7 @@ export async function getRewardsBalance(
   client: PublicClient,
   args: Viem.ContractCallParameters<{
     aaveIncentivesController: Address;
-    assets: Address[];
+    assets: ReadonlyArray<Address>;
     user: Address;
   }>,
 ) {

--- a/packages/sdk/src/Portfolio/Integrations/BalancerV2.ts
+++ b/packages/sdk/src/Portfolio/Integrations/BalancerV2.ts
@@ -536,8 +536,8 @@ export async function queryBatchSwap(
   args: Viem.ContractCallParameters<{
     balancerQueries: Address;
     kind: (typeof SwapKind)[keyof typeof SwapKind];
-    swaps: BatchSwapStep[];
-    assets: Address[];
+    swaps: ReadonlyArray<BatchSwapStep>;
+    assets: ReadonlyArray<Address>;
     funds: BatchSwapFunds;
   }>,
 ) {
@@ -576,8 +576,8 @@ export async function queryExit(
     sender: Address;
     recipient: Address;
     request: {
-      assets: Address[];
-      minAmountsOut: bigint[];
+      assets: ReadonlyArray<Address>;
+      minAmountsOut: ReadonlyArray<bigint>;
       userData: Hex;
       toInternalBalance: boolean;
     };
@@ -606,8 +606,8 @@ export async function queryJoin(
     sender: Address;
     recipient: Address;
     request: {
-      assets: Address[];
-      maxAmountsIn: bigint[];
+      assets: ReadonlyArray<Address>;
+      maxAmountsIn: ReadonlyArray<bigint>;
       userData: Hex;
       fromInternalBalance: boolean;
     };
@@ -653,7 +653,7 @@ export function weightedPoolsUserDataBptInForExactTokensOut({
   amountsOut,
   maxBPTAmountIn,
 }: {
-  amountsOut: bigint[];
+  amountsOut: ReadonlyArray<bigint>;
   maxBPTAmountIn: bigint;
 }) {
   return encodeAbiParameters(parseAbiParameters("uint8, uint256[], uint256"), [
@@ -690,7 +690,7 @@ export function weightedPoolsUserDataExactTokensInForBptOut({
   amountsIn,
   bptOut,
 }: {
-  amountsIn: bigint[];
+  amountsIn: ReadonlyArray<bigint>;
   bptOut: bigint;
 }) {
   return encodeAbiParameters(parseAbiParameters(["uint8, uint256[], uint256"]), [
@@ -760,7 +760,7 @@ export function stablePoolsUserDataExactTokensInForBptOut({
   amountsIn,
   bptOut,
 }: {
-  amountsIn: bigint[];
+  amountsIn: ReadonlyArray<bigint>;
   bptOut: bigint;
 }) {
   return encodeAbiParameters(parseAbiParameters(["uint8, uint256[], uint256"]), [
@@ -807,7 +807,7 @@ export function composableStablePoolsUserDataExactTokensInForBptOut({
   amountsIn,
   bptOut,
 }: {
-  amountsIn: bigint[];
+  amountsIn: ReadonlyArray<bigint>;
   bptOut: bigint;
 }) {
   return encodeAbiParameters(parseAbiParameters(["uint8, uint256[], uint256"]), [

--- a/packages/sdk/src/Portfolio/Integrations/Convex.ts
+++ b/packages/sdk/src/Portfolio/Integrations/Convex.ts
@@ -695,7 +695,7 @@ export async function getEstimateRewards(
 export async function getAllEstimateRewards(
   client: PublicClient,
   args: Viem.ContractCallParameters<{
-    stakingWrappers: Address[];
+    stakingWrappers: ReadonlyArray<Address>;
     beneficiary: Address;
   }>,
 ) {

--- a/packages/sdk/src/Portfolio/Integrations/Curve.ts
+++ b/packages/sdk/src/Portfolio/Integrations/Curve.ts
@@ -314,7 +314,7 @@ export function redeemDecode(encoded: Hex): RedeemArgs {
 
 export type StandardRedeemArgs = {
   redeemType: typeof RedeemType.Standard;
-  orderedMinIncomingAssetAmounts: readonly bigint[];
+  orderedMinIncomingAssetAmounts: ReadonlyArray<bigint>;
 };
 
 export type OneCoinRedeemArgs = {
@@ -326,7 +326,7 @@ export type OneCoinRedeemArgs = {
 const standardRedeemEncoding = parseAbiParameters("uint256[]");
 const oneCoinRedeemEncoding = parseAbiParameters("uint256, uint256");
 
-export function standardRedeemEncode(orderedMinIncomingAssetAmounts: readonly bigint[]): Hex {
+export function standardRedeemEncode(orderedMinIncomingAssetAmounts: ReadonlyArray<bigint>): Hex {
   return encodeAbiParameters(standardRedeemEncoding, [orderedMinIncomingAssetAmounts]);
 }
 
@@ -695,7 +695,7 @@ export async function getExpectedGaugeTokens(
   client: PublicClient,
   args: Viem.ContractCallParameters<{
     curvePool: Address;
-    tokenAmounts: bigint[];
+    tokenAmounts: ReadonlyArray<bigint>;
     isDeposit: boolean;
   }>,
 ) {
@@ -750,7 +750,7 @@ export async function getExpectedWithdrawalTokens(
   args: Viem.ContractCallParameters<{
     curvePool: Address;
     singleTokenIndex: bigint;
-    underlyingAssetsDecimals: number[];
+    underlyingAssetsDecimals: ReadonlyArray<number>;
     lpToken: Address;
     lpTokenAmount: bigint;
     equalProportion: boolean;

--- a/packages/sdk/src/Tools/GatedRedemptionQueueSharesWrapper.ts
+++ b/packages/sdk/src/Tools/GatedRedemptionQueueSharesWrapper.ts
@@ -23,7 +23,7 @@ export type RedemptionWindowConfig = {
 export function deploy(args: {
   sharesWrapperFactory: Address;
   vaultProxy: Address;
-  managers: Address[];
+  managers: ReadonlyArray<Address>;
   redemptionAsset: Address;
   useDepositApproval: boolean;
   useRedemptionApproval: boolean;
@@ -111,9 +111,9 @@ export function forceTransfer(args: {
 
 export function setDepositApprovals(args: {
   sharesWrapper: Address;
-  depositors: Address[];
-  assets: Address[];
-  amounts: bigint[];
+  depositors: ReadonlyArray<Address>;
+  assets: ReadonlyArray<Address>;
+  amounts: ReadonlyArray<bigint>;
 }) {
   return new Viem.PopulatedTransaction({
     abi: Abis.IGatedRedemptionQueueSharesWrapperLib,
@@ -125,8 +125,8 @@ export function setDepositApprovals(args: {
 
 export function setRedemptionApprovals(args: {
   sharesWrapper: Address;
-  depositors: Address[];
-  amounts: bigint[];
+  depositors: ReadonlyArray<Address>;
+  amounts: ReadonlyArray<bigint>;
 }) {
   return new Viem.PopulatedTransaction({
     abi: Abis.IGatedRedemptionQueueSharesWrapperLib,
@@ -138,9 +138,9 @@ export function setRedemptionApprovals(args: {
 
 export function setTransferApprovals(args: {
   sharesWrapper: Address;
-  senders: Address[];
-  recipients: Address[];
-  amounts: bigint[];
+  senders: ReadonlyArray<Address>;
+  recipients: ReadonlyArray<Address>;
+  amounts: ReadonlyArray<bigint>;
 }) {
   return new Viem.PopulatedTransaction({
     abi: Abis.IGatedRedemptionQueueSharesWrapperLib,
@@ -153,7 +153,7 @@ export function setTransferApprovals(args: {
 export function depositFromQueue(args: {
   sharesWrapper: Address;
   asset: Address;
-  depositors: Address[];
+  depositors: ReadonlyArray<Address>;
 }) {
   return new Viem.PopulatedTransaction({
     abi: Abis.IGatedRedemptionQueueSharesWrapperLib,
@@ -177,7 +177,7 @@ export function depositAllFromQueue(args: {
 
 export function addManagers(args: {
   sharesWrapper: Address;
-  managers: Address[];
+  managers: ReadonlyArray<Address>;
 }) {
   return new Viem.PopulatedTransaction({
     abi: Abis.IGatedRedemptionQueueSharesWrapperLib,
@@ -189,7 +189,7 @@ export function addManagers(args: {
 
 export function removeManagers(args: {
   sharesWrapper: Address;
-  managers: Address[];
+  managers: ReadonlyArray<Address>;
 }) {
   return new Viem.PopulatedTransaction({
     abi: Abis.IGatedRedemptionQueueSharesWrapperLib,

--- a/packages/sdk/src/Tools/SharesSplitter.ts
+++ b/packages/sdk/src/Tools/SharesSplitter.ts
@@ -9,8 +9,8 @@ import { Viem } from "../Utils.js";
 
 export function deploy(args: {
   sharesSplitterFactory: Address;
-  addresses: Address[];
-  percentages: bigint[];
+  addresses: ReadonlyArray<Address>;
+  percentages: ReadonlyArray<bigint>;
 }) {
   return new Viem.PopulatedTransaction({
     abi: Abis.ISharesSplitterFactory,

--- a/packages/sdk/src/Tools/UnpermissionedActionsWrapper.ts
+++ b/packages/sdk/src/Tools/UnpermissionedActionsWrapper.ts
@@ -5,7 +5,7 @@ import { Viem } from "../Utils.js";
 export function invokeContinuousFeeHookAndPayoutSharesOutstandingForFund(args: {
   unpermissionedActionsWrapper: Address;
   comptrollerProxy: Address;
-  fees: Address[];
+  fees: ReadonlyArray<Address>;
 }) {
   return new Viem.PopulatedTransaction({
     abi: Abis.IUnpermissionedActionsWrapper,

--- a/packages/sdk/src/Utils/bigint.ts
+++ b/packages/sdk/src/Utils/bigint.ts
@@ -1,4 +1,4 @@
-export function min(first: bigint, ...rest: bigint[]) {
+export function min(first: bigint, ...rest: Array<bigint>) {
   let min = first;
   for (const value of rest) {
     if (value < min) {
@@ -9,7 +9,7 @@ export function min(first: bigint, ...rest: bigint[]) {
   return min;
 }
 
-export function max(first: bigint, ...rest: bigint[]) {
+export function max(first: bigint, ...rest: Array<bigint>) {
   let max = first;
   for (const value of rest) {
     if (value > max) {

--- a/packages/sdk/src/Utils/types.ts
+++ b/packages/sdk/src/Utils/types.ts
@@ -8,8 +8,10 @@ export type Prettify<T> = {
   [K in keyof T]: T[K];
 } & {};
 
-export type TupleOf<T, N extends number, R extends unknown[]> = R["length"] extends N ? R : TupleOf<T, N, [T, ...R]>;
+export type TupleOf<T, N extends number, R extends Array<unknown>> = R["length"] extends N
+  ? R
+  : TupleOf<T, N, [T, ...R]>;
 
-export type Tuple<T, N extends number> = N extends N ? (number extends N ? T[] : TupleOf<T, N, []>) : never;
+export type Tuple<T, N extends number> = N extends N ? (number extends N ? Array<T> : TupleOf<T, N, []>) : never;
 
 export type DeepWriteable<T> = { -readonly [P in keyof T]: DeepWriteable<T[P]> };

--- a/packages/sdk/src/Vault.ts
+++ b/packages/sdk/src/Vault.ts
@@ -230,7 +230,7 @@ export function sharesAreFreelyTransferable(
 export function addAssetManagers(
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
-    managers: Address[];
+    managers: ReadonlyArray<Address>;
   }>,
 ) {
   return new Viem.PopulatedTransaction({
@@ -244,7 +244,7 @@ export function addAssetManagers(
 export function removeAssetManagers(
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
-    managers: Address[];
+    managers: ReadonlyArray<Address>;
   }>,
 ) {
   return new Viem.PopulatedTransaction({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the codebase to use `ReadonlyArray` where applicable for enhanced immutability and type safety.

### Detailed summary
- Replaced `Address[]` with `ReadonlyArray<Address>` in multiple files for immutability
- Updated functions to accept `ReadonlyArray` parameters for improved type safety
- Added a new `min` function in `bigint.ts`
- Adjusted types in `types.ts` for better readability and consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->