### PR TITLE
fix: arbitrary loan encoding

### DIFF
--- a/.changeset/brown-hats-grin.md
+++ b/.changeset/brown-hats-grin.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Arbitrary loan encoding

--- a/packages/sdk/src/Portfolio/Integrations/ArbitraryLoan.ts
+++ b/packages/sdk/src/Portfolio/Integrations/ArbitraryLoan.ts
@@ -67,7 +67,7 @@ export function configureLoanEncode(args: ConfigureLoanArgs): Hex {
     args.amount,
     args.accountingModule,
     args.accountingModuleConfigData,
-    stringToHex(args.description),
+    stringToHex(args.description, { size: 32 }),
   ]);
 }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding support for arbitrary loan encoding in the `ArbitraryLoan` class in the SDK.

### Detailed summary
- Added support for arbitrary loan encoding in `ArbitraryLoan.ts`
- Updated `stringToHex` function call with size parameter set to 32

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->