### PR TITLE
fix: arbitrary loan reconcile encoding

### DIFF
--- a/.changeset/tasty-jokes-leave.md
+++ b/.changeset/tasty-jokes-leave.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Arbitrary loan reconcile encoding

--- a/packages/sdk/src/Portfolio/Integrations/ArbitraryLoan.ts
+++ b/packages/sdk/src/Portfolio/Integrations/ArbitraryLoan.ts
@@ -99,7 +99,7 @@ export const updateBorrowableAmount = ExternalPositionManager.makeUse(
 const updateBorrowableAmountEncoding = [
   {
     name: "amountDelta",
-    type: "uint256",
+    type: "int256",
   },
 ] as const;
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `ArbitraryLoan.ts` file in the `@enzymefinance/sdk` package to change the data type of the `amountDelta` field from `uint256` to `int256`.

### Detailed summary
- Updated the data type of the `amountDelta` field in `ArbitraryLoan.ts` from `uint256` to `int256`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->