### PR TITLE
refactor: use base client everywhere

### DIFF
--- a/.changeset/long-frogs-fold.md
+++ b/.changeset/long-frogs-fold.md
@@ -1,0 +1,6 @@
+---
+"@enzymefinance/environment": patch
+"@enzymefinance/sdk": patch
+---
+
+Use base client instead of public client

--- a/packages/environment/package.json
+++ b/packages/environment/package.json
@@ -35,11 +35,7 @@
   },
   "effect": {
     "generateExports": {
-      "include": [
-        "*.ts",
-        "assets/*.ts",
-        "deployments/*.ts"
-      ]
+      "include": ["*.ts", "assets/*.ts", "deployments/*.ts"]
     }
   }
 }

--- a/packages/sdk/src/Asset.ts
+++ b/packages/sdk/src/Asset.ts
@@ -1,12 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import {
-  type Address,
-  ContractFunctionExecutionError,
-  type PublicClient,
-  bytesToString,
-  hexToBytes,
-  parseAbi,
-} from "viem";
+import { type Address, type Client, ContractFunctionExecutionError, bytesToString, hexToBytes, parseAbi } from "viem";
 import { readContract, simulateContract } from "viem/actions";
 import { Viem } from "./Utils.js";
 import { removeTrailingZeros } from "./Utils/bytes.js";
@@ -35,7 +28,7 @@ export function approve(args: ApproveParams) {
 //--------------------------------------------------------------------------------------------
 
 export async function getInfo(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     asset: Address;
   }>,
@@ -50,7 +43,7 @@ export async function getInfo(
 }
 
 export async function getName(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     asset: Address;
   }>,
@@ -84,7 +77,7 @@ export async function getName(
 }
 
 export async function getSymbol(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     asset: Address;
   }>,
@@ -118,7 +111,7 @@ export async function getSymbol(
 }
 
 export function getBalanceOf(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     owner: Address;
     asset: Address;
@@ -134,7 +127,7 @@ export function getBalanceOf(
 }
 
 export function getBalancesOf(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     owner: Address;
     assets: ReadonlyArray<Address>;
@@ -153,7 +146,7 @@ export function getBalancesOf(
 }
 
 export function getAllowance(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     asset: Address;
     owner: Address;
@@ -170,7 +163,7 @@ export function getAllowance(
 }
 
 export function getDecimals(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     asset: Address;
   }>,
@@ -184,7 +177,7 @@ export function getDecimals(
 }
 
 export function getTotalSupply(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     asset: Address;
   }>,
@@ -198,7 +191,7 @@ export function getTotalSupply(
 }
 
 export async function getCanonicalValue(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     valueInterpreter: Address;
     baseAsset: Address;

--- a/packages/sdk/src/Configuration.ts
+++ b/packages/sdk/src/Configuration.ts
@@ -1,5 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import { type Address, type PublicClient, isAddressEqual } from "viem";
+import { type Address, type Client, isAddressEqual } from "viem";
 import { readContract, simulateContract } from "viem/actions";
 import { getInfo } from "./Configuration/Fees/Performance.js";
 import { Viem } from "./Utils.js";
@@ -11,7 +11,7 @@ export * as Policies from "./Configuration/Policies.js";
 export * as ProtocolFee from "./Configuration/ProtocolFee.js";
 
 export function getEnabledFees(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     comptrollerProxy: Address;
     feeManager: Address;
@@ -27,7 +27,7 @@ export function getEnabledFees(
 }
 
 export async function getAccruedContinuousFees(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     feeManager: Address;
     unpermissionedActionsWrapper: Address;
@@ -106,7 +106,7 @@ export async function getAccruedContinuousFees(
 }
 
 export function getEnabledPolicies(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     comptrollerProxy: Address;
     policyManager: Address;

--- a/packages/sdk/src/Configuration/Fee.ts
+++ b/packages/sdk/src/Configuration/Fee.ts
@@ -1,5 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import type { Address, PublicClient } from "viem";
+import type { Address, Client } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../Utils.js";
 
@@ -15,7 +15,7 @@ export {
 } from "../_internal/FeeManager.js";
 
 export function getRecipient(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     comptrollerProxy: Address;
     fee: Address;

--- a/packages/sdk/src/Configuration/Fees/Entrance.ts
+++ b/packages/sdk/src/Configuration/Fees/Entrance.ts
@@ -1,5 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters, zeroAddress } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters, zeroAddress } from "viem";
 import { readContract } from "viem/actions";
 import { type Types, Viem } from "../../Utils.js";
 
@@ -99,7 +99,7 @@ export function setRecipient(args: SetRecipientParams) {
 //--------------------------------------------------------------------------------------------
 
 export function getRate(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     entranceRateFee: Address;
     comptrollerProxy: Address;

--- a/packages/sdk/src/Configuration/Fees/Exit.ts
+++ b/packages/sdk/src/Configuration/Fees/Exit.ts
@@ -1,5 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters, zeroAddress } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters, zeroAddress } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 
@@ -108,7 +108,7 @@ export function setRecipient(args: SetRecipientParams) {
 //--------------------------------------------------------------------------------------------
 
 export function getInKindRate(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     exitRateFee: Address;
     comptrollerProxy: Address;
@@ -124,7 +124,7 @@ export function getInKindRate(
 }
 
 export function getSpecificAssetsRate(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     exitRateFee: Address;
     comptrollerProxy: Address;

--- a/packages/sdk/src/Configuration/Fees/Management.ts
+++ b/packages/sdk/src/Configuration/Fees/Management.ts
@@ -1,5 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters, zeroAddress } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters, zeroAddress } from "viem";
 import { readContract } from "viem/actions";
 import { Rates, Viem } from "../../Utils.js";
 
@@ -100,7 +100,7 @@ export function setRecipient(args: SetRecipientParams) {
 //--------------------------------------------------------------------------------------------
 
 export function getInfo(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     comptrollerProxy: Address;
     managementFee: Address;

--- a/packages/sdk/src/Configuration/Fees/Performance.ts
+++ b/packages/sdk/src/Configuration/Fees/Performance.ts
@@ -1,5 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters, zeroAddress } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters, zeroAddress } from "viem";
 import { readContract } from "viem/actions";
 import { type Types, Viem } from "../../Utils.js";
 
@@ -59,7 +59,7 @@ export function setRecipient(args: SetRecipientParams) {
 //--------------------------------------------------------------------------------------------
 
 export function getInfo(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     comptrollerProxy: Address;
     performanceFee: Address;

--- a/packages/sdk/src/Configuration/Policies/CumulativeSlippageTolerance.ts
+++ b/packages/sdk/src/Configuration/Policies/CumulativeSlippageTolerance.ts
@@ -1,5 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters } from "viem";
 import { multicall, readContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 
@@ -45,7 +45,7 @@ export function decodeSettings(settings: Hex): Settings {
 //--------------------------------------------------------------------------------------------
 
 export function getInfo(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     comptrollerProxy: Address;
     cumulativeSlippageTolerancePolicy: Address;
@@ -61,7 +61,7 @@ export function getInfo(
 }
 
 export async function getCurrentCumulativeSlippage(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     cumulativeSlippageTolerancePolicy: Address;
     comptrollerProxy: Address;

--- a/packages/sdk/src/Configuration/Policies/MinMaxInvestment.ts
+++ b/packages/sdk/src/Configuration/Policies/MinMaxInvestment.ts
@@ -1,5 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters, maxUint256 } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters, maxUint256 } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 
@@ -68,7 +68,7 @@ export function decodeSettings(settings: Hex): Settings {
 //--------------------------------------------------------------------------------------------
 
 export function getSettings(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     comptrollerProxy: Address;
     minMaxInvestmentPolicy: Address;

--- a/packages/sdk/src/Configuration/Policy.ts
+++ b/packages/sdk/src/Configuration/Policy.ts
@@ -1,5 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import { type Address, type PublicClient, isAddressEqual } from "viem";
+import { type Address, type Client, isAddressEqual } from "viem";
 import { readContract } from "viem/actions";
 import { getEnabledPolicies } from "../Configuration.js";
 import { Viem } from "../Utils.js";
@@ -14,7 +14,7 @@ export {
 } from "../_internal/PolicyManager.js";
 
 export async function isEnabled(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     policy: Address;
     policyManager: Address;
@@ -26,7 +26,7 @@ export async function isEnabled(
 }
 
 export function getIdentifier(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     policy: Address;
   }>,
@@ -64,7 +64,7 @@ const getListIdsForFundAbi = {
 } as const;
 
 export function getListIds(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     policyContract: Address;
     comptrollerProxy: Address;
@@ -84,7 +84,7 @@ export function getListIds(
 //--------------------------------------------------------------------------------------------
 
 export function getPricelessAssetBypassTimeLimit(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     policy: Address;
   }>,
@@ -98,7 +98,7 @@ export function getPricelessAssetBypassTimeLimit(
 }
 
 export function getPricelessAssetBypassTimelock(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     policy: Address;
   }>,

--- a/packages/sdk/src/Configuration/ProtocolFee.ts
+++ b/packages/sdk/src/Configuration/ProtocolFee.ts
@@ -1,5 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import type { Address, PublicClient } from "viem";
+import type { Address, Client } from "viem";
 import { readContract, simulateContract } from "viem/actions";
 import { Viem } from "../Utils.js";
 
@@ -40,7 +40,7 @@ export function buyBackProtocolFeeShares(args: BuyBackProtocolFeeSharesParams) {
 //--------------------------------------------------------------------------------------------
 
 export function getProtocolFeeRate(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
     protocolFeeTracker: Address;
@@ -56,7 +56,7 @@ export function getProtocolFeeRate(
 }
 
 export async function getAccruedProtocolFee(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
     protocolFeeTracker: Address;
@@ -74,7 +74,7 @@ export async function getAccruedProtocolFee(
 }
 
 export function doesAutoProtocolFeeSharesBuyback(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     comptrollerProxy: Address;
   }>,
@@ -88,7 +88,7 @@ export function doesAutoProtocolFeeSharesBuyback(
 }
 
 export async function getMlnValueAndBurnAmountForSharesBuyback(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     denominationAsset: Address;
     buybackSharesAmount: bigint;

--- a/packages/sdk/src/Depositor.ts
+++ b/packages/sdk/src/Depositor.ts
@@ -1,5 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import type { Address, Hex, PublicClient } from "viem";
+import type { Address, Client, Hex } from "viem";
 import { readContract, simulateContract } from "viem/actions";
 import { isEnabled } from "./Configuration/Policy.js";
 import { Viem } from "./Utils.js";
@@ -10,7 +10,7 @@ import { Assertion } from "./Utils.js";
 //--------------------------------------------------------------------------------------------
 
 export function getSharesActionTimelock(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     comptrollerProxy: Address;
   }>,
@@ -24,7 +24,7 @@ export function getSharesActionTimelock(
 }
 
 export function getLastSharesBoughtTimestamp(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     depositor: Address;
     comptrollerProxy: Address;
@@ -40,7 +40,7 @@ export function getLastSharesBoughtTimestamp(
 }
 
 export async function getExpectedSharesForDeposit(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     comptrollerProxy: Address;
     amount: bigint;
@@ -88,7 +88,7 @@ export type RedeemSharesForSpecificAssetsParams = {
 };
 
 export async function getSpecificAssetsRedemptionExpectedAmounts(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<RedeemSharesForSpecificAssetsParams>,
 ) {
   const { result: payoutAmounts } = await simulateContract(client, {
@@ -155,7 +155,7 @@ interface NativeDepositArgs {
 }
 
 export async function getExpectedSharesForNativeTokenDeposit(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<NativeDepositArgs & { depositor: Address }>,
 ) {
   const { result } = await simulateContract(client, {
@@ -207,7 +207,7 @@ interface ERC20DepositArgs {
 }
 
 export async function getExpectedSharesForERC20Deposit(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<ERC20DepositArgs & { depositor: Address }>,
 ) {
   const { result } = await simulateContract(client, {
@@ -259,7 +259,7 @@ export type SharesWrapperDepositBaseParams = {
 };
 
 export async function getExpectedSharesForSharesWrapperDeposit(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<
     SharesWrapperDepositBaseParams & {
       depositor: Address;
@@ -376,7 +376,7 @@ export function redemptionQueueWithdrawRequest(
 //--------------------------------------------------------------------------------------------
 
 export async function isAllowedDepositor(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     allowedDepositRecipientsPolicy: Address;
     comptrollerProxy: Address;

--- a/packages/sdk/src/LifeCycle.ts
+++ b/packages/sdk/src/LifeCycle.ts
@@ -1,5 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import type { Address, Hex, PublicClient } from "viem";
+import type { Address, Client, Hex } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "./Utils.js";
 
@@ -96,7 +96,7 @@ export function executeMigration(args: ExecuteMigrationParams) {
 }
 
 export function hasMigrationRequest(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
     dispatcher: Address;
@@ -112,7 +112,7 @@ export function hasMigrationRequest(
 }
 
 export function hasExecutableMigrationRequest(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
     dispatcher: Address;
@@ -128,7 +128,7 @@ export function hasExecutableMigrationRequest(
 }
 
 export function getRemainingMigrationRequestTimelock(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
     dispatcher: Address;
@@ -144,7 +144,7 @@ export function getRemainingMigrationRequestTimelock(
 }
 
 export async function getMigrationRequestDetails(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vault: Address;
     dispatcher: Address;
@@ -223,7 +223,7 @@ export function executeReconfiguration(args: ExecuteReconfigurationParams) {
 }
 
 export function hasReconfigurationRequest(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
     fundDeployer: Address;
@@ -239,7 +239,7 @@ export function hasReconfigurationRequest(
 }
 
 export function getReconfigurationRequestDetails(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
     fundDeployer: Address;

--- a/packages/sdk/src/Performance.ts
+++ b/packages/sdk/src/Performance.ts
@@ -1,10 +1,10 @@
 import * as Abis from "@enzymefinance/abis";
-import { type Address, ContractFunctionExecutionError, type PublicClient } from "viem";
+import { type Address, type Client, ContractFunctionExecutionError } from "viem";
 import { simulateContract } from "viem/actions";
 import { Viem } from "./Utils.js";
 
 export async function getNav(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
     valueCalculator: Address;
@@ -24,7 +24,7 @@ export async function getNav(
 }
 
 export async function getNavInAsset(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     asset: Address;
     vaultProxy: Address;
@@ -43,7 +43,7 @@ export async function getNavInAsset(
 }
 
 export async function getGav(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
     valueCalculator: Address;
@@ -63,7 +63,7 @@ export async function getGav(
 }
 
 export async function getGavInAsset(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     asset: Address;
     vaultProxy: Address;
@@ -82,7 +82,7 @@ export async function getGavInAsset(
 }
 
 export async function getSharePrice(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
     valueCalculator: Address;
@@ -102,7 +102,7 @@ export async function getSharePrice(
 }
 
 export async function getSharePriceInAsset(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     asset: Address;
     vaultProxy: Address;
@@ -121,7 +121,7 @@ export async function getSharePriceInAsset(
 }
 
 export async function getCanonicalAssetValue(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     valueInterpreter: Address;
     baseAsset: Address;
@@ -150,7 +150,7 @@ export async function getCanonicalAssetValue(
 }
 
 export async function calcCanonicalAssetsTotalValue(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     valueInterpreter: Address;
     baseAssets: ReadonlyArray<Address>;

--- a/packages/sdk/src/Portfolio.ts
+++ b/packages/sdk/src/Portfolio.ts
@@ -1,5 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import type { Address, Hex, PublicClient } from "viem";
+import type { Address, Client, Hex } from "viem";
 import { readContract, simulateContract } from "viem/actions";
 import * as Assets from "./Asset.js";
 import { Assertion, Viem } from "./Utils.js";
@@ -60,7 +60,7 @@ export function vaultCallOnContract(args: VaultCallOnContractParams) {
 }
 
 export async function getPortfolio(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
   }>,
@@ -100,7 +100,7 @@ export async function getPortfolio(
 }
 
 export function getTrackedAssets(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
   }>,
@@ -118,7 +118,7 @@ export function getTrackedAssets(
 //--------------------------------------------------------------------------------------------
 
 export function isActiveExternalPosition(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
     externalPosition: Address;
@@ -134,7 +134,7 @@ export function isActiveExternalPosition(
 }
 
 export async function getTotalValueForAllExternalPositions(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
   }>,
@@ -162,7 +162,7 @@ export async function getTotalValueForAllExternalPositions(
 }
 
 export function getActiveExternalPositions(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
   }>,
@@ -176,7 +176,7 @@ export function getActiveExternalPositions(
 }
 
 export async function getExternalPositionManagedAssets(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     externalPosition: Address;
   }>,
@@ -202,7 +202,7 @@ export async function getExternalPositionManagedAssets(
 }
 
 export async function getExternalPositionDebtAssets(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     externalPosition: Address;
   }>,
@@ -228,7 +228,7 @@ export async function getExternalPositionDebtAssets(
 }
 
 export async function getExternalPositionAssets(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     externalPosition: Address;
   }>,
@@ -245,7 +245,7 @@ export async function getExternalPositionAssets(
 }
 
 export function getExternalPositionType(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     externalPosition: Address;
   }>,
@@ -259,7 +259,7 @@ export function getExternalPositionType(
 }
 
 export function getTypeLabel(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     externalPositionFactory: Address;
     typeId: bigint;

--- a/packages/sdk/src/Portfolio/Integrations/AaveV2.ts
+++ b/packages/sdk/src/Portfolio/Integrations/AaveV2.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 import * as ExternalPositionManager from "../../_internal/ExternalPositionManager.js";
@@ -285,7 +285,7 @@ const aaveIncentivesControllerAbi = [
 ] as const;
 
 export function getRewardsBalance(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     aaveIncentivesController: Address;
     assets: ReadonlyArray<Address>;
@@ -302,7 +302,7 @@ export function getRewardsBalance(
 }
 
 export function getUserUnclaimedRewards(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     aaveIncentivesController: Address;
     user: Address;

--- a/packages/sdk/src/Portfolio/Integrations/AaveV3.ts
+++ b/packages/sdk/src/Portfolio/Integrations/AaveV3.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 import * as ExternalPositionManager from "../../_internal/ExternalPositionManager.js";
@@ -326,7 +326,7 @@ const poolAddressProviderAbi = [
 ] as const;
 
 export function getPool(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     poolAddressProvider: Address;
   }>,
@@ -363,7 +363,7 @@ const poolAbi = [
 ] as const;
 
 export function getEModeCategoryData(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     pool: Address;
     categoryId: number;

--- a/packages/sdk/src/Portfolio/Integrations/Alice.ts
+++ b/packages/sdk/src/Portfolio/Integrations/Alice.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 import * as ExternalPositionManager from "../../_internal/ExternalPositionManager.js";
@@ -167,7 +167,7 @@ export function sweepDecode(encoded: Hex): SweepArgs {
 //--------------------------------------------------------------------------------------------
 
 export async function getInstrument(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     aliceOrderManagerAddress: Address;
     instrumentId: number;
@@ -188,7 +188,7 @@ export async function getInstrument(
 }
 
 export function getOrderHash(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     aliceOrderManagerAddress: Address;
     orderId: bigint;
@@ -204,7 +204,7 @@ export function getOrderHash(
 }
 
 export async function isAddressWhitelisted(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     aliceOrderManagerAddress: Address;
     addressToCheck: Address;

--- a/packages/sdk/src/Portfolio/Integrations/ArrakisV2.ts
+++ b/packages/sdk/src/Portfolio/Integrations/ArrakisV2.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters } from "viem";
 import { readContract, simulateContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 import * as IntegrationManager from "../../_internal/IntegrationManager.js";
@@ -108,7 +108,7 @@ const resolverAbi = [
 ] as const;
 
 export async function getMintAmounts(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     resolver: Address;
     arrakisVault: Address;
@@ -145,7 +145,7 @@ const helperAbi = [
 ] as const;
 
 export async function totalUnderlying(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     helper: Address;
     arrakisVault: Address;
@@ -214,7 +214,7 @@ const vaultAbi = [
 ] as const;
 
 export async function burn(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     arrakisVault: Address;
     receiver: Address;
@@ -240,7 +240,7 @@ export async function burn(
 }
 
 export async function inits(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     arrakisVault: Address;
   }>,
@@ -267,7 +267,7 @@ export async function inits(
 }
 
 export async function numberOfRanges(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     arrakisVault: Address;
   }>,

--- a/packages/sdk/src/Portfolio/Integrations/BalancerV2.ts
+++ b/packages/sdk/src/Portfolio/Integrations/BalancerV2.ts
@@ -1,7 +1,7 @@
 import {
   type Address,
+  type Client,
   type Hex,
-  type PublicClient,
   decodeAbiParameters,
   encodeAbiParameters,
   parseAbiParameters,
@@ -329,7 +329,7 @@ const minterAbi = [
 ] as const;
 
 export async function getMinterRewards(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     minter: Address;
     beneficiary: Address;
@@ -366,7 +366,7 @@ const gaugeAbi = [
 ] as const;
 
 export function getClaimableRewards(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     gauge: Address;
     user: Address;
@@ -532,7 +532,7 @@ export interface BatchSwapFunds {
 }
 
 export async function queryBatchSwap(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     balancerQueries: Address;
     kind: (typeof SwapKind)[keyof typeof SwapKind];
@@ -569,7 +569,7 @@ export async function queryBatchSwap(
 }
 
 export async function queryExit(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     balancerQueries: Address;
     poolId: Hex;
@@ -599,7 +599,7 @@ export async function queryExit(
 }
 
 export async function queryJoin(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     balancerQueries: Address;
     poolId: Hex;

--- a/packages/sdk/src/Portfolio/Integrations/CompoundV2.ts
+++ b/packages/sdk/src/Portfolio/Integrations/CompoundV2.ts
@@ -1,5 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 import * as ExternalPositionManager from "../../_internal/ExternalPositionManager.js";
@@ -228,7 +228,7 @@ export const claimComp = ExternalPositionManager.makeUse(Action.ClaimComp);
 //--------------------------------------------------------------------------------------------
 
 export function getCTokenFromBorrowedAsset(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     externalPositionProxy: Address;
     borrowedAsset: Address;
@@ -367,7 +367,7 @@ export interface Market {
 }
 
 export function getBorrowRatePerBlock(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     cToken: Address;
   }>,
@@ -381,7 +381,7 @@ export function getBorrowRatePerBlock(
 }
 
 export function getSupplyRatePerBlock(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     cToken: Address;
   }>,
@@ -395,7 +395,7 @@ export function getSupplyRatePerBlock(
 }
 
 export function getTotalSupply(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     cToken: Address;
   }>,
@@ -409,7 +409,7 @@ export function getTotalSupply(
 }
 
 export function getTotalBorrows(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     cToken: Address;
   }>,
@@ -423,7 +423,7 @@ export function getTotalBorrows(
 }
 
 export function getExchangeRateStored(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     cToken: Address;
   }>,
@@ -437,7 +437,7 @@ export function getExchangeRateStored(
 }
 
 export function getBalanceOf(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     cToken: Address;
     account: Address;
@@ -453,7 +453,7 @@ export function getBalanceOf(
 }
 
 export function getCompSupplySpeeds(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     compoundComptroller: Address;
     cToken: Address;
@@ -469,7 +469,7 @@ export function getCompSupplySpeeds(
 }
 
 export function getCompBorrowSpeeds(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     compoundComptroller: Address;
     cToken: Address;
@@ -485,7 +485,7 @@ export function getCompBorrowSpeeds(
 }
 
 export async function getMarkets(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     compoundComptroller: Address;
     cToken: Address;
@@ -503,7 +503,7 @@ export async function getMarkets(
 }
 
 export function getMintGuardianPaused(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     compoundComptroller: Address;
     cToken: Address;
@@ -518,7 +518,7 @@ export function getMintGuardianPaused(
 }
 
 export function getCompAccrued(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     compoundComptroller: Address;
     account: Address;

--- a/packages/sdk/src/Portfolio/Integrations/CompoundV3.ts
+++ b/packages/sdk/src/Portfolio/Integrations/CompoundV3.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters } from "viem";
 import { readContract, simulateContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 import * as IntegrationManager from "../../_internal/IntegrationManager.js";
@@ -158,7 +158,7 @@ const cometRewardsAbi = [
 ] as const;
 
 export function getUtilization(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     asset: Address;
   }>,
@@ -172,7 +172,7 @@ export function getUtilization(
 }
 
 export function getSupplyRate(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     asset: Address;
     utilization: bigint;
@@ -188,7 +188,7 @@ export function getSupplyRate(
 }
 
 export function getTotalSupply(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     asset: Address;
   }>,
@@ -202,7 +202,7 @@ export function getTotalSupply(
 }
 
 export function getBaseTrackingSupplySpeed(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     asset: Address;
   }>,
@@ -216,7 +216,7 @@ export function getBaseTrackingSupplySpeed(
 }
 
 export async function getRewardOwed(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     cometRewards: Address;
     asset: Address;

--- a/packages/sdk/src/Portfolio/Integrations/Convex.ts
+++ b/packages/sdk/src/Portfolio/Integrations/Convex.ts
@@ -1,5 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
 import { readContract, simulateContract } from "viem/actions";
 import { Assertion, Viem } from "../../Utils.js";
 import * as ExternalPositionManager from "../../_internal/ExternalPositionManager.js";
@@ -276,7 +276,7 @@ const cvxMiningAbi = {
 } as const;
 
 export function convertCrvToCvx(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     cvxMining: Address;
     amount: bigint;
@@ -352,7 +352,7 @@ const cvxLockerV2Abi = [
 ] as const;
 
 export async function getVoteLockedBalances(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     voteLockedConvexToken: Address;
     positionAddress: Address;
@@ -381,7 +381,7 @@ export async function getVoteLockedBalances(
 }
 
 export function getClaimableRewards(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     voteLockedConvexToken: Address;
     user: Address;
@@ -397,7 +397,7 @@ export function getClaimableRewards(
 }
 
 export async function getUserLocks(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     voteLockedConvexToken: Address;
     user: Address;
@@ -475,7 +475,7 @@ export interface PoolInfo {
 }
 
 export async function getPoolInfo(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     booster: Address;
     pid: bigint;
@@ -493,7 +493,7 @@ export async function getPoolInfo(
 }
 
 export function getLockIncentive(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     booster: Address;
   }>,
@@ -507,7 +507,7 @@ export function getLockIncentive(
 }
 
 export function getStakerIncentive(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     booster: Address;
   }>,
@@ -521,7 +521,7 @@ export function getStakerIncentive(
 }
 
 export function getEarmarkIncentive(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     booster: Address;
   }>,
@@ -535,7 +535,7 @@ export function getEarmarkIncentive(
 }
 
 export function getPlatformFee(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     booster: Address;
   }>,
@@ -578,7 +578,7 @@ const cvxCrvRewards = [
 ] as const;
 
 export function getRewards(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     cvxCrvRewards: Address;
     user: Address;
@@ -594,7 +594,7 @@ export function getRewards(
 }
 
 export function getExtraRewardsLength(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     cvxCrvRewards: Address;
     user: Address;
@@ -609,7 +609,7 @@ export function getExtraRewardsLength(
 }
 
 export function getExtraRewards(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     cvxCrvRewards: Address;
     id: bigint;
@@ -629,7 +629,7 @@ export function getExtraRewards(
 //--------------------------------------------------------------------------------------------
 
 export function getExtraRewardsRewards(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     cvxCrvExtraRewards: Address;
     user: Address;
@@ -645,7 +645,7 @@ export function getExtraRewardsRewards(
 }
 
 export function getExtraRewardsRewardToken(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     cvxCrvExtraRewards: Address;
   }>,
@@ -663,7 +663,7 @@ export function getExtraRewardsRewardToken(
 //--------------------------------------------------------------------------------------------
 
 export async function getEstimateRewards(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     stakingWrapper: Address;
     beneficiary: Address;
@@ -693,7 +693,7 @@ export async function getEstimateRewards(
 }
 
 export function getAllEstimateRewards(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     stakingWrappers: ReadonlyArray<Address>;
     beneficiary: Address;

--- a/packages/sdk/src/Portfolio/Integrations/Curve.ts
+++ b/packages/sdk/src/Portfolio/Integrations/Curve.ts
@@ -1,8 +1,8 @@
 import {
   type Address,
+  type Client,
   ContractFunctionExecutionError,
   type Hex,
-  type PublicClient,
   decodeAbiParameters,
   encodeAbiParameters,
   isAddressEqual,
@@ -601,7 +601,7 @@ const erc20Abi = {
 const swapId = 2n; // id won't change, for swaps it will be always the same id in the registry
 
 export async function getBestPrice(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     incoming: Address;
     outgoing: Address;
@@ -620,7 +620,7 @@ export async function getBestPrice(
   const curveOutgoing = isAddressEqual(args.outgoing, args.weth) ? Constants.ETH_ADDRESS : args.outgoing;
   const curveIncoming = isAddressEqual(args.incoming, args.weth) ? Constants.ETH_ADDRESS : args.incoming;
 
-  const [bestPool, amountReceived] = await client.readContract({
+  const [bestPool, amountReceived] = await readContract(client, {
     abi: [curveSwapsAbi],
     address: curveSwaps,
     functionName: "get_best_rate",
@@ -632,7 +632,7 @@ export async function getBestPrice(
 
   try {
     // not all pools support this method, this is why we need to catch the error
-    const poolName = await client.readContract({
+    const poolName = await readContract(client, {
       abi: [erc20Abi],
       address: bestPool,
       functionName: "name",
@@ -665,7 +665,7 @@ const calcWithdrawOneCoinAbi = {
 } as const;
 
 export async function isSingleAssetRedemptionAllowed(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     pool: Address;
   }>,
@@ -692,7 +692,7 @@ export async function isSingleAssetRedemptionAllowed(
 }
 
 export async function getExpectedGaugeTokens(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     curvePool: Address;
     tokenAmounts: ReadonlyArray<bigint>;
@@ -746,7 +746,7 @@ const lpTokenAbi = [
 const balancesUint256Signature = "function balances(uint256 i) view returns(uint256)" as const;
 
 export async function getExpectedWithdrawalTokens(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     curvePool: Address;
     singleTokenIndex: bigint;
@@ -861,7 +861,7 @@ export async function getExpectedWithdrawalTokens(
 //--------------------------------------------------------------------------------------------
 
 export async function getClaimableTokens(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     curveGauge: Address;
     user: Address;
@@ -883,7 +883,7 @@ export async function getClaimableTokens(
 //--------------------------------------------------------------------------------------------
 
 export async function isAllowedToMintFor(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     curveMinter: Address;
     vault: Address;

--- a/packages/sdk/src/Portfolio/Integrations/Erc4626.ts
+++ b/packages/sdk/src/Portfolio/Integrations/Erc4626.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 import * as IntegrationManager from "../../_internal/IntegrationManager.js";
@@ -94,7 +94,7 @@ export function redeemDecode(encoded: Hex): RedeemArgs {
 //--------------------------------------------------------------------------------------------
 
 export function convertToAssets(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     erc4626Vault: Address;
     sharesAmount: bigint;
@@ -110,7 +110,7 @@ export function convertToAssets(
 }
 
 export function convertToShares(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     erc4626Vault: Address;
     assetAmount: bigint;
@@ -130,7 +130,7 @@ export function convertToShares(
 //--------------------------------------------------------------------------------------------
 
 export function getMakerDsr(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     asset: Address;
   }>,
@@ -148,7 +148,7 @@ export function getMakerDsr(
 //--------------------------------------------------------------------------------------------
 
 export function getMorphoPoolToken(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     asset: Address;
   }>,

--- a/packages/sdk/src/Portfolio/Integrations/IdleV4.ts
+++ b/packages/sdk/src/Portfolio/Integrations/IdleV4.ts
@@ -1,9 +1,9 @@
 import * as Abis from "@enzymefinance/abis";
 import {
   type Address,
+  type Client,
   ContractFunctionExecutionError,
   type Hex,
-  type PublicClient,
   decodeAbiParameters,
   encodeAbiParameters,
   parseAbi,
@@ -130,7 +130,7 @@ export function claimRewardsDecode(encoded: Hex): ClaimRewardsArgs {
 //--------------------------------------------------------------------------------------------
 
 export async function getRate(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     priceFeed: Address;
     poolToken: Address;
@@ -174,7 +174,7 @@ export async function getRate(
 //--------------------------------------------------------------------------------------------
 
 export async function getGovTokensAmounts(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     pool: Address;
     tokensOwner: Address;
@@ -216,7 +216,7 @@ export async function getGovTokensAmounts(
 }
 
 export function getSpeeds(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     idleController: Address;
     idlePool: Address;

--- a/packages/sdk/src/Portfolio/Integrations/Kiln.ts
+++ b/packages/sdk/src/Portfolio/Integrations/Kiln.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
 import { readContract } from "viem/actions";
 import { Assertion, Viem } from "../../Utils.js";
 import * as ExternalPositionManager from "../../_internal/ExternalPositionManager.js";
@@ -163,7 +163,7 @@ export function unstakeDecode(encoded: Hex): UnstakeArgs {
 //--------------------------------------------------------------------------------------------
 
 export function getCLFeeRecipient(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     kilnStaking: Address;
     validatorPublicKey: Hex;
@@ -179,7 +179,7 @@ export function getCLFeeRecipient(
 }
 
 export function getELFeeRecipient(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     kilnStaking: Address;
     validatorPublicKey: Hex;
@@ -195,7 +195,7 @@ export function getELFeeRecipient(
 }
 
 export function getGlobalFee(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     kilnStaking: Address;
   }>,

--- a/packages/sdk/src/Portfolio/Integrations/Lido.ts
+++ b/packages/sdk/src/Portfolio/Integrations/Lido.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 import * as ExternalPositionManager from "../../_internal/ExternalPositionManager.js";
@@ -122,7 +122,7 @@ const lidoWithdrawalsQueueAbi = [
 ] as const;
 
 export function getLastCheckpointIndex(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     lidoWithdrawalsQueue: Address;
   }>,
@@ -136,7 +136,7 @@ export function getLastCheckpointIndex(
 }
 
 export function findCheckpointHints(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     lidoWithdrawalsQueue: Address;
     requestIds: ReadonlyArray<bigint>;
@@ -154,7 +154,7 @@ export function findCheckpointHints(
 }
 
 export function getWithdrawalStatus(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     lidoWithdrawalsQueue: Address;
     requestIds: ReadonlyArray<bigint>;

--- a/packages/sdk/src/Portfolio/Integrations/Liquity.ts
+++ b/packages/sdk/src/Portfolio/Integrations/Liquity.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 import * as ExternalPositionManager from "../../_internal/ExternalPositionManager.js";
@@ -345,7 +345,7 @@ const troveManagerAbi = [
 ] as const;
 
 export async function getTrove(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     troveManager: Address;
     debtPosition: Address;
@@ -369,7 +369,7 @@ export async function getTrove(
 }
 
 export function getLusdGasCompensation(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     troveManager: Address;
   }>,
@@ -383,7 +383,7 @@ export function getLusdGasCompensation(
 }
 
 export function getBorrowingFeeWithDecay(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     troveManager: Address;
     lusdAmount: bigint;
@@ -453,7 +453,7 @@ const sortedTrovesAbi = [
 ] as const;
 
 export function getSortedTrovesSize(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     sortedTroves: Address;
   }>,
@@ -467,7 +467,7 @@ export function getSortedTrovesSize(
 }
 
 export async function findInsertPosition(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     sortedTroves: Address;
     nicr: bigint;
@@ -533,7 +533,7 @@ const hintHelpersAbi = [
 ] as const;
 
 export async function getApproxHint(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     hintHelpers: Address;
     nicr: bigint;
@@ -553,7 +553,7 @@ export async function getApproxHint(
 }
 
 export function getSurplusPoolCollaterall(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     collSurplusPool: Address;
     account: Address;

--- a/packages/sdk/src/Portfolio/Integrations/Maple.ts
+++ b/packages/sdk/src/Portfolio/Integrations/Maple.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 import * as ExternalPositionManager from "../../_internal/ExternalPositionManager.js";
@@ -190,7 +190,7 @@ export function claimRewardsV1Decode(encoded: Hex): ClaimRewardsV1Args {
 //--------------------------------------------------------------------------------------------
 
 export function getMaxDeposit(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     pool: Address;
     receiver: Address;
@@ -206,7 +206,7 @@ export function getMaxDeposit(
 }
 
 export function getTotalAssets(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     pool: Address;
   }>,
@@ -220,7 +220,7 @@ export function getTotalAssets(
 }
 
 export function getUnrealizedLosses(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     pool: Address;
   }>,
@@ -234,7 +234,7 @@ export function getUnrealizedLosses(
 }
 
 export function getSharesConvertedToExitAssets(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     pool: Address;
     shares: bigint;
@@ -254,7 +254,7 @@ export function getSharesConvertedToExitAssets(
 //--------------------------------------------------------------------------------------------
 
 export function getWithdrawalManager(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     poolManager: Address;
   }>,
@@ -272,7 +272,7 @@ export function getWithdrawalManager(
 //--------------------------------------------------------------------------------------------
 
 export function getLockedShares(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     withdrawalManager: Address;
     user: Address;
@@ -288,7 +288,7 @@ export function getLockedShares(
 }
 
 export function getCurrentCycleId(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     withdrawalManager: Address;
   }>,
@@ -302,7 +302,7 @@ export function getCurrentCycleId(
 }
 
 export async function getWindowAtId(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     withdrawalManager: Address;
     cycleId: bigint;
@@ -320,7 +320,7 @@ export async function getWindowAtId(
 }
 
 export function getExitCycleId(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     withdrawalManager: Address;
     user: Address;
@@ -336,7 +336,7 @@ export function getExitCycleId(
 }
 
 export async function getRedemptionPreview(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     withdrawalManager: Address;
     user: Address;

--- a/packages/sdk/src/Portfolio/Integrations/PendleV2.ts
+++ b/packages/sdk/src/Portfolio/Integrations/PendleV2.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
 import { readContract, simulateContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 import * as ExternalPositionManager from "../../_internal/ExternalPositionManager.js";
@@ -318,7 +318,7 @@ export function claimRewardsDecode(encoded: Hex): ClaimRewardsArgs {
 //--------------------------------------------------------------------------------------------
 
 export async function readTokensForMarket(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     pendleMarket: Address;
   }>,
@@ -334,7 +334,7 @@ export async function readTokensForMarket(
 }
 
 export function getRewardTokensForMarket(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     pendleMarket: Address;
   }>,
@@ -348,7 +348,7 @@ export function getRewardTokensForMarket(
 }
 
 export async function simulateRedeemRewardsForMarket(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     pendleMarket: Address;
     user: Address;
@@ -366,7 +366,7 @@ export async function simulateRedeemRewardsForMarket(
 }
 
 export async function getRewardsForMarket(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     pendleMarket: Address;
     user: Address;
@@ -381,7 +381,7 @@ export async function getRewardsForMarket(
 }
 
 export async function getOracleState(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     pendlePtLpOracle: Address;
     pendleMarket: Address;
@@ -402,7 +402,7 @@ export async function getOracleState(
 }
 
 export async function isDurationValid(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     pendlePtLpOracle: Address;
     pendleMarket: Address;
@@ -415,7 +415,7 @@ export async function isDurationValid(
 }
 
 export function getLpToAssetRate(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     pendlePtLpOracle: Address;
     pendleMarket: Address;
@@ -432,7 +432,7 @@ export function getLpToAssetRate(
 }
 
 export function getPtToAssetRate(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     pendlePtLpOracle: Address;
     pendleMarket: Address;
@@ -449,7 +449,7 @@ export function getPtToAssetRate(
 }
 
 export function getSyTokensIn(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     syToken: Address;
   }>,
@@ -463,7 +463,7 @@ export function getSyTokensIn(
 }
 
 export function getSyTokensOut(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     syToken: Address;
   }>,

--- a/packages/sdk/src/Portfolio/Integrations/StakeWiseV3.ts
+++ b/packages/sdk/src/Portfolio/Integrations/StakeWiseV3.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 import * as ExternalPositionManager from "../../_internal/ExternalPositionManager.js";
@@ -165,7 +165,7 @@ export function claimExitedAssetsDecode(encoded: Hex): ClaimExitedAssetsArgs {
 //--------------------------------------------------------------------------------------------
 
 export function convertSharesToAssets(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     sharesAmount: bigint;
     stakeWiseVault: Address;
@@ -181,7 +181,7 @@ export function convertSharesToAssets(
 }
 
 export function getVaultSharesBalance(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     account: Address;
     stakeWiseVault: Address;
@@ -197,7 +197,7 @@ export function getVaultSharesBalance(
 }
 
 export async function getStakedEthBalance(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     account: Address;
     stakeWiseVault: Address;
@@ -208,7 +208,7 @@ export async function getStakedEthBalance(
 }
 
 export function getStakePreview(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     account: Address;
     stakeWiseVault: Address;
@@ -225,7 +225,7 @@ export function getStakePreview(
 }
 
 export function getClaimExitedAssetsPreview(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     exitQueueIndex: bigint;
     positionTicket: bigint;
@@ -246,7 +246,7 @@ export function getClaimExitedAssetsPreview(
 }
 
 export function getExitQueueIndex(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     positionTicket: bigint;
     stakeWiseVault: Address;
@@ -262,7 +262,7 @@ export function getExitQueueIndex(
 }
 
 export function isCollateralized(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     keeperRewards: Address;
     stakeWiseVault: Address;
@@ -278,7 +278,7 @@ export function isCollateralized(
 }
 
 export function isHarvestRequired(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     keeperRewards: Address;
     stakeWiseVault: Address;

--- a/packages/sdk/src/Portfolio/Integrations/Swell.ts
+++ b/packages/sdk/src/Portfolio/Integrations/Swell.ts
@@ -1,4 +1,4 @@
-import { type Address, type PublicClient, parseAbi } from "viem";
+import { type Address, type Client, parseAbi } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 
@@ -7,7 +7,7 @@ import { Viem } from "../../Utils.js";
 //--------------------------------------------------------------------------------------------
 
 export function ethToSwETHRate(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     swethAddress: Address;
   }>,

--- a/packages/sdk/src/Portfolio/Integrations/TheGraph.ts
+++ b/packages/sdk/src/Portfolio/Integrations/TheGraph.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 import * as ExternalPositionManager from "../../_internal/ExternalPositionManager.js";
@@ -123,7 +123,7 @@ export function withdrawDecode(encoded: Hex): WithdrawArgs {
 //--------------------------------------------------------------------------------------------
 
 export async function getDelegationPool(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     stakingContract: Address;
     indexer: Address;
@@ -143,7 +143,7 @@ export async function getDelegationPool(
 }
 
 export function getDelegationTaxPercentage(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     stakingContract: Address;
   }>,
@@ -157,7 +157,7 @@ export function getDelegationTaxPercentage(
 }
 
 export function getCurrentEpoch(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     epochManager: Address;
   }>,

--- a/packages/sdk/src/Portfolio/Integrations/UniswapV2.ts
+++ b/packages/sdk/src/Portfolio/Integrations/UniswapV2.ts
@@ -1,9 +1,9 @@
 import * as Abis from "@enzymefinance/abis";
 import {
   type Address,
+  type Client,
   ContractFunctionExecutionError,
   type Hex,
-  type PublicClient,
   decodeAbiParameters,
   encodeAbiParameters,
   isAddressEqual,
@@ -223,7 +223,7 @@ const uniswapV2FactoryAbi = [
 ] as const;
 
 export async function getLendRate(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     asset: Address;
     amount: bigint;
@@ -271,7 +271,7 @@ export async function getLendRate(
 }
 
 export async function getPairData(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     token0: Address;
     token1: Address;
@@ -285,7 +285,7 @@ export async function getPairData(
     args: [args.token0, args.token1],
   });
 
-  const [reserve0, reserve1] = await client.readContract({
+  const [reserve0, reserve1] = await readContract(client, {
     abi: uniswapV2PoolAbi,
     functionName: "getReserves",
     address: pairAddress,
@@ -305,7 +305,7 @@ export async function getPairData(
 }
 
 export async function getSwapRedeemRate(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     poolValue: {
       token: Address;
@@ -339,12 +339,12 @@ export async function getSwapRedeemRate(
   } catch (error) {
     if (error instanceof ContractFunctionExecutionError) {
       const [poolTokensSupply, [reserve0, reserve1]] = await Promise.all([
-        client.readContract({
+        readContract(client, {
           abi: uniswapV2PoolAbi,
           functionName: "totalSupply",
           address: args.poolValue.token,
         }),
-        client.readContract({
+        readContract(client, {
           abi: uniswapV2PoolAbi,
           functionName: "getReserves",
           address: args.poolValue.token,

--- a/packages/sdk/src/Portfolio/Integrations/UniswapV3.ts
+++ b/packages/sdk/src/Portfolio/Integrations/UniswapV3.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
 import { readContract, simulateContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 import * as ExternalPositionManager from "../../_internal/ExternalPositionManager.js";
@@ -407,7 +407,7 @@ const v3PoolAbi = [
 ] as const;
 
 export async function getSlot0(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     pool: Address;
   }>,
@@ -439,7 +439,7 @@ export async function getSlot0(
 }
 
 export function getLiquidity(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     pool: Address;
   }>,
@@ -513,7 +513,7 @@ export interface CollectParams {
 }
 
 export async function getPendingFees(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     nonFungiblePositionManager: Address;
     params: CollectParams;
@@ -540,7 +540,7 @@ export async function getPendingFees(
 }
 
 export function getPool(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     factory: Address;
     tokenA: Address;

--- a/packages/sdk/src/Portfolio/Integrations/YearnV2.ts
+++ b/packages/sdk/src/Portfolio/Integrations/YearnV2.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 import * as IntegrationManager from "../../_internal/IntegrationManager.js";
@@ -101,7 +101,7 @@ export function redeemDecode(encoded: Hex): RedeemArgs {
 //--------------------------------------------------------------------------------------------
 
 export function pricePerShare(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     yearnVault: Address;
   }>,

--- a/packages/sdk/src/Portfolio/Integrations/ZeroExV2.ts
+++ b/packages/sdk/src/Portfolio/Integrations/ZeroExV2.ts
@@ -1,9 +1,9 @@
-import { type Address, type PublicClient, parseAbi } from "viem";
+import { type Address, type Client, parseAbi } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 
 export function getZeroExV2Exchange(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     zeroExV2Adapter: Address;
   }>,
@@ -17,7 +17,7 @@ export function getZeroExV2Exchange(
 }
 
 export function isAllowedMaker(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     zeroExV2Adapter: Address;
     who: Address;

--- a/packages/sdk/src/Portfolio/Integrations/ZeroExV4.ts
+++ b/packages/sdk/src/Portfolio/Integrations/ZeroExV4.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, type PublicClient, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters, parseAbi } from "viem";
 import { readContract } from "viem/actions";
 import { Assertion, Viem } from "../../Utils.js";
 import * as IntegrationManager from "../../_internal/IntegrationManager.js";
@@ -360,7 +360,7 @@ export function takeOrderDecode(encoded: Hex): TakeOrderArgs {
 }
 
 export function isAllowedMaker(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     zeroExV4Adapter: Address;
     who: Address;

--- a/packages/sdk/src/Portfolio/VoteDelegation.ts
+++ b/packages/sdk/src/Portfolio/VoteDelegation.ts
@@ -1,4 +1,4 @@
-import type { Address, PublicClient } from "viem";
+import type { Address, Client } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../Utils.js";
 
@@ -54,7 +54,7 @@ const tokenDaoDelegateeByTypeAbi = {
 } as const;
 
 export async function getDelegatees(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
   }>,

--- a/packages/sdk/src/Relayer.ts
+++ b/packages/sdk/src/Relayer.ts
@@ -1,13 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import {
-  type Address,
-  type Hex,
-  type PublicClient,
-  encodeFunctionData,
-  isAddressEqual,
-  parseAbi,
-  zeroAddress,
-} from "viem";
+import { type Address, type Client, type Hex, encodeFunctionData, isAddressEqual, parseAbi, zeroAddress } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "./Utils.js";
 
@@ -127,7 +119,7 @@ export function shutdownGasRelayPaymaster(args: {
 //--------------------------------------------------------------------------------------------
 
 export async function isRelayerEnabled(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     comptrollerProxy: Address;
   }>,
@@ -143,7 +135,7 @@ export async function isRelayerEnabled(
 }
 
 export function getGasRelayPaymaster(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     comptrollerProxy: Address;
   }>,
@@ -157,7 +149,7 @@ export function getGasRelayPaymaster(
 }
 
 export function getRelayerBalance(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     gasRelayPaymaster: Address;
   }>,
@@ -171,7 +163,7 @@ export function getRelayerBalance(
 }
 
 export function getTrustedForwarder(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     gasRelayPaymaster: Address;
   }>,
@@ -185,7 +177,7 @@ export function getTrustedForwarder(
 }
 
 export function getNonce(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     trustedForwarder: Address;
     sender: Address;

--- a/packages/sdk/src/Tools/GatedRedemptionQueueSharesWrapper.ts
+++ b/packages/sdk/src/Tools/GatedRedemptionQueueSharesWrapper.ts
@@ -1,5 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import type { Address, PublicClient } from "viem";
+import type { Address, Client } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../Utils.js";
 
@@ -253,7 +253,7 @@ export function setRedemptionAsset(args: {
 //--------------------------------------------------------------------------------------------
 
 export function getDepositQueueUser(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     sharesWrapper: Address;
     depositAsset: Address;
@@ -270,7 +270,7 @@ export function getDepositQueueUser(
 }
 
 export function getRedemptionQueueUsers(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     sharesWrapperId: Address;
   }>,
@@ -284,7 +284,7 @@ export function getRedemptionQueueUsers(
 }
 
 export function getRedemptionQueueUsersLength(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     sharesWrapperId: Address;
   }>,

--- a/packages/sdk/src/Tools/SharesSplitter.ts
+++ b/packages/sdk/src/Tools/SharesSplitter.ts
@@ -1,5 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import type { Address, PublicClient } from "viem";
+import type { Address, Client } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../Utils.js";
 
@@ -37,7 +37,7 @@ export function claimToken(args: {
 //--------------------------------------------------------------------------------------------
 
 export function getClaimableTokenBalance(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     splitter: Address;
     token: Address;

--- a/packages/sdk/src/Tools/SingleAssetRedemptionQueue.ts
+++ b/packages/sdk/src/Tools/SingleAssetRedemptionQueue.ts
@@ -1,5 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import type { Address, PublicClient } from "viem";
+import type { Address, Client } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../Utils.js";
 
@@ -134,7 +134,7 @@ export function shutdown(args: {
 //--------------------------------------------------------------------------------------------
 
 export function getBypassableSharesThreshold(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     redemptionQueue: Address;
   }>,
@@ -148,7 +148,7 @@ export function getBypassableSharesThreshold(
 }
 
 export function getNextNewId(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     redemptionQueue: Address;
   }>,
@@ -162,7 +162,7 @@ export function getNextNewId(
 }
 
 export function getNextQueuedId(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     redemptionQueue: Address;
   }>,
@@ -176,7 +176,7 @@ export function getNextQueuedId(
 }
 
 export function getRedemptionAsset(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     redemptionQueue: Address;
   }>,
@@ -190,7 +190,7 @@ export function getRedemptionAsset(
 }
 
 export function getSharesForRequest(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     redemptionQueue: Address;
     requestId: bigint;
@@ -206,7 +206,7 @@ export function getSharesForRequest(
 }
 
 export function getUserForRequest(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     redemptionQueue: Address;
     requestId: bigint;
@@ -222,7 +222,7 @@ export function getUserForRequest(
 }
 
 export function getVaultProxy(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     redemptionQueue: Address;
   }>,
@@ -236,7 +236,7 @@ export function getVaultProxy(
 }
 
 export function isManager(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     redemptionQueue: Address;
     user: Address;
@@ -252,7 +252,7 @@ export function isManager(
 }
 
 export function queueIsShutdown(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     redemptionQueue: Address;
   }>,

--- a/packages/sdk/src/Utils/viem.ts
+++ b/packages/sdk/src/Utils/viem.ts
@@ -6,15 +6,16 @@ import type {
   BlockTag,
   CallParameters,
   Chain,
+  Client,
   ContractFunctionName,
   ContractFunctionParameters,
   EstimateContractGasReturnType,
   EstimateGasParameters,
   GetValue,
   Hex,
-  PublicClient,
   SimulateContractReturnType,
 } from "viem";
+import { estimateContractGas, simulateContract } from "viem/actions";
 
 export type PopulatedTransactionParams<
   TAbi extends Abi,
@@ -45,10 +46,10 @@ export class PopulatedTransaction<
   constructor(public readonly params: PopulatedTransactionParams<TAbi, TFunctionName>) {}
 
   simulate(
-    client: PublicClient,
+    client: Client,
     args: PopulatedTransactionSimulateParams,
   ): Promise<SimulateContractReturnType<TAbi, TFunctionName>> {
-    return client.simulateContract({
+    return simulateContract(client, {
       ...args,
       abi: this.params.abi,
       functionName: this.params.functionName,
@@ -58,8 +59,8 @@ export class PopulatedTransaction<
     } as any);
   }
 
-  estimate(client: PublicClient, args: PopulatedTransactionEstimateParams): Promise<EstimateContractGasReturnType> {
-    return client.estimateContractGas({
+  estimate(client: Client, args: PopulatedTransactionEstimateParams): Promise<EstimateContractGasReturnType> {
+    return estimateContractGas(client, {
       ...args,
       abi: this.params.abi,
       functionName: this.params.functionName,

--- a/packages/sdk/src/Vault.ts
+++ b/packages/sdk/src/Vault.ts
@@ -1,5 +1,5 @@
 import * as Abis from "@enzymefinance/abis";
-import type { Address, PublicClient } from "viem";
+import type { Address, Client } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "./Utils.js";
 
@@ -102,7 +102,7 @@ export function setSymbol(args: SetSymbolParams) {
 //--------------------------------------------------------------------------------------------
 
 export function getName(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
   }>,
@@ -116,7 +116,7 @@ export function getName(
 }
 
 export function getSymbol(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
   }>,
@@ -130,7 +130,7 @@ export function getSymbol(
 }
 
 export function getOwner(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
   }>,
@@ -144,7 +144,7 @@ export function getOwner(
 }
 
 export function getNominatedOwner(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vault: Address;
   }>,
@@ -158,7 +158,7 @@ export function getNominatedOwner(
 }
 
 export function getDenominationAsset(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     comptrollerProxy: Address;
   }>,
@@ -172,7 +172,7 @@ export function getDenominationAsset(
 }
 
 export function getComptrollerProxy(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
   }>,
@@ -186,7 +186,7 @@ export function getComptrollerProxy(
 }
 
 export function getPolicyManager(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     comptrollerProxy: Address;
   }>,
@@ -200,7 +200,7 @@ export function getPolicyManager(
 }
 
 export function getFeeManager(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     comptrollerProxy: Address;
   }>,
@@ -214,7 +214,7 @@ export function getFeeManager(
 }
 
 export function sharesAreFreelyTransferable(
-  client: PublicClient,
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
   }>,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates client types in multiple files to use `Client` instead of `PublicClient`.

### Detailed summary
- Updated client type from `PublicClient` to `Client` in various functions
- Replaced `PublicClient` imports with `Client` in multiple files

> The following files were skipped due to too many changes: `packages/sdk/src/Portfolio/Integrations/Lido.ts`, `packages/sdk/src/Portfolio/Integrations/IdleV4.ts`, `packages/sdk/src/Portfolio/Integrations/Kiln.ts`, `packages/sdk/src/Portfolio/Integrations/TheGraph.ts`, `packages/sdk/src/Configuration.ts`, `packages/sdk/src/Portfolio/Integrations/Alice.ts`, `packages/sdk/src/Portfolio/Integrations/UniswapV3.ts`, `packages/sdk/src/Portfolio/Integrations/BalancerV2.ts`, `packages/sdk/src/Utils/viem.ts`, `packages/sdk/src/Portfolio/Integrations/CompoundV3.ts`, `packages/sdk/src/Configuration/ProtocolFee.ts`, `packages/sdk/src/Portfolio/Integrations/ArrakisV2.ts`, `packages/sdk/src/Portfolio/Integrations/Erc4626.ts`, `packages/sdk/src/Configuration/Policy.ts`, `packages/sdk/src/Relayer.ts`, `packages/sdk/src/Portfolio/Integrations/UniswapV2.ts`, `packages/sdk/src/LifeCycle.ts`, `packages/sdk/src/Portfolio/Integrations/Liquity.ts`, `packages/sdk/src/Performance.ts`, `packages/sdk/src/Vault.ts`, `packages/sdk/src/Tools/SingleAssetRedemptionQueue.ts`, `packages/sdk/src/Portfolio/Integrations/StakeWiseV3.ts`, `packages/sdk/src/Asset.ts`, `packages/sdk/src/Depositor.ts`, `packages/sdk/src/Portfolio.ts`, `packages/sdk/src/Portfolio/Integrations/PendleV2.ts`, `packages/sdk/src/Portfolio/Integrations/Curve.ts`, `packages/sdk/src/Portfolio/Integrations/Maple.ts`, `packages/sdk/src/Portfolio/Integrations/CompoundV2.ts`, `packages/sdk/src/Portfolio/Integrations/Convex.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->