### PR TITLE
fix: alice arg ordering

### DIFF
--- a/.changeset/itchy-ants-walk.md
+++ b/.changeset/itchy-ants-walk.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Fix alice arg ordering

--- a/packages/environment/package.json
+++ b/packages/environment/package.json
@@ -34,11 +34,7 @@
   },
   "effect": {
     "generateExports": {
-      "include": [
-        "*.ts",
-        "assets/*.ts",
-        "deployments/*.ts"
-      ]
+      "include": ["*.ts", "assets/*.ts", "deployments/*.ts"]
     }
   }
 }

--- a/packages/sdk/src/Portfolio/Integrations/Alice.ts
+++ b/packages/sdk/src/Portfolio/Integrations/Alice.ts
@@ -48,19 +48,19 @@ export function placeOrderEncode(args: PlaceOrderArgs): Hex {
   return encodeAbiParameters(placeOrderEncoding, [
     args.instrumentId,
     args.isBuyOrder,
-    args.limitAmountToGet,
     args.quantityToSell,
+    args.limitAmountToGet,
   ]);
 }
 
 export function placeOrderDecode(encoded: Hex): PlaceOrderArgs {
-  const [instrumentId, isBuyOrder, limitAmountToGet, quantityToSell] = decodeAbiParameters(placeOrderEncoding, encoded);
+  const [instrumentId, isBuyOrder,  quantityToSell, limitAmountToGet] = decodeAbiParameters(placeOrderEncoding, encoded);
 
   return {
     instrumentId,
     isBuyOrder,
-    limitAmountToGet,
     quantityToSell,
+    limitAmountToGet,
   };
 }
 

--- a/packages/sdk/src/Portfolio/Integrations/Alice.ts
+++ b/packages/sdk/src/Portfolio/Integrations/Alice.ts
@@ -54,7 +54,7 @@ export function placeOrderEncode(args: PlaceOrderArgs): Hex {
 }
 
 export function placeOrderDecode(encoded: Hex): PlaceOrderArgs {
-  const [instrumentId, isBuyOrder,  quantityToSell, limitAmountToGet] = decodeAbiParameters(placeOrderEncoding, encoded);
+  const [instrumentId, isBuyOrder, quantityToSell, limitAmountToGet] = decodeAbiParameters(placeOrderEncoding, encoded);
 
   return {
     instrumentId,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is fixing the `args` argument ordering in the `Alice.ts` file and adjusting the `generateExports` include list. 

### Detailed summary
- Fixed `args` argument ordering in `Alice.ts`
- Adjusted `generateExports` include list in `package.json`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->