### PR TITLE
fix: alice sweep args

### DIFF
--- a/.changeset/seven-comics-change.md
+++ b/.changeset/seven-comics-change.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Update sweep encoding to use a tuple"

--- a/packages/sdk/src/Portfolio/Integrations/Alice.ts
+++ b/packages/sdk/src/Portfolio/Integrations/Alice.ts
@@ -139,15 +139,15 @@ export function refundOrderDecode(encoded: Hex): RefundOrderArgs {
 
 export const sweep = ExternalPositionManager.makeUse(Action.Sweep, sweepEncode);
 
-
 const sweepEncoding = [
   {
-    type: 'tuple',
+    type: "tuple",
     components: [
       {
-    type: "uint256[]",
-    name: "orderIds",
-      }]
+        type: "uint256[]",
+        name: "orderIds",
+      },
+    ],
   },
 ] as const;
 
@@ -156,11 +156,11 @@ export type SweepArgs = {
 };
 
 export function sweepEncode(args: SweepArgs): Hex {
-  return encodeAbiParameters(sweepEncoding, [{orderIds: args.orderIds}]);
+  return encodeAbiParameters(sweepEncoding, [{ orderIds: args.orderIds }]);
 }
 
 export function sweepDecode(encoded: Hex): SweepArgs {
-  const [{orderIds}] = decodeAbiParameters(sweepEncoding, encoded);
+  const [{ orderIds }] = decodeAbiParameters(sweepEncoding, encoded);
 
   return {
     orderIds,

--- a/packages/sdk/src/Portfolio/Integrations/Alice.ts
+++ b/packages/sdk/src/Portfolio/Integrations/Alice.ts
@@ -139,26 +139,31 @@ export function refundOrderDecode(encoded: Hex): RefundOrderArgs {
 
 export const sweep = ExternalPositionManager.makeUse(Action.Sweep, sweepEncode);
 
+
 const sweepEncoding = [
   {
+    type: 'tuple',
+    components: [
+      {
     type: "uint256[]",
     name: "orderIds",
+      }]
   },
 ] as const;
 
 export type SweepArgs = {
-  orderIds: Array<bigint>;
+  orderIds: ReadonlyArray<bigint>;
 };
 
 export function sweepEncode(args: SweepArgs): Hex {
-  return encodeAbiParameters(sweepEncoding, [args.orderIds]);
+  return encodeAbiParameters(sweepEncoding, [{orderIds: args.orderIds}]);
 }
 
 export function sweepDecode(encoded: Hex): SweepArgs {
-  const [orderIds] = decodeAbiParameters(sweepEncoding, encoded);
+  const [{orderIds}] = decodeAbiParameters(sweepEncoding, encoded);
 
   return {
-    orderIds: [...orderIds],
+    orderIds,
   };
 }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the sweep encoding in `@enzymefinance/sdk` to use a tuple structure for better organization and readability.

### Detailed summary
- Updated sweep encoding to use a tuple structure for `orderIds`
- Changed `SweepArgs` type to use `ReadonlyArray<bigint>`
- Modified `sweepEncode` and `sweepDecode` functions to work with tuple-encoded `orderIds`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->