### PR TITLE
feat: re-register wstETH as a primitive asset on Ethereum

### DIFF
--- a/.changeset/tidy-papayas-argue.md
+++ b/.changeset/tidy-papayas-argue.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Reregister wstETH as a primitive on Ethereum

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -2541,8 +2541,9 @@ export default defineAssetList(Network.ETHEREUM, [
     symbol: "wstETH",
     type: AssetType.PRIMITIVE,
     priceFeed: {
-      type: PriceFeedType.DERIVATIVE_WSTETH,
-      address: "0x50da4957032c8fc5f94ec8d5ec8bfce84f9c9311",
+      type: PriceFeedType.PRIMITIVE_CHAINLINK,
+      aggregator: "0x92829c41115311ca43d5c9f722f0e9e7b9fcd30a",
+      rateAsset: RateAsset.ETH,
     },
   },
   {

--- a/packages/environment/src/contracts.ts
+++ b/packages/environment/src/contracts.ts
@@ -64,6 +64,7 @@ export interface SuluContracts extends CommonContracts {
   readonly BalancerV2LiquidityAdapter: Address;
   readonly BalancerV2StablePoolPriceFeed: Address;
   readonly BalancerV2WeightedPoolPriceFeed: Address;
+  readonly ChainlinkLikeWstethPriceFeed: Address;
   readonly CompoundAdapter: Address;
   readonly CompoundDebtPositionLib: Address;
   readonly CompoundDebtPositionParser: Address;

--- a/packages/environment/src/deployments/arbitrum.ts
+++ b/packages/environment/src/deployments/arbitrum.ts
@@ -107,6 +107,7 @@ export default defineDeployment<Deployment.ARBITRUM>({
         BalancerV2LiquidityAdapter: "0xb3ea1f2f3d2cdbd81a3de91fdf9a2f3e3acd66c1",
         BalancerV2StablePoolPriceFeed: "0x8f30c0483c1cd32c100462f1af6d4ae6283086a9",
         BalancerV2WeightedPoolPriceFeed: "0xa95878965f3af1d88002e06ae25182a45943b9e2",
+        ChainlinkLikeWstethPriceFeed: "0x0000000000000000000000000000000000000000",
         CompoundAdapter: "0x0000000000000000000000000000000000000000",
         CompoundDebtPositionLib: "0x0000000000000000000000000000000000000000",
         CompoundDebtPositionParser: "0x0000000000000000000000000000000000000000",

--- a/packages/environment/src/deployments/ethereum.ts
+++ b/packages/environment/src/deployments/ethereum.ts
@@ -124,6 +124,7 @@ export default defineDeployment<Deployment.ETHEREUM>({
         BalancerV2LiquidityAdapter: "0xab5da4aa08b56c7e5a9d5d8a5ff19cf09a88c305",
         BalancerV2StablePoolPriceFeed: "0x438254d66e2bc576819a76a0ecb11fe41195d39f",
         BalancerV2WeightedPoolPriceFeed: "0x083b8f465bba2bb274e48387e3f9c56323341286",
+        ChainlinkLikeWstethPriceFeed: "0x92829c41115311ca43d5c9f722f0e9e7b9fcd30a",
         CompoundAdapter: "0x6ce8095a692aff6698c3aa8593be3976b6b8743d",
         CompoundDebtPositionLib: "0xc8e0c169dae4cdfd2f51e7494d2b5459f9314ee9",
         CompoundDebtPositionParser: "0x8bfbd013020c4d26d043183eff600ea3b36b4afb",

--- a/packages/environment/src/deployments/polygon.ts
+++ b/packages/environment/src/deployments/polygon.ts
@@ -111,6 +111,7 @@ export default defineDeployment<Deployment.POLYGON>({
         BalancerV2LiquidityAdapter: "0xaa7f7b3daaabdeaf828f4c489379160b034d125b",
         BalancerV2StablePoolPriceFeed: "0xea9cf93260aee30a5c4fd892607920bbbeb8c409",
         BalancerV2WeightedPoolPriceFeed: "0x30ee2560675f8a523cd07b109fcb472a54b08314",
+        ChainlinkLikeWstethPriceFeed: "0x0000000000000000000000000000000000000000",
         CompoundAdapter: "0x0000000000000000000000000000000000000000",
         CompoundDebtPositionLib: "0x0000000000000000000000000000000000000000",
         CompoundDebtPositionParser: "0x0000000000000000000000000000000000000000",

--- a/packages/environment/src/deployments/testnet.ts
+++ b/packages/environment/src/deployments/testnet.ts
@@ -54,6 +54,7 @@ export default defineDeployment<Deployment.TESTNET>({
         BalancerV2LiquidityAdapter: "0x8ffe411488c2d2c55acbea7d1feab7beb5881605",
         BalancerV2StablePoolPriceFeed: "0xbbd3cc67c7f90f3fa546c62d13db59e3fd11eb36",
         BalancerV2WeightedPoolPriceFeed: "0xfd63783414032e146842e191d2568329a91b3aae",
+        ChainlinkLikeWstethPriceFeed: "0x0000000000000000000000000000000000000000",
         CompoundAdapter: "0x0000000000000000000000000000000000000000",
         CompoundDebtPositionLib: "0x0000000000000000000000000000000000000000",
         CompoundDebtPositionParser: "0x0000000000000000000000000000000000000000",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the environment package to reregister `wstETH` as a primitive asset on Ethereum.

### Detailed summary
- Reregisters `wstETH` as a primitive asset on Ethereum
- Changes `PriceFeedType` to `PRIMITIVE_CHAINLINK`
- Updates addresses for various assets and price feeds across different networks

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->