### PR TITLE
feat: add wif and pepe to arbitrum

### DIFF
--- a/.changeset/pink-lizards-invite.md
+++ b/.changeset/pink-lizards-invite.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Add WIF and Pepe to Arbitrum

--- a/packages/environment/src/assets/arbitrum.ts
+++ b/packages/environment/src/assets/arbitrum.ts
@@ -695,4 +695,26 @@ export default defineAssetList(Network.ARBITRUM, [
       rateAsset: RateAsset.USD,
     },
   },
+  {
+    decimals: 6,
+    id: "0xa1b91fe9fd52141ff8cac388ce3f10bfdc1de79d",
+    name: "dogwifhat",
+    releases: [],
+    symbol: "$WIF",
+    type: AssetType.PRIMITIVE,
+    priceFeed: {
+      type: PriceFeedType.NONE,
+    },
+  },
+  {
+    decimals: 18,
+    id: "0x25d887ce7a35172c62febfd67a1856f20faebb00",
+    name: "Pepe",
+    releases: [],
+    symbol: "PEPE",
+    type: AssetType.PRIMITIVE,
+    priceFeed: {
+      type: PriceFeedType.NONE,
+    },
+  },
 ]);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds WIF and Pepe assets to the Arbitrum environment in `@enzymefinance/environment`.

### Detailed summary
- Added `dogwifhat` asset with symbol $WIF and id "0xa1b91fe9fd52141ff8cac388ce3f10bfdc1de79d"
- Added `Pepe` asset with symbol PEPE and id "0x25d887ce7a35172c62febfd67a1856f20faebb00"
- Both assets have type AssetType.PRIMITIVE and price feed type PriceFeedType.NONE

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->