### PR TITLE
feat: add Aave v3 getUserAccountData

### DIFF
--- a/.changeset/hungry-emus-report.md
+++ b/.changeset/hungry-emus-report.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Aave v3 getUserAccountData

--- a/packages/sdk/src/Portfolio/Integrations/AaveV3.ts
+++ b/packages/sdk/src/Portfolio/Integrations/AaveV3.ts
@@ -360,6 +360,20 @@ const poolAbi = [
     stateMutability: "view",
     type: "function",
   },
+  {
+    inputs: [{ internalType: "address", name: "user", type: "address" }],
+    name: "getUserAccountData",
+    outputs: [
+      { internalType: "uint256", name: "totalCollateralBase", type: "uint256" },
+      { internalType: "uint256", name: "totalDebtBase", type: "uint256" },
+      { internalType: "uint256", name: "availableBorrowsBase", type: "uint256" },
+      { internalType: "uint256", name: "currentLiquidationThreshold", type: "uint256" },
+      { internalType: "uint256", name: "ltv", type: "uint256" },
+      { internalType: "uint256", name: "healthFactor", type: "uint256" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
 ] as const;
 
 export function getEModeCategoryData(
@@ -376,4 +390,23 @@ export function getEModeCategoryData(
     address: args.pool,
     args: [args.categoryId],
   });
+}
+
+export async function getUserAccountData(
+  client: Client,
+  args: Viem.ContractCallParameters<{
+    pool: Address;
+    user: Address;
+  }>,
+) {
+  const [availableBorrowsBase, currentLiquidationThreshold, healthFactor, ltv, totalCollateralBase, totalDebtBase] =
+    await readContract(client, {
+      ...Viem.extractBlockParameters(args),
+      abi: poolAbi,
+      functionName: "getUserAccountData",
+      address: args.pool,
+      args: [args.user],
+    });
+
+  return { availableBorrowsBase, currentLiquidationThreshold, healthFactor, ltv, totalCollateralBase, totalDebtBase };
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new function `getUserAccountData` in the `AaveV3.ts` file, allowing users to retrieve specific account data related to Aave V3's lending and borrowing functionalities.

### Detailed summary
- Added a new function `getUserAccountData` to `packages/sdk/src/Portfolio/Integrations/AaveV3.ts`.
- The function retrieves:
  - `availableBorrowsBase`
  - `currentLiquidationThreshold`
  - `healthFactor`
  - `ltv`
  - `totalCollateralBase`
  - `totalDebtBase`
- The function is asynchronous and utilizes `readContract`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->