### PR TITLE
feat: add various Aave v3 read functions

### DIFF
--- a/.changeset/twelve-maps-camp.md
+++ b/.changeset/twelve-maps-camp.md
@@ -1,0 +1,6 @@
+---
+"@enzymefinance/environment": patch
+"@enzymefinance/sdk": patch
+---
+
+Add various Aave v3 read functions

--- a/packages/environment/src/deployments/arbitrum.ts
+++ b/packages/environment/src/deployments/arbitrum.ts
@@ -9,7 +9,7 @@ export default defineDeployment<Deployment.ARBITRUM>({
   externalContracts: {
     aaveV2IncentivesController: "0x0000000000000000000000000000000000000000",
     aaveV2LendingPoolProvider: "0x0000000000000000000000000000000000000000",
-    aaveV3IncentivesController: "0x929ec64c34a17401f460460d4b9390518e5b473e",
+    aaveV3RewardsController: "0x929ec64c34a17401f460460d4b9390518e5b473e",
     aaveV3LendingPoolProvider: "0xa97684ead0e402dc232d5a977953df7ecbab3cdb",
     aaveV3ProtocolDataProvider: "0x69fa688f1dc47d4b5d8029d5a35fb7a548310654",
     aliceOrderManager: "0x0000000000000000000000000000000000000000",

--- a/packages/environment/src/deployments/arbitrum.ts
+++ b/packages/environment/src/deployments/arbitrum.ts
@@ -9,7 +9,9 @@ export default defineDeployment<Deployment.ARBITRUM>({
   externalContracts: {
     aaveV2IncentivesController: "0x0000000000000000000000000000000000000000",
     aaveV2LendingPoolProvider: "0x0000000000000000000000000000000000000000",
+    aaveV3IncentivesController: "0x929ec64c34a17401f460460d4b9390518e5b473e",
     aaveV3LendingPoolProvider: "0xa97684ead0e402dc232d5a977953df7ecbab3cdb",
+    aaveV3ProtocolDataProvider: "0x69fa688f1dc47d4b5d8029d5a35fb7a548310654",
     aliceOrderManager: "0x0000000000000000000000000000000000000000",
     arrakisV2Helper: "0x0000000000000000000000000000000000000000",
     arrakisV2Resolver: "0x0000000000000000000000000000000000000000",

--- a/packages/environment/src/deployments/ethereum.ts
+++ b/packages/environment/src/deployments/ethereum.ts
@@ -9,7 +9,9 @@ export default defineDeployment<Deployment.ETHEREUM>({
   externalContracts: {
     aaveV2IncentivesController: "0xd784927ff2f95ba542bfc824c8a8a98f3495f6b5",
     aaveV2LendingPoolProvider: "0xb53c1a33016b2dc2ff3653530bff1848a515c8c5",
+    aaveV3IncentivesController: "0x8164cc65827dcfe994ab23944cbc90e0aa80bfcb",
     aaveV3LendingPoolProvider: "0x2f39d218133afab8f2b819b1066c7e434ad94e9e",
+    aaveV3ProtocolDataProvider: "0x7b4eb56e7cd4b454ba8ff71e4518426369a138a3",
     aliceOrderManager: "0x841473a19279e54a850e9083a3a57de9e6244d2e",
     arrakisV2Helper: "0x89e4be1f999e3a58d16096fbe405fc2a1d7f07d6",
     arrakisV2Resolver: "0x535c5fdf31477f799366df6e4899a12a801cc7b8",

--- a/packages/environment/src/deployments/ethereum.ts
+++ b/packages/environment/src/deployments/ethereum.ts
@@ -9,7 +9,7 @@ export default defineDeployment<Deployment.ETHEREUM>({
   externalContracts: {
     aaveV2IncentivesController: "0xd784927ff2f95ba542bfc824c8a8a98f3495f6b5",
     aaveV2LendingPoolProvider: "0xb53c1a33016b2dc2ff3653530bff1848a515c8c5",
-    aaveV3IncentivesController: "0x8164cc65827dcfe994ab23944cbc90e0aa80bfcb",
+    aaveV3RewardsController: "0x8164cc65827dcfe994ab23944cbc90e0aa80bfcb",
     aaveV3LendingPoolProvider: "0x2f39d218133afab8f2b819b1066c7e434ad94e9e",
     aaveV3ProtocolDataProvider: "0x7b4eb56e7cd4b454ba8ff71e4518426369a138a3",
     aliceOrderManager: "0x841473a19279e54a850e9083a3a57de9e6244d2e",

--- a/packages/environment/src/deployments/polygon.ts
+++ b/packages/environment/src/deployments/polygon.ts
@@ -11,7 +11,7 @@ export default defineDeployment<Deployment.POLYGON>({
     aaveV2LendingPoolProvider: "0xd05e3e715d945b59290df0ae8ef85c1bdb684744",
     aaveV3IncentivesController: "0x929ec64c34a17401f460460d4b9390518e5b473e",
     aaveV3LendingPoolProvider: "0xa97684ead0e402dc232d5a977953df7ecbab3cdb",
-    aaveV3ProtocolDataProvider: "0x0000000000000000000000000000000000000000",
+    aaveV3ProtocolDataProvider: "0x69fa688f1dc47d4b5d8029d5a35fb7a548310654",
     aliceOrderManager: "0x0000000000000000000000000000000000000000",
     arrakisV2Helper: "0x89e4be1f999e3a58d16096fbe405fc2a1d7f07d6",
     arrakisV2Resolver: "0x535c5fdf31477f799366df6e4899a12a801cc7b8",

--- a/packages/environment/src/deployments/polygon.ts
+++ b/packages/environment/src/deployments/polygon.ts
@@ -9,7 +9,9 @@ export default defineDeployment<Deployment.POLYGON>({
   externalContracts: {
     aaveV2IncentivesController: "0x357d51124f59836ded84c8a1730d72b749d8bc23",
     aaveV2LendingPoolProvider: "0xd05e3e715d945b59290df0ae8ef85c1bdb684744",
+    aaveV3IncentivesController: "0x929ec64c34a17401f460460d4b9390518e5b473e",
     aaveV3LendingPoolProvider: "0xa97684ead0e402dc232d5a977953df7ecbab3cdb",
+    aaveV3ProtocolDataProvider: "0x0000000000000000000000000000000000000000",
     aliceOrderManager: "0x0000000000000000000000000000000000000000",
     arrakisV2Helper: "0x89e4be1f999e3a58d16096fbe405fc2a1d7f07d6",
     arrakisV2Resolver: "0x535c5fdf31477f799366df6e4899a12a801cc7b8",

--- a/packages/environment/src/deployments/polygon.ts
+++ b/packages/environment/src/deployments/polygon.ts
@@ -9,7 +9,7 @@ export default defineDeployment<Deployment.POLYGON>({
   externalContracts: {
     aaveV2IncentivesController: "0x357d51124f59836ded84c8a1730d72b749d8bc23",
     aaveV2LendingPoolProvider: "0xd05e3e715d945b59290df0ae8ef85c1bdb684744",
-    aaveV3IncentivesController: "0x929ec64c34a17401f460460d4b9390518e5b473e",
+    aaveV3RewardsController: "0x929ec64c34a17401f460460d4b9390518e5b473e",
     aaveV3LendingPoolProvider: "0xa97684ead0e402dc232d5a977953df7ecbab3cdb",
     aaveV3ProtocolDataProvider: "0x69fa688f1dc47d4b5d8029d5a35fb7a548310654",
     aliceOrderManager: "0x0000000000000000000000000000000000000000",

--- a/packages/environment/src/releases.ts
+++ b/packages/environment/src/releases.ts
@@ -234,7 +234,7 @@ export interface KnownAddressListIdMapping {
 export interface ExternalContractsMapping {
   readonly aaveV2IncentivesController: Address;
   readonly aaveV2LendingPoolProvider: Address;
-  readonly aaveV3IncentivesController: Address;
+  readonly aaveV3RewardsController: Address;
   readonly aaveV3LendingPoolProvider: Address;
   readonly aaveV3ProtocolDataProvider: Address;
   readonly aliceOrderManager: Address;

--- a/packages/environment/src/releases.ts
+++ b/packages/environment/src/releases.ts
@@ -234,7 +234,9 @@ export interface KnownAddressListIdMapping {
 export interface ExternalContractsMapping {
   readonly aaveV2IncentivesController: Address;
   readonly aaveV2LendingPoolProvider: Address;
+  readonly aaveV3IncentivesController: Address;
   readonly aaveV3LendingPoolProvider: Address;
+  readonly aaveV3ProtocolDataProvider: Address;
   readonly aliceOrderManager: Address;
   readonly arrakisV2Resolver: Address;
   readonly arrakisV2Helper: Address;

--- a/packages/sdk/src/Portfolio/Integrations/AaveV3.ts
+++ b/packages/sdk/src/Portfolio/Integrations/AaveV3.ts
@@ -414,186 +414,6 @@ export async function getUserAccountData(
 
 const incentivesProviderAbi = [
   {
-    inputs: [{ internalType: "address", name: "emissionManager", type: "address" }],
-    stateMutability: "nonpayable",
-    type: "constructor",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      { indexed: true, internalType: "address", name: "asset", type: "address" },
-      { indexed: true, internalType: "address", name: "reward", type: "address" },
-      { indexed: true, internalType: "address", name: "user", type: "address" },
-      { indexed: false, internalType: "uint256", name: "assetIndex", type: "uint256" },
-      { indexed: false, internalType: "uint256", name: "userIndex", type: "uint256" },
-      { indexed: false, internalType: "uint256", name: "rewardsAccrued", type: "uint256" },
-    ],
-    name: "Accrued",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      { indexed: true, internalType: "address", name: "asset", type: "address" },
-      { indexed: true, internalType: "address", name: "reward", type: "address" },
-      { indexed: false, internalType: "uint256", name: "oldEmission", type: "uint256" },
-      { indexed: false, internalType: "uint256", name: "newEmission", type: "uint256" },
-      { indexed: false, internalType: "uint256", name: "oldDistributionEnd", type: "uint256" },
-      { indexed: false, internalType: "uint256", name: "newDistributionEnd", type: "uint256" },
-      { indexed: false, internalType: "uint256", name: "assetIndex", type: "uint256" },
-    ],
-    name: "AssetConfigUpdated",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      { indexed: true, internalType: "address", name: "user", type: "address" },
-      { indexed: true, internalType: "address", name: "claimer", type: "address" },
-    ],
-    name: "ClaimerSet",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      { indexed: true, internalType: "address", name: "reward", type: "address" },
-      { indexed: true, internalType: "address", name: "rewardOracle", type: "address" },
-    ],
-    name: "RewardOracleUpdated",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      { indexed: true, internalType: "address", name: "user", type: "address" },
-      { indexed: true, internalType: "address", name: "reward", type: "address" },
-      { indexed: true, internalType: "address", name: "to", type: "address" },
-      { indexed: false, internalType: "address", name: "claimer", type: "address" },
-      { indexed: false, internalType: "uint256", name: "amount", type: "uint256" },
-    ],
-    name: "RewardsClaimed",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      { indexed: true, internalType: "address", name: "reward", type: "address" },
-      { indexed: true, internalType: "address", name: "transferStrategy", type: "address" },
-    ],
-    name: "TransferStrategyInstalled",
-    type: "event",
-  },
-  {
-    inputs: [],
-    name: "EMISSION_MANAGER",
-    outputs: [{ internalType: "address", name: "", type: "address" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "REVISION",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address[]", name: "assets", type: "address[]" },
-      { internalType: "address", name: "to", type: "address" },
-    ],
-    name: "claimAllRewards",
-    outputs: [
-      { internalType: "address[]", name: "rewardsList", type: "address[]" },
-      { internalType: "uint256[]", name: "claimedAmounts", type: "uint256[]" },
-    ],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address[]", name: "assets", type: "address[]" },
-      { internalType: "address", name: "user", type: "address" },
-      { internalType: "address", name: "to", type: "address" },
-    ],
-    name: "claimAllRewardsOnBehalf",
-    outputs: [
-      { internalType: "address[]", name: "rewardsList", type: "address[]" },
-      { internalType: "uint256[]", name: "claimedAmounts", type: "uint256[]" },
-    ],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address[]", name: "assets", type: "address[]" }],
-    name: "claimAllRewardsToSelf",
-    outputs: [
-      { internalType: "address[]", name: "rewardsList", type: "address[]" },
-      { internalType: "uint256[]", name: "claimedAmounts", type: "uint256[]" },
-    ],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address[]", name: "assets", type: "address[]" },
-      { internalType: "uint256", name: "amount", type: "uint256" },
-      { internalType: "address", name: "to", type: "address" },
-      { internalType: "address", name: "reward", type: "address" },
-    ],
-    name: "claimRewards",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address[]", name: "assets", type: "address[]" },
-      { internalType: "uint256", name: "amount", type: "uint256" },
-      { internalType: "address", name: "user", type: "address" },
-      { internalType: "address", name: "to", type: "address" },
-      { internalType: "address", name: "reward", type: "address" },
-    ],
-    name: "claimRewardsOnBehalf",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address[]", name: "assets", type: "address[]" },
-      { internalType: "uint256", name: "amount", type: "uint256" },
-      { internalType: "address", name: "reward", type: "address" },
-    ],
-    name: "claimRewardsToSelf",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      {
-        components: [
-          { internalType: "uint88", name: "emissionPerSecond", type: "uint88" },
-          { internalType: "uint256", name: "totalSupply", type: "uint256" },
-          { internalType: "uint32", name: "distributionEnd", type: "uint32" },
-          { internalType: "address", name: "asset", type: "address" },
-          { internalType: "address", name: "reward", type: "address" },
-          { internalType: "contract ITransferStrategyBase", name: "transferStrategy", type: "address" },
-          { internalType: "contract IEACAggregatorProxy", name: "rewardOracle", type: "address" },
-        ],
-        internalType: "struct RewardsDataTypes.RewardsConfigInput[]",
-        name: "config",
-        type: "tuple[]",
-      },
-    ],
-    name: "configureAssets",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
     inputs: [
       { internalType: "address[]", name: "assets", type: "address[]" },
       { internalType: "address", name: "user", type: "address" },
@@ -603,57 +423,6 @@ const incentivesProviderAbi = [
       { internalType: "address[]", name: "rewardsList", type: "address[]" },
       { internalType: "uint256[]", name: "unclaimedAmounts", type: "uint256[]" },
     ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "asset", type: "address" }],
-    name: "getAssetDecimals",
-    outputs: [{ internalType: "uint8", name: "", type: "uint8" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "asset", type: "address" },
-      { internalType: "address", name: "reward", type: "address" },
-    ],
-    name: "getAssetIndex",
-    outputs: [
-      { internalType: "uint256", name: "", type: "uint256" },
-      { internalType: "uint256", name: "", type: "uint256" },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "user", type: "address" }],
-    name: "getClaimer",
-    outputs: [{ internalType: "address", name: "", type: "address" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "asset", type: "address" },
-      { internalType: "address", name: "reward", type: "address" },
-    ],
-    name: "getDistributionEnd",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "getEmissionManager",
-    outputs: [{ internalType: "address", name: "", type: "address" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "reward", type: "address" }],
-    name: "getRewardOracle",
-    outputs: [{ internalType: "address", name: "", type: "address" }],
     stateMutability: "view",
     type: "function",
   },
@@ -679,122 +448,6 @@ const incentivesProviderAbi = [
     stateMutability: "view",
     type: "function",
   },
-  {
-    inputs: [],
-    name: "getRewardsList",
-    outputs: [{ internalType: "address[]", name: "", type: "address[]" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "reward", type: "address" }],
-    name: "getTransferStrategy",
-    outputs: [{ internalType: "address", name: "", type: "address" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "user", type: "address" },
-      { internalType: "address", name: "reward", type: "address" },
-    ],
-    name: "getUserAccruedRewards",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "user", type: "address" },
-      { internalType: "address", name: "asset", type: "address" },
-      { internalType: "address", name: "reward", type: "address" },
-    ],
-    name: "getUserAssetIndex",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address[]", name: "assets", type: "address[]" },
-      { internalType: "address", name: "user", type: "address" },
-      { internalType: "address", name: "reward", type: "address" },
-    ],
-    name: "getUserRewards",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "user", type: "address" },
-      { internalType: "uint256", name: "totalSupply", type: "uint256" },
-      { internalType: "uint256", name: "userBalance", type: "uint256" },
-    ],
-    name: "handleAction",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "", type: "address" }],
-    name: "initialize",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "user", type: "address" },
-      { internalType: "address", name: "caller", type: "address" },
-    ],
-    name: "setClaimer",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "asset", type: "address" },
-      { internalType: "address", name: "reward", type: "address" },
-      { internalType: "uint32", name: "newDistributionEnd", type: "uint32" },
-    ],
-    name: "setDistributionEnd",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "asset", type: "address" },
-      { internalType: "address[]", name: "rewards", type: "address[]" },
-      { internalType: "uint88[]", name: "newEmissionsPerSecond", type: "uint88[]" },
-    ],
-    name: "setEmissionPerSecond",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "reward", type: "address" },
-      { internalType: "contract IEACAggregatorProxy", name: "rewardOracle", type: "address" },
-    ],
-    name: "setRewardOracle",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "reward", type: "address" },
-      { internalType: "contract ITransferStrategyBase", name: "transferStrategy", type: "address" },
-    ],
-    name: "setTransferStrategy",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
 ] as const;
 
 export async function getAllUserRewards(
@@ -814,6 +467,22 @@ export async function getAllUserRewards(
   });
 
   return { rewardsList, unclaimedAmounts };
+}
+
+export function getRewardsByAsset(
+  client: Client,
+  args: Viem.ContractCallParameters<{
+    incentivesProvider: Address;
+    asset: Address;
+  }>,
+) {
+  return readContract(client, {
+    ...Viem.extractBlockParameters(args),
+    abi: incentivesProviderAbi,
+    functionName: "getRewardsByAsset",
+    address: args.incentivesProvider,
+    args: [args.asset],
+  });
 }
 
 export async function getRewardsData(
@@ -837,124 +506,11 @@ export async function getRewardsData(
 
 const protocolDataProviderAbi = [
   {
-    inputs: [{ internalType: "contract IPoolAddressesProvider", name: "addressesProvider", type: "address" }],
-    stateMutability: "nonpayable",
-    type: "constructor",
-  },
-  {
-    inputs: [],
-    name: "ADDRESSES_PROVIDER",
-    outputs: [{ internalType: "contract IPoolAddressesProvider", name: "", type: "address" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "asset", type: "address" }],
-    name: "getATokenTotalSupply",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "getAllATokens",
-    outputs: [
-      {
-        components: [
-          { internalType: "string", name: "symbol", type: "string" },
-          { internalType: "address", name: "tokenAddress", type: "address" },
-        ],
-        internalType: "struct IPoolDataProvider.TokenData[]",
-        name: "",
-        type: "tuple[]",
-      },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "getAllReservesTokens",
-    outputs: [
-      {
-        components: [
-          { internalType: "string", name: "symbol", type: "string" },
-          { internalType: "address", name: "tokenAddress", type: "address" },
-        ],
-        internalType: "struct IPoolDataProvider.TokenData[]",
-        name: "",
-        type: "tuple[]",
-      },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "asset", type: "address" }],
-    name: "getDebtCeiling",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "getDebtCeilingDecimals",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "pure",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "asset", type: "address" }],
-    name: "getFlashLoanEnabled",
-    outputs: [{ internalType: "bool", name: "", type: "bool" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "asset", type: "address" }],
-    name: "getInterestRateStrategyAddress",
-    outputs: [{ internalType: "address", name: "irStrategyAddress", type: "address" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "asset", type: "address" }],
-    name: "getLiquidationProtocolFee",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "asset", type: "address" }],
-    name: "getPaused",
-    outputs: [{ internalType: "bool", name: "isPaused", type: "bool" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
     inputs: [{ internalType: "address", name: "asset", type: "address" }],
     name: "getReserveCaps",
     outputs: [
       { internalType: "uint256", name: "borrowCap", type: "uint256" },
       { internalType: "uint256", name: "supplyCap", type: "uint256" },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "asset", type: "address" }],
-    name: "getReserveConfigurationData",
-    outputs: [
-      { internalType: "uint256", name: "decimals", type: "uint256" },
-      { internalType: "uint256", name: "ltv", type: "uint256" },
-      { internalType: "uint256", name: "liquidationThreshold", type: "uint256" },
-      { internalType: "uint256", name: "liquidationBonus", type: "uint256" },
-      { internalType: "uint256", name: "reserveFactor", type: "uint256" },
-      { internalType: "bool", name: "usageAsCollateralEnabled", type: "bool" },
-      { internalType: "bool", name: "borrowingEnabled", type: "bool" },
-      { internalType: "bool", name: "stableBorrowRateEnabled", type: "bool" },
-      { internalType: "bool", name: "isActive", type: "bool" },
-      { internalType: "bool", name: "isFrozen", type: "bool" },
     ],
     stateMutability: "view",
     type: "function",
@@ -975,65 +531,6 @@ const protocolDataProviderAbi = [
       { internalType: "uint256", name: "liquidityIndex", type: "uint256" },
       { internalType: "uint256", name: "variableBorrowIndex", type: "uint256" },
       { internalType: "uint40", name: "lastUpdateTimestamp", type: "uint40" },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "asset", type: "address" }],
-    name: "getReserveEModeCategory",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "asset", type: "address" }],
-    name: "getReserveTokensAddresses",
-    outputs: [
-      { internalType: "address", name: "aTokenAddress", type: "address" },
-      { internalType: "address", name: "stableDebtTokenAddress", type: "address" },
-      { internalType: "address", name: "variableDebtTokenAddress", type: "address" },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "asset", type: "address" }],
-    name: "getSiloedBorrowing",
-    outputs: [{ internalType: "bool", name: "", type: "bool" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "asset", type: "address" }],
-    name: "getTotalDebt",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [{ internalType: "address", name: "asset", type: "address" }],
-    name: "getUnbackedMintCap",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      { internalType: "address", name: "asset", type: "address" },
-      { internalType: "address", name: "user", type: "address" },
-    ],
-    name: "getUserReserveData",
-    outputs: [
-      { internalType: "uint256", name: "currentATokenBalance", type: "uint256" },
-      { internalType: "uint256", name: "currentStableDebt", type: "uint256" },
-      { internalType: "uint256", name: "currentVariableDebt", type: "uint256" },
-      { internalType: "uint256", name: "principalStableDebt", type: "uint256" },
-      { internalType: "uint256", name: "scaledVariableDebt", type: "uint256" },
-      { internalType: "uint256", name: "stableBorrowRate", type: "uint256" },
-      { internalType: "uint256", name: "liquidityRate", type: "uint256" },
-      { internalType: "uint40", name: "stableRateLastUpdated", type: "uint40" },
-      { internalType: "bool", name: "usageAsCollateralEnabled", type: "bool" },
     ],
     stateMutability: "view",
     type: "function",

--- a/packages/sdk/src/Portfolio/Integrations/AaveV3.ts
+++ b/packages/sdk/src/Portfolio/Integrations/AaveV3.ts
@@ -816,6 +816,25 @@ export async function getAllUserRewards(
   return { rewardsList, unclaimedAmounts };
 }
 
+export async function getRewardsData(
+  client: Client,
+  args: Viem.ContractCallParameters<{
+    incentivesProvider: Address;
+    asset: Address;
+    user: Address;
+  }>,
+) {
+  const [emissionPerSecond, index, lastUpdateTimestamp, distributionEnd] = await readContract(client, {
+    ...Viem.extractBlockParameters(args),
+    abi: incentivesProviderAbi,
+    functionName: "getRewardsData",
+    address: args.incentivesProvider,
+    args: [args.asset, args.user],
+  });
+
+  return { emissionPerSecond, index, lastUpdateTimestamp, distributionEnd };
+}
+
 const protocolDataProviderAbi = [
   {
     inputs: [{ internalType: "contract IPoolAddressesProvider", name: "addressesProvider", type: "address" }],

--- a/packages/sdk/src/Portfolio/Integrations/AaveV3.ts
+++ b/packages/sdk/src/Portfolio/Integrations/AaveV3.ts
@@ -821,15 +821,15 @@ export async function getRewardsData(
   args: Viem.ContractCallParameters<{
     incentivesProvider: Address;
     asset: Address;
-    user: Address;
+    reward: Address;
   }>,
 ) {
-  const [emissionPerSecond, index, lastUpdateTimestamp, distributionEnd] = await readContract(client, {
+  const [index, emissionPerSecond, lastUpdateTimestamp, distributionEnd] = await readContract(client, {
     ...Viem.extractBlockParameters(args),
     abi: incentivesProviderAbi,
     functionName: "getRewardsData",
     address: args.incentivesProvider,
-    args: [args.asset, args.user],
+    args: [args.asset, args.reward],
   });
 
   return { emissionPerSecond, index, lastUpdateTimestamp, distributionEnd };

--- a/packages/sdk/src/Portfolio/Integrations/AaveV3.ts
+++ b/packages/sdk/src/Portfolio/Integrations/AaveV3.ts
@@ -1,8 +1,9 @@
-import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters } from "viem";
+import { type Address, type Client, type Hex, decodeAbiParameters, encodeAbiParameters, parseUnits } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "../../Utils.js";
 import * as ExternalPositionManager from "../../_internal/ExternalPositionManager.js";
 import * as IntegrationManager from "../../_internal/IntegrationManager.js";
+import { Asset } from "../../index.js";
 
 //--------------------------------------------------------------------------------------------
 // LEND
@@ -409,4 +410,693 @@ export async function getUserAccountData(
     });
 
   return { availableBorrowsBase, currentLiquidationThreshold, healthFactor, ltv, totalCollateralBase, totalDebtBase };
+}
+
+const incentivesProviderAbi = [
+  {
+    inputs: [{ internalType: "address", name: "emissionManager", type: "address" }],
+    stateMutability: "nonpayable",
+    type: "constructor",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: "address", name: "asset", type: "address" },
+      { indexed: true, internalType: "address", name: "reward", type: "address" },
+      { indexed: true, internalType: "address", name: "user", type: "address" },
+      { indexed: false, internalType: "uint256", name: "assetIndex", type: "uint256" },
+      { indexed: false, internalType: "uint256", name: "userIndex", type: "uint256" },
+      { indexed: false, internalType: "uint256", name: "rewardsAccrued", type: "uint256" },
+    ],
+    name: "Accrued",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: "address", name: "asset", type: "address" },
+      { indexed: true, internalType: "address", name: "reward", type: "address" },
+      { indexed: false, internalType: "uint256", name: "oldEmission", type: "uint256" },
+      { indexed: false, internalType: "uint256", name: "newEmission", type: "uint256" },
+      { indexed: false, internalType: "uint256", name: "oldDistributionEnd", type: "uint256" },
+      { indexed: false, internalType: "uint256", name: "newDistributionEnd", type: "uint256" },
+      { indexed: false, internalType: "uint256", name: "assetIndex", type: "uint256" },
+    ],
+    name: "AssetConfigUpdated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: "address", name: "user", type: "address" },
+      { indexed: true, internalType: "address", name: "claimer", type: "address" },
+    ],
+    name: "ClaimerSet",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: "address", name: "reward", type: "address" },
+      { indexed: true, internalType: "address", name: "rewardOracle", type: "address" },
+    ],
+    name: "RewardOracleUpdated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: "address", name: "user", type: "address" },
+      { indexed: true, internalType: "address", name: "reward", type: "address" },
+      { indexed: true, internalType: "address", name: "to", type: "address" },
+      { indexed: false, internalType: "address", name: "claimer", type: "address" },
+      { indexed: false, internalType: "uint256", name: "amount", type: "uint256" },
+    ],
+    name: "RewardsClaimed",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: "address", name: "reward", type: "address" },
+      { indexed: true, internalType: "address", name: "transferStrategy", type: "address" },
+    ],
+    name: "TransferStrategyInstalled",
+    type: "event",
+  },
+  {
+    inputs: [],
+    name: "EMISSION_MANAGER",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "REVISION",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address[]", name: "assets", type: "address[]" },
+      { internalType: "address", name: "to", type: "address" },
+    ],
+    name: "claimAllRewards",
+    outputs: [
+      { internalType: "address[]", name: "rewardsList", type: "address[]" },
+      { internalType: "uint256[]", name: "claimedAmounts", type: "uint256[]" },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address[]", name: "assets", type: "address[]" },
+      { internalType: "address", name: "user", type: "address" },
+      { internalType: "address", name: "to", type: "address" },
+    ],
+    name: "claimAllRewardsOnBehalf",
+    outputs: [
+      { internalType: "address[]", name: "rewardsList", type: "address[]" },
+      { internalType: "uint256[]", name: "claimedAmounts", type: "uint256[]" },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address[]", name: "assets", type: "address[]" }],
+    name: "claimAllRewardsToSelf",
+    outputs: [
+      { internalType: "address[]", name: "rewardsList", type: "address[]" },
+      { internalType: "uint256[]", name: "claimedAmounts", type: "uint256[]" },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address[]", name: "assets", type: "address[]" },
+      { internalType: "uint256", name: "amount", type: "uint256" },
+      { internalType: "address", name: "to", type: "address" },
+      { internalType: "address", name: "reward", type: "address" },
+    ],
+    name: "claimRewards",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address[]", name: "assets", type: "address[]" },
+      { internalType: "uint256", name: "amount", type: "uint256" },
+      { internalType: "address", name: "user", type: "address" },
+      { internalType: "address", name: "to", type: "address" },
+      { internalType: "address", name: "reward", type: "address" },
+    ],
+    name: "claimRewardsOnBehalf",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address[]", name: "assets", type: "address[]" },
+      { internalType: "uint256", name: "amount", type: "uint256" },
+      { internalType: "address", name: "reward", type: "address" },
+    ],
+    name: "claimRewardsToSelf",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "uint88", name: "emissionPerSecond", type: "uint88" },
+          { internalType: "uint256", name: "totalSupply", type: "uint256" },
+          { internalType: "uint32", name: "distributionEnd", type: "uint32" },
+          { internalType: "address", name: "asset", type: "address" },
+          { internalType: "address", name: "reward", type: "address" },
+          { internalType: "contract ITransferStrategyBase", name: "transferStrategy", type: "address" },
+          { internalType: "contract IEACAggregatorProxy", name: "rewardOracle", type: "address" },
+        ],
+        internalType: "struct RewardsDataTypes.RewardsConfigInput[]",
+        name: "config",
+        type: "tuple[]",
+      },
+    ],
+    name: "configureAssets",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address[]", name: "assets", type: "address[]" },
+      { internalType: "address", name: "user", type: "address" },
+    ],
+    name: "getAllUserRewards",
+    outputs: [
+      { internalType: "address[]", name: "rewardsList", type: "address[]" },
+      { internalType: "uint256[]", name: "unclaimedAmounts", type: "uint256[]" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "asset", type: "address" }],
+    name: "getAssetDecimals",
+    outputs: [{ internalType: "uint8", name: "", type: "uint8" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "asset", type: "address" },
+      { internalType: "address", name: "reward", type: "address" },
+    ],
+    name: "getAssetIndex",
+    outputs: [
+      { internalType: "uint256", name: "", type: "uint256" },
+      { internalType: "uint256", name: "", type: "uint256" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "user", type: "address" }],
+    name: "getClaimer",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "asset", type: "address" },
+      { internalType: "address", name: "reward", type: "address" },
+    ],
+    name: "getDistributionEnd",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "getEmissionManager",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "reward", type: "address" }],
+    name: "getRewardOracle",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "asset", type: "address" }],
+    name: "getRewardsByAsset",
+    outputs: [{ internalType: "address[]", name: "", type: "address[]" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "asset", type: "address" },
+      { internalType: "address", name: "reward", type: "address" },
+    ],
+    name: "getRewardsData",
+    outputs: [
+      { internalType: "uint256", name: "", type: "uint256" },
+      { internalType: "uint256", name: "", type: "uint256" },
+      { internalType: "uint256", name: "", type: "uint256" },
+      { internalType: "uint256", name: "", type: "uint256" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "getRewardsList",
+    outputs: [{ internalType: "address[]", name: "", type: "address[]" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "reward", type: "address" }],
+    name: "getTransferStrategy",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "user", type: "address" },
+      { internalType: "address", name: "reward", type: "address" },
+    ],
+    name: "getUserAccruedRewards",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "user", type: "address" },
+      { internalType: "address", name: "asset", type: "address" },
+      { internalType: "address", name: "reward", type: "address" },
+    ],
+    name: "getUserAssetIndex",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address[]", name: "assets", type: "address[]" },
+      { internalType: "address", name: "user", type: "address" },
+      { internalType: "address", name: "reward", type: "address" },
+    ],
+    name: "getUserRewards",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "user", type: "address" },
+      { internalType: "uint256", name: "totalSupply", type: "uint256" },
+      { internalType: "uint256", name: "userBalance", type: "uint256" },
+    ],
+    name: "handleAction",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "", type: "address" }],
+    name: "initialize",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "user", type: "address" },
+      { internalType: "address", name: "caller", type: "address" },
+    ],
+    name: "setClaimer",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "asset", type: "address" },
+      { internalType: "address", name: "reward", type: "address" },
+      { internalType: "uint32", name: "newDistributionEnd", type: "uint32" },
+    ],
+    name: "setDistributionEnd",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "asset", type: "address" },
+      { internalType: "address[]", name: "rewards", type: "address[]" },
+      { internalType: "uint88[]", name: "newEmissionsPerSecond", type: "uint88[]" },
+    ],
+    name: "setEmissionPerSecond",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "reward", type: "address" },
+      { internalType: "contract IEACAggregatorProxy", name: "rewardOracle", type: "address" },
+    ],
+    name: "setRewardOracle",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "reward", type: "address" },
+      { internalType: "contract ITransferStrategyBase", name: "transferStrategy", type: "address" },
+    ],
+    name: "setTransferStrategy",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+] as const;
+
+export async function getAllUserRewards(
+  client: Client,
+  args: Viem.ContractCallParameters<{
+    incentivesProvider: Address;
+    assets: ReadonlyArray<Address>;
+    user: Address;
+  }>,
+) {
+  const [rewardsList, unclaimedAmounts] = await readContract(client, {
+    ...Viem.extractBlockParameters(args),
+    abi: incentivesProviderAbi,
+    functionName: "getAllUserRewards",
+    address: args.incentivesProvider,
+    args: [args.assets, args.user],
+  });
+
+  return { rewardsList, unclaimedAmounts };
+}
+
+const protocolDataProviderAbi = [
+  {
+    inputs: [{ internalType: "contract IPoolAddressesProvider", name: "addressesProvider", type: "address" }],
+    stateMutability: "nonpayable",
+    type: "constructor",
+  },
+  {
+    inputs: [],
+    name: "ADDRESSES_PROVIDER",
+    outputs: [{ internalType: "contract IPoolAddressesProvider", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "asset", type: "address" }],
+    name: "getATokenTotalSupply",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "getAllATokens",
+    outputs: [
+      {
+        components: [
+          { internalType: "string", name: "symbol", type: "string" },
+          { internalType: "address", name: "tokenAddress", type: "address" },
+        ],
+        internalType: "struct IPoolDataProvider.TokenData[]",
+        name: "",
+        type: "tuple[]",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "getAllReservesTokens",
+    outputs: [
+      {
+        components: [
+          { internalType: "string", name: "symbol", type: "string" },
+          { internalType: "address", name: "tokenAddress", type: "address" },
+        ],
+        internalType: "struct IPoolDataProvider.TokenData[]",
+        name: "",
+        type: "tuple[]",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "asset", type: "address" }],
+    name: "getDebtCeiling",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "getDebtCeilingDecimals",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "pure",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "asset", type: "address" }],
+    name: "getFlashLoanEnabled",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "asset", type: "address" }],
+    name: "getInterestRateStrategyAddress",
+    outputs: [{ internalType: "address", name: "irStrategyAddress", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "asset", type: "address" }],
+    name: "getLiquidationProtocolFee",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "asset", type: "address" }],
+    name: "getPaused",
+    outputs: [{ internalType: "bool", name: "isPaused", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "asset", type: "address" }],
+    name: "getReserveCaps",
+    outputs: [
+      { internalType: "uint256", name: "borrowCap", type: "uint256" },
+      { internalType: "uint256", name: "supplyCap", type: "uint256" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "asset", type: "address" }],
+    name: "getReserveConfigurationData",
+    outputs: [
+      { internalType: "uint256", name: "decimals", type: "uint256" },
+      { internalType: "uint256", name: "ltv", type: "uint256" },
+      { internalType: "uint256", name: "liquidationThreshold", type: "uint256" },
+      { internalType: "uint256", name: "liquidationBonus", type: "uint256" },
+      { internalType: "uint256", name: "reserveFactor", type: "uint256" },
+      { internalType: "bool", name: "usageAsCollateralEnabled", type: "bool" },
+      { internalType: "bool", name: "borrowingEnabled", type: "bool" },
+      { internalType: "bool", name: "stableBorrowRateEnabled", type: "bool" },
+      { internalType: "bool", name: "isActive", type: "bool" },
+      { internalType: "bool", name: "isFrozen", type: "bool" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "asset", type: "address" }],
+    name: "getReserveData",
+    outputs: [
+      { internalType: "uint256", name: "unbacked", type: "uint256" },
+      { internalType: "uint256", name: "accruedToTreasuryScaled", type: "uint256" },
+      { internalType: "uint256", name: "totalAToken", type: "uint256" },
+      { internalType: "uint256", name: "totalStableDebt", type: "uint256" },
+      { internalType: "uint256", name: "totalVariableDebt", type: "uint256" },
+      { internalType: "uint256", name: "liquidityRate", type: "uint256" },
+      { internalType: "uint256", name: "variableBorrowRate", type: "uint256" },
+      { internalType: "uint256", name: "stableBorrowRate", type: "uint256" },
+      { internalType: "uint256", name: "averageStableBorrowRate", type: "uint256" },
+      { internalType: "uint256", name: "liquidityIndex", type: "uint256" },
+      { internalType: "uint256", name: "variableBorrowIndex", type: "uint256" },
+      { internalType: "uint40", name: "lastUpdateTimestamp", type: "uint40" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "asset", type: "address" }],
+    name: "getReserveEModeCategory",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "asset", type: "address" }],
+    name: "getReserveTokensAddresses",
+    outputs: [
+      { internalType: "address", name: "aTokenAddress", type: "address" },
+      { internalType: "address", name: "stableDebtTokenAddress", type: "address" },
+      { internalType: "address", name: "variableDebtTokenAddress", type: "address" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "asset", type: "address" }],
+    name: "getSiloedBorrowing",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "asset", type: "address" }],
+    name: "getTotalDebt",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "asset", type: "address" }],
+    name: "getUnbackedMintCap",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "asset", type: "address" },
+      { internalType: "address", name: "user", type: "address" },
+    ],
+    name: "getUserReserveData",
+    outputs: [
+      { internalType: "uint256", name: "currentATokenBalance", type: "uint256" },
+      { internalType: "uint256", name: "currentStableDebt", type: "uint256" },
+      { internalType: "uint256", name: "currentVariableDebt", type: "uint256" },
+      { internalType: "uint256", name: "principalStableDebt", type: "uint256" },
+      { internalType: "uint256", name: "scaledVariableDebt", type: "uint256" },
+      { internalType: "uint256", name: "stableBorrowRate", type: "uint256" },
+      { internalType: "uint256", name: "liquidityRate", type: "uint256" },
+      { internalType: "uint40", name: "stableRateLastUpdated", type: "uint40" },
+      { internalType: "bool", name: "usageAsCollateralEnabled", type: "bool" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+export async function getReserveCaps(
+  client: Client,
+  args: Viem.ContractCallParameters<{
+    protocolDataProvider: Address;
+    asset: Address;
+  }>,
+) {
+  const [[supplyCap, borrowCap], decimals] = await Promise.all([
+    readContract(client, {
+      ...Viem.extractBlockParameters(args),
+      abi: protocolDataProviderAbi,
+      functionName: "getReserveCaps",
+      address: args.protocolDataProvider,
+      args: [args.asset],
+    }),
+    Asset.getDecimals(client, { asset: args.asset }),
+  ]);
+
+  return {
+    supplyCap: parseUnits(supplyCap.toString(), Number(decimals)),
+    borrowCap: parseUnits(borrowCap.toString(), Number(decimals)),
+  };
+}
+
+export async function getReserveData(
+  client: Client,
+  args: Viem.ContractCallParameters<{
+    protocolDataProvider: Address;
+    asset: Address;
+  }>,
+) {
+  const [
+    unbacked,
+    accruedToTreasuryScaled,
+    totalAToken,
+    totalStableDebt,
+    totalVariableDebt,
+    liquidityRate,
+    variableBorrowRate,
+    stableBorrowRate,
+    averageStableBorrowRate,
+    liquidityIndex,
+    variableBorrowIndex,
+    lastUpdateTimestamp,
+  ] = await readContract(client, {
+    ...Viem.extractBlockParameters(args),
+    abi: protocolDataProviderAbi,
+    functionName: "getReserveData",
+    address: args.protocolDataProvider,
+    args: [args.asset],
+  });
+
+  return {
+    unbacked,
+    accruedToTreasuryScaled,
+    totalAToken,
+    totalStableDebt,
+    totalVariableDebt,
+    liquidityRate,
+    variableBorrowRate,
+    stableBorrowRate,
+    averageStableBorrowRate,
+    liquidityIndex,
+    variableBorrowIndex,
+    lastUpdateTimestamp,
+  };
+}
+
+export async function getAvailableSupplyAmount(
+  client: Client,
+  args: Viem.ContractCallParameters<{
+    protocolDataProvider: Address;
+    asset: Address;
+  }>,
+) {
+  const [reserveCaps, reserveData] = await Promise.all([getReserveCaps(client, args), getReserveData(client, args)]);
+
+  return reserveCaps.supplyCap - reserveData.totalAToken;
 }

--- a/packages/sdk/src/Portfolio/Integrations/AaveV3.ts
+++ b/packages/sdk/src/Portfolio/Integrations/AaveV3.ts
@@ -412,7 +412,7 @@ export async function getUserAccountData(
   return { availableBorrowsBase, currentLiquidationThreshold, healthFactor, ltv, totalCollateralBase, totalDebtBase };
 }
 
-const incentivesProviderAbi = [
+const rewardsControllerAbi = [
   {
     inputs: [
       { internalType: "address[]", name: "assets", type: "address[]" },
@@ -453,16 +453,16 @@ const incentivesProviderAbi = [
 export async function getAllUserRewards(
   client: Client,
   args: Viem.ContractCallParameters<{
-    incentivesProvider: Address;
+    rewardsController: Address;
     assets: ReadonlyArray<Address>;
     user: Address;
   }>,
 ) {
   const [rewardsList, unclaimedAmounts] = await readContract(client, {
     ...Viem.extractBlockParameters(args),
-    abi: incentivesProviderAbi,
+    abi: rewardsControllerAbi,
     functionName: "getAllUserRewards",
-    address: args.incentivesProvider,
+    address: args.rewardsController,
     args: [args.assets, args.user],
   });
 
@@ -472,15 +472,15 @@ export async function getAllUserRewards(
 export function getRewardsByAsset(
   client: Client,
   args: Viem.ContractCallParameters<{
-    incentivesProvider: Address;
+    rewardsController: Address;
     asset: Address;
   }>,
 ) {
   return readContract(client, {
     ...Viem.extractBlockParameters(args),
-    abi: incentivesProviderAbi,
+    abi: rewardsControllerAbi,
     functionName: "getRewardsByAsset",
-    address: args.incentivesProvider,
+    address: args.rewardsController,
     args: [args.asset],
   });
 }
@@ -488,16 +488,16 @@ export function getRewardsByAsset(
 export async function getRewardsData(
   client: Client,
   args: Viem.ContractCallParameters<{
-    incentivesProvider: Address;
+    rewardsController: Address;
     asset: Address;
     reward: Address;
   }>,
 ) {
   const [index, emissionPerSecond, lastUpdateTimestamp, distributionEnd] = await readContract(client, {
     ...Viem.extractBlockParameters(args),
-    abi: incentivesProviderAbi,
+    abi: rewardsControllerAbi,
     functionName: "getRewardsData",
-    address: args.incentivesProvider,
+    address: args.rewardsController,
     args: [args.asset, args.reward],
   });
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces various read functions for Aave v3, enhancing the `environment` and `sdk` packages with new properties and methods to interact with Aave's rewards and protocol data.

### Detailed summary
- Added new properties for Aave v3 in `packages/environment/src/releases.ts`.
- Updated Aave v3 contract addresses in `packages/environment/src/deployments/polygon.ts`, `arbitrum.ts`, and `ethereum.ts`.
- Implemented new read functions in `packages/sdk/src/Portfolio/Integrations/AaveV3.ts`:
  - `getAllUserRewards`
  - `getRewardsByAsset`
  - `getRewardsData`
  - `getReserveCaps`
  - `getReserveData`
  - `getAvailableSupplyAmount`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->