### PR TITLE
chore: rename WMATIC

### DIFF
--- a/.changeset/quick-planes-type.md
+++ b/.changeset/quick-planes-type.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Rename WMATIC

--- a/packages/environment/src/assets/polygon.ts
+++ b/packages/environment/src/assets/polygon.ts
@@ -296,9 +296,9 @@ export default defineAssetList(Network.POLYGON, [
   {
     decimals: 18,
     id: "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
-    name: "Wrapped Matic",
+    name: "Wrapped Polygon Ecosystem Token",
     releases: [polygon.sulu, testnet.sulu],
-    symbol: "WMATIC",
+    symbol: "WPOL",
     type: AssetType.PRIMITIVE,
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on renaming the `WMATIC` asset to `WPOL` and updating its name to reflect its association with the Polygon ecosystem.

### Detailed summary
- Updated `name` from `"Wrapped Matic"` to `"Wrapped Polygon Ecosystem Token"` in `packages/environment/src/assets/polygon.ts`
- Changed `symbol` from `"WMATIC"` to `"WPOL"` in the same file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->