### PR TITLE
feat: update aave ui incentive data provider

### DIFF
--- a/.changeset/gentle-suns-design.md
+++ b/.changeset/gentle-suns-design.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Update Aave UI incenctive data provider

--- a/packages/environment/src/deployments/arbitrum.ts
+++ b/packages/environment/src/deployments/arbitrum.ts
@@ -7,7 +7,7 @@ export default defineDeployment<Deployment.ARBITRUM>({
   address: "0x8da28441a4c594fd2fac72726c1412d8cf9e4a19",
   assets,
   externalContracts: {
-    aaveUIIncentiveDataProvider: "0xda67af3403555ce0ae3ffc22fdb7354458277358",
+    aaveUIIncentiveDataProvider: "0xe92cd6164ce7dc68e740765bc1f2a091b6cbc3e4",
     aaveV2IncentivesController: "0x0000000000000000000000000000000000000000",
     aaveV2LendingPoolProvider: "0x0000000000000000000000000000000000000000",
     aaveV3RewardsController: "0x929ec64c34a17401f460460d4b9390518e5b473e",

--- a/packages/environment/src/deployments/ethereum.ts
+++ b/packages/environment/src/deployments/ethereum.ts
@@ -7,7 +7,7 @@ export default defineDeployment<Deployment.ETHEREUM>({
   address: "0xc3dc853dd716bd5754f421ef94fdcbac3902ab32",
   assets,
   externalContracts: {
-    aaveUIIncentiveDataProvider: "0x162a7ac02f547ad796ca549f757e2b8d1d9b10a6",
+    aaveUIIncentiveDataProvider: "0x5a40cde2b76da2bed545efb3ae15708ee56aaf9c",
     aaveV2IncentivesController: "0xd784927ff2f95ba542bfc824c8a8a98f3495f6b5",
     aaveV2LendingPoolProvider: "0xb53c1a33016b2dc2ff3653530bff1848a515c8c5",
     aaveV3RewardsController: "0x8164cc65827dcfe994ab23944cbc90e0aa80bfcb",

--- a/packages/environment/src/deployments/polygon.ts
+++ b/packages/environment/src/deployments/polygon.ts
@@ -7,7 +7,7 @@ export default defineDeployment<Deployment.POLYGON>({
   address: "0x2e25271297537b8124b8f883a92ffd95c4032733",
   assets,
   externalContracts: {
-    aaveUIIncentiveDataProvider: "0x874313a46e4957d29faac43bf5eb2b144894f557",
+    aaveUIIncentiveDataProvider: "0x5c5228ac8bc1528482514af3e27e692495148717",
     aaveV2IncentivesController: "0x357d51124f59836ded84c8a1730d72b749d8bc23",
     aaveV2LendingPoolProvider: "0xd05e3e715d945b59290df0ae8ef85c1bdb684744",
     aaveV3RewardsController: "0x929ec64c34a17401f460460d4b9390518e5b473e",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `aaveUIIncentiveDataProvider` addresses across multiple deployment files for different networks.

### Detailed summary
- Updated `aaveUIIncentiveDataProvider` address in:
  - `packages/environment/src/deployments/polygon.ts` to `"0x5c5228ac8bc1528482514af3e27e692495148717"`
  - `packages/environment/src/deployments/arbitrum.ts` to `"0xe92cd6164ce7dc68e740765bc1f2a091b6cbc3e4"`
  - `packages/environment/src/deployments/ethereum.ts` to `"0x5a40cde2b76da2bed545efb3ae15708ee56aaf9c"`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->