### PR TITLE
fix: aave amounts

### DIFF
--- a/.changeset/cool-avocados-build.md
+++ b/.changeset/cool-avocados-build.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Aave amounts

--- a/packages/sdk/src/Portfolio/Integrations/AaveV3.ts
+++ b/packages/sdk/src/Portfolio/Integrations/AaveV3.ts
@@ -657,7 +657,7 @@ export async function getAvailableSupplyAmount(
 ) {
   const [reserveCaps, reserveData] = await Promise.all([getReserveCaps(client, args), getReserveData(client, args)]);
 
-  return reserveCaps.supplyCap * 10n ** BigInt(args.decimals) - reserveData.totalAToken;
+  return reserveCaps.supplyCap - reserveData.totalAToken;
 }
 
 export async function getAvailableVariableDebtAmount(
@@ -670,7 +670,7 @@ export async function getAvailableVariableDebtAmount(
 ) {
   const [reserveCaps, reserveData] = await Promise.all([getReserveCaps(client, args), getReserveData(client, args)]);
 
-  return reserveCaps.borrowCap * 10n ** BigInt(args.decimals) - reserveData.totalVariableDebt;
+  return reserveCaps.borrowCap - reserveData.totalVariableDebt;
 }
 
 const uiIncentiveDataProviderAbi = [


### PR DESCRIPTION
Remove double conversion.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the calculations for the supply and borrow caps in the `AaveV3` integration of the SDK. The changes simplify the return statements by removing the multiplication with `10n ** BigInt(args.decimals)`.

### Detailed summary
- In `packages/sdk/src/Portfolio/Integrations/AaveV3.ts`:
  - Updated the return statement in the function that handles supply cap calculation by removing the multiplication with `10n ** BigInt(args.decimals)`.
  - Updated the return statement in the function that handles borrow cap calculation similarly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->