### PR TITLE
feat: add ManualValueOracle and related

### DIFF
--- a/.changeset/seven-bugs-doubt.md
+++ b/.changeset/seven-bugs-doubt.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Add ManualValueOracle and related

--- a/.changeset/silly-guests-fix.md
+++ b/.changeset/silly-guests-fix.md
@@ -1,0 +1,6 @@
+---
+"@enzymefinance/environment": patch
+"@enzymefinance/sdk": patch
+---
+
+Add ManualValueOracle

--- a/packages/environment/src/contracts.ts
+++ b/packages/environment/src/contracts.ts
@@ -112,6 +112,7 @@ export interface SuluContracts extends CommonContracts {
   readonly LiquityDebtPositionLib: Address;
   readonly LiquityDebtPositionParser: Address;
   readonly ManagementFee: Address;
+  readonly ManualValueOracleFactory: Address;
   readonly MapleLiquidityPositionLib: Address;
   readonly MapleLiquidityPositionParser: Address;
   readonly MinAssetBalancesPostRedemptionPolicy: Address;

--- a/packages/environment/src/deployments/arbitrum.ts
+++ b/packages/environment/src/deployments/arbitrum.ts
@@ -166,6 +166,7 @@ export default defineDeployment<Deployment.ARBITRUM>({
         LiquityDebtPositionLib: "0x0000000000000000000000000000000000000000",
         LiquityDebtPositionParser: "0x0000000000000000000000000000000000000000",
         ManagementFee: "0xd2fa8f6706241dfdf8069d05e1d6f6c4a439aa86",
+        ManualValueOracleFactory: "0x0000000000000000000000000000000000000000",
         MapleLiquidityPositionLib: "0x0000000000000000000000000000000000000000",
         MapleLiquidityPositionParser: "0x0000000000000000000000000000000000000000",
         MinAssetBalancesPostRedemptionPolicy: "0x53a124c9201f0d00470cd4245946d2bbb98210ba",

--- a/packages/environment/src/deployments/arbitrum.ts
+++ b/packages/environment/src/deployments/arbitrum.ts
@@ -166,7 +166,7 @@ export default defineDeployment<Deployment.ARBITRUM>({
         LiquityDebtPositionLib: "0x0000000000000000000000000000000000000000",
         LiquityDebtPositionParser: "0x0000000000000000000000000000000000000000",
         ManagementFee: "0xd2fa8f6706241dfdf8069d05e1d6f6c4a439aa86",
-        ManualValueOracleFactory: "0x0000000000000000000000000000000000000000",
+        ManualValueOracleFactory: "0x671ed11497e8fe5c98ed45e699639cf081ee0a5f",
         MapleLiquidityPositionLib: "0x0000000000000000000000000000000000000000",
         MapleLiquidityPositionParser: "0x0000000000000000000000000000000000000000",
         MinAssetBalancesPostRedemptionPolicy: "0x53a124c9201f0d00470cd4245946d2bbb98210ba",

--- a/packages/environment/src/deployments/ethereum.ts
+++ b/packages/environment/src/deployments/ethereum.ts
@@ -183,7 +183,7 @@ export default defineDeployment<Deployment.ETHEREUM>({
         LiquityDebtPositionLib: "0x016b63941df5fd92b49f861559d8b7792629419f",
         LiquityDebtPositionParser: "0x55e41333d949f13c73ae99689d7137574d927d4b",
         ManagementFee: "0xfaf2c3db614e9d38fe05edc634848be7ff0542b9",
-        ManualValueOracleFactory: "0x0000000000000000000000000000000000000000",
+        ManualValueOracleFactory: "0x0edbb060a8f00f5967eecfc87c8559fa65501a3d",
         MapleLiquidityPositionLib: "0xb35623a479383b87da32fdde8dbe83fac5f6bf3d",
         MapleLiquidityPositionParser: "0x31915278772a2bc68cbfb7effe1209677b0aad10",
         MinAssetBalancesPostRedemptionPolicy: "0x58c0a2a546b3903fa68a53e34ee0c8a02aabfad0",

--- a/packages/environment/src/deployments/ethereum.ts
+++ b/packages/environment/src/deployments/ethereum.ts
@@ -183,6 +183,7 @@ export default defineDeployment<Deployment.ETHEREUM>({
         LiquityDebtPositionLib: "0x016b63941df5fd92b49f861559d8b7792629419f",
         LiquityDebtPositionParser: "0x55e41333d949f13c73ae99689d7137574d927d4b",
         ManagementFee: "0xfaf2c3db614e9d38fe05edc634848be7ff0542b9",
+        ManualValueOracleFactory: "0x0000000000000000000000000000000000000000",
         MapleLiquidityPositionLib: "0xb35623a479383b87da32fdde8dbe83fac5f6bf3d",
         MapleLiquidityPositionParser: "0x31915278772a2bc68cbfb7effe1209677b0aad10",
         MinAssetBalancesPostRedemptionPolicy: "0x58c0a2a546b3903fa68a53e34ee0c8a02aabfad0",

--- a/packages/environment/src/deployments/polygon.ts
+++ b/packages/environment/src/deployments/polygon.ts
@@ -170,7 +170,7 @@ export default defineDeployment<Deployment.POLYGON>({
         LiquityDebtPositionLib: "0x0000000000000000000000000000000000000000",
         LiquityDebtPositionParser: "0x0000000000000000000000000000000000000000",
         ManagementFee: "0x97f13b3040a565be791d331b0edd4b1b58dbd843",
-        ManualValueOracleFactory: "0x0000000000000000000000000000000000000000",
+        ManualValueOracleFactory: "0x735615beb04bfd3665f06541ea00af1860c4354f",
         MapleLiquidityPositionLib: "0x0000000000000000000000000000000000000000",
         MapleLiquidityPositionParser: "0x0000000000000000000000000000000000000000",
         MinAssetBalancesPostRedemptionPolicy: "0x9d940beaa6e3cfb441d49787fdf1db18d7f8251e",

--- a/packages/environment/src/deployments/polygon.ts
+++ b/packages/environment/src/deployments/polygon.ts
@@ -170,6 +170,7 @@ export default defineDeployment<Deployment.POLYGON>({
         LiquityDebtPositionLib: "0x0000000000000000000000000000000000000000",
         LiquityDebtPositionParser: "0x0000000000000000000000000000000000000000",
         ManagementFee: "0x97f13b3040a565be791d331b0edd4b1b58dbd843",
+        ManualValueOracleFactory: "0x0000000000000000000000000000000000000000",
         MapleLiquidityPositionLib: "0x0000000000000000000000000000000000000000",
         MapleLiquidityPositionParser: "0x0000000000000000000000000000000000000000",
         MinAssetBalancesPostRedemptionPolicy: "0x9d940beaa6e3cfb441d49787fdf1db18d7f8251e",

--- a/packages/environment/src/deployments/testnet.ts
+++ b/packages/environment/src/deployments/testnet.ts
@@ -193,7 +193,7 @@ export default defineDeployment<Deployment.TESTNET>({
     core: {
       slug: "enzyme-core-testnet",
       id: "98iFcdDw1g5akWxbTFqcs2TsUaJhVDNxPTgH8P2WBUao",
-      devVersion: "daiap-v3",
+      devVersion: "version/latest",
     },
     shares: {
       slug: "vault-shares-testnet",

--- a/packages/environment/src/deployments/testnet.ts
+++ b/packages/environment/src/deployments/testnet.ts
@@ -111,6 +111,7 @@ export default defineDeployment<Deployment.TESTNET>({
         LiquityDebtPositionLib: "0x0000000000000000000000000000000000000000",
         LiquityDebtPositionParser: "0x0000000000000000000000000000000000000000",
         ManagementFee: "0x4a95185896adce31a8cdfaaa2832decc3d20dc2c",
+        ManualValueOracleFactory: "0x0b7fa18e37e9bd2e156cac8467d164261f5119cc",
         MapleLiquidityPositionLib: "0x0000000000000000000000000000000000000000",
         MapleLiquidityPositionParser: "0x0000000000000000000000000000000000000000",
         MinAssetBalancesPostRedemptionPolicy: "0x7800955aae98c31e4eac22c1b4e7edd6ad0c3ba0",

--- a/packages/sdk/src/Portfolio/Integrations/ArbitraryLoan.ts
+++ b/packages/sdk/src/Portfolio/Integrations/ArbitraryLoan.ts
@@ -87,6 +87,32 @@ export function configureLoanDecode(encoded: Hex): ConfigureLoanArgs {
   };
 }
 
+const configureTotalNominalDeltaOracleModuleEncoding = [
+  {
+    name: "oracle",
+    type: "address",
+  },
+  {
+    name: "stalenessThreshold",
+    type: "uint32",
+  },
+] as const;
+
+export type ConfigureTotalNominalDeltaOracleModuleArgs = {
+  oracle: Address;
+  stalenessThreshold: number;
+};
+
+export function configureTotalNominalDeltaOracleModuleEncode(args: ConfigureTotalNominalDeltaOracleModuleArgs): Hex {
+  return encodeAbiParameters(configureTotalNominalDeltaOracleModuleEncoding, [args.oracle, args.stalenessThreshold]);
+}
+
+export function configureTotalNominalDeltaOracleModuleDecode(encoded: Hex): ConfigureTotalNominalDeltaOracleModuleArgs {
+  const [oracle, stalenessThreshold] = decodeAbiParameters(configureTotalNominalDeltaOracleModuleEncoding, encoded);
+
+  return { oracle, stalenessThreshold };
+}
+
 //--------------------------------------------------------------------------------------------
 // UPDATE BORROWABLE AMOUNT
 //--------------------------------------------------------------------------------------------

--- a/packages/sdk/src/Tools/ManualValueOracle.ts
+++ b/packages/sdk/src/Tools/ManualValueOracle.ts
@@ -1,0 +1,98 @@
+import { IManualValueOracleFactory, IManualValueOracleLib } from "@enzymefinance/abis";
+import { type Address, type Client, stringToHex } from "viem";
+import { readContract } from "viem/actions";
+import { Viem } from "../Utils.js";
+
+//--------------------------------------------------------------------------------------------
+// TRANSACTIONS
+//--------------------------------------------------------------------------------------------
+
+export function deploy(args: {
+  manualValueOracleFactory: Address;
+  owner: Address;
+  updater: Address;
+  description: string;
+}) {
+  return new Viem.PopulatedTransaction({
+    abi: IManualValueOracleFactory,
+    functionName: "deploy",
+    address: args.manualValueOracleFactory,
+    args: [args.owner, args.updater, stringToHex(args.description, { size: 32 })],
+  });
+}
+
+export function setUpdater(args: {
+  manualValueOracle: Address;
+  updater: Address;
+}) {
+  return new Viem.PopulatedTransaction({
+    abi: IManualValueOracleLib,
+    functionName: "setUpdater",
+    address: args.manualValueOracle,
+    args: [args.updater],
+  });
+}
+
+export function setNominatedOwner(args: {
+  manualValueOracle: Address;
+  nominatedOwner: Address;
+}) {
+  return new Viem.PopulatedTransaction({
+    abi: IManualValueOracleLib,
+    functionName: "setNominatedOwner",
+    address: args.manualValueOracle,
+    args: [args.nominatedOwner],
+  });
+}
+
+export function updateValue(args: {
+  manualValueOracle: Address;
+  value: bigint;
+}) {
+  return new Viem.PopulatedTransaction({
+    abi: IManualValueOracleLib,
+    functionName: "updateValue",
+    address: args.manualValueOracle,
+    args: [args.value],
+  });
+}
+
+//--------------------------------------------------------------------------------------------
+// READ FUNCTIONS
+//--------------------------------------------------------------------------------------------
+
+export function getValueWithTimestamp(
+  client: Client,
+  args: Viem.ContractCallParameters<{ manualValueOracle: Address }>,
+) {
+  return readContract(client, {
+    ...Viem.extractBlockParameters(args),
+    abi: IManualValueOracleLib,
+    address: args.manualValueOracle,
+    functionName: "getValueWithTimestamp",
+  });
+}
+export function getLastUpdated(client: Client, args: Viem.ContractCallParameters<{ manualValueOracle: Address }>) {
+  return readContract(client, {
+    ...Viem.extractBlockParameters(args),
+    abi: IManualValueOracleLib,
+    address: args.manualValueOracle,
+    functionName: "getLastUpdated",
+  });
+}
+export function getUpdater(client: Client, args: Viem.ContractCallParameters<{ manualValueOracle: Address }>) {
+  return readContract(client, {
+    ...Viem.extractBlockParameters(args),
+    abi: IManualValueOracleLib,
+    address: args.manualValueOracle,
+    functionName: "getUpdater",
+  });
+}
+export function getValue(client: Client, args: Viem.ContractCallParameters<{ manualValueOracle: Address }>) {
+  return readContract(client, {
+    ...Viem.extractBlockParameters(args),
+    abi: IManualValueOracleLib,
+    address: args.manualValueOracle,
+    functionName: "getValue",
+  });
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces the `ManualValueOracle` and related functionalities to the `@enzymefinance/sdk` and `@enzymefinance/environment` packages, enhancing the deployment scripts and SDK with new contract interactions.

### Detailed summary
- Added `ManualValueOracleFactory` to various deployment files.
- Updated `devVersion` from `"daiap-v3"` to `"version/latest"`.
- Introduced encoding and decoding functions for `ConfigureTotalNominalDeltaOracleModule`.
- Implemented transaction functions for deploying and managing `ManualValueOracle`.
- Added read functions to retrieve values from `ManualValueOracle`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->