### PR TITLE
chore: fix aave v3 tests

### DIFF
--- a/.changeset/quick-cups-mix.md
+++ b/.changeset/quick-cups-mix.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Fix aave v3 test

--- a/packages/environment/test/assets/aave-v3.test.ts
+++ b/packages/environment/test/assets/aave-v3.test.ts
@@ -1,7 +1,14 @@
 import { expect, test } from "vitest";
 
 import { AssetType } from "../../src/index.js";
+import { getClient } from "../utils/client.js";
+import {
+  getUnderlyingAssetAddressLowerCase,
+  getUnderlyingAssetAddressUpperCase,
+} from "../utils/contracts/AaveToken.js";
 import { environment } from "../utils/fixtures.js";
+
+const client = getClient(environment.network.id);
 
 const aaveV3Assets = environment.getAssets({ types: [AssetType.AAVE_V3] });
 const assets = environment.getAssets();
@@ -18,6 +25,14 @@ test.each(aaveV3Assets)("aave V3 underlying is correct: $symbol ($name): $id", a
     asset.registered ? environment.getAsset(asset.underlying).registered : true,
     "Underlying asset not registered",
   ).toBe(true);
+
+  const checksum = await getUnderlyingAssetAddressUpperCase(client, { asset: asset.id }).catch(() =>
+    getUnderlyingAssetAddressLowerCase(client, { asset: asset.id }),
+  );
+
+  console.log(checksum);
+
+  expect(checksum.toLowerCase(), "Actual underlying asset does not match expected").toBe(asset.underlying);
 });
 
 test.skip("empty test suite fallback");

--- a/packages/environment/test/assets/aave-v3.test.ts
+++ b/packages/environment/test/assets/aave-v3.test.ts
@@ -2,10 +2,7 @@ import { expect, test } from "vitest";
 
 import { AssetType } from "../../src/index.js";
 import { getClient } from "../utils/client.js";
-import {
-  getUnderlyingAssetAddressLowerCase,
-  getUnderlyingAssetAddressUpperCase,
-} from "../utils/contracts/AaveToken.js";
+import { getUnderlyingAssetAddressUpperCase } from "../utils/contracts/AaveToken.js";
 import { environment } from "../utils/fixtures.js";
 
 const client = getClient(environment.network.id);
@@ -14,6 +11,10 @@ const aaveV3Assets = environment.getAssets({ types: [AssetType.AAVE_V3] });
 const assets = environment.getAssets();
 
 test.each(aaveV3Assets)("aave V3 underlying is correct: $symbol ($name): $id", async (asset) => {
+  // check if underlying is correct
+  const checksum = await getUnderlyingAssetAddressUpperCase(client, { asset: asset.id });
+  expect(checksum.toLowerCase(), "Actual underlying asset does not match expected").toBe(asset.underlying);
+
   // Check that the underlying asset exists.
   expect(
     assets.filter((item) => item.id === asset.underlying).length,
@@ -25,14 +26,5 @@ test.each(aaveV3Assets)("aave V3 underlying is correct: $symbol ($name): $id", a
     asset.registered ? environment.getAsset(asset.underlying).registered : true,
     "Underlying asset not registered",
   ).toBe(true);
-
-  const checksum = await getUnderlyingAssetAddressUpperCase(client, { asset: asset.id }).catch(() =>
-    getUnderlyingAssetAddressLowerCase(client, { asset: asset.id }),
-  );
-
-  console.log(checksum);
-
-  expect(checksum.toLowerCase(), "Actual underlying asset does not match expected").toBe(asset.underlying);
 });
-
 test.skip("empty test suite fallback");


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing a test related to Aave V3 assets in the `packages/environment/test/assets/aave-v3.test.ts` file, ensuring that the underlying asset addresses are correctly validated.

### Detailed summary
- Added import for `getClient` and `getUnderlyingAssetAddressUpperCase`.
- Created a `client` instance using the environment's network ID.
- Validated that the underlying asset address matches the expected value.
- Added a check to ensure the underlying asset exists in the assets list.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->