### PR TITLE
feat: update GMX router

### DIFF
--- a/.changeset/stale-bats-juggle.md
+++ b/.changeset/stale-bats-juggle.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Update GMX router

--- a/packages/environment/src/deployments/arbitrum.ts
+++ b/packages/environment/src/deployments/arbitrum.ts
@@ -28,7 +28,7 @@ export default defineDeployment<Deployment.ARBITRUM>({
     curveMinter: "0x0000000000000000000000000000000000000000",
     curveRegistry: "0x0000000000000000000000000000000000000000",
     cvxCrvStaking: "0x0000000000000000000000000000000000000000",
-    gmxV2ExchangeRouter: "0x674ee2ffe588c4b1fde6d5481c55ef6133004cba",
+    gmxV2ExchangeRouter: "0x900173a66dbd345006c51fa35fa3ab760fcd843b",
     gmxV2ChainlinkPriceFeed: "0x527fb0bcff63c47761039bb386cfe181a92a4701",
     gmxV2DataStore: "0xfd70de6b91282d8017aa4e741e9ae325cab992d8",
     gmxV2Reader: "0x0537c767cdac0726c76bb89e92904fe28fd02fe1",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `gmxV2ExchangeRouter` address in the `arbitrum.ts` file as part of a patch for the `@enzymefinance/environment`.

### Detailed summary
- Updated `gmxV2ExchangeRouter` from `0x674ee2ffe588c4b1fde6d5481c55ef6133004cba` to `0x900173a66dbd345006c51fa35fa3ab760fcd843b` in `packages/environment/src/deployments/arbitrum.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->