### PR TITLE
chore: apply changeset release plan patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,10 @@
     "vite": "^5.4.2",
     "vite-tsconfig-paths": "^5.0.1",
     "vitest": "^2.0.5"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@changesets/assemble-release-plan": "patches/@changesets__assemble-release-plan.patch"
+    }
   }
 }

--- a/patches/@changesets__assemble-release-plan.patch
+++ b/patches/@changesets__assemble-release-plan.patch
@@ -1,0 +1,42 @@
+diff --git a/dist/changesets-assemble-release-plan.cjs.js b/dist/changesets-assemble-release-plan.cjs.js
+index e32a5e5d39c3bd920201b5694632d2b44c92d486..219118d1a9e22df3ece9c5560decb5862ea4a16f 100644
+--- a/dist/changesets-assemble-release-plan.cjs.js
++++ b/dist/changesets-assemble-release-plan.cjs.js
+@@ -228,16 +228,6 @@ function determineDependents({
+         } of dependencyVersionRanges) {
+           if (nextRelease.type === "none") {
+             continue;
+-          } else if (shouldBumpMajor({
+-            dependent,
+-            depType,
+-            versionRange,
+-            releases,
+-            nextRelease,
+-            preInfo,
+-            onlyUpdatePeerDependentsWhenOutOfRange: config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange
+-          })) {
+-            type = "major";
+           } else if ((!releases.has(dependent) || releases.get(dependent).type === "none") && (config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.updateInternalDependents === "always" || !semverSatisfies__default["default"](incrementVersion(nextRelease, preInfo), versionRange))) {
+             switch (depType) {
+               case "dependencies":
+diff --git a/dist/changesets-assemble-release-plan.esm.js b/dist/changesets-assemble-release-plan.esm.js
+index 221822a2e3ac86431b8aadeaf5f01eaee72a5c8e..d9bb557ff3fe5e31934d86dc24a72e176b3a413f 100644
+--- a/dist/changesets-assemble-release-plan.esm.js
++++ b/dist/changesets-assemble-release-plan.esm.js
+@@ -217,16 +217,6 @@ function determineDependents({
+         } of dependencyVersionRanges) {
+           if (nextRelease.type === "none") {
+             continue;
+-          } else if (shouldBumpMajor({
+-            dependent,
+-            depType,
+-            versionRange,
+-            releases,
+-            nextRelease,
+-            preInfo,
+-            onlyUpdatePeerDependentsWhenOutOfRange: config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange
+-          })) {
+-            type = "major";
+           } else if ((!releases.has(dependent) || releases.get(dependent).type === "none") && (config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.updateInternalDependents === "always" || !semverSatisfies(incrementVersion(nextRelease, preInfo), versionRange))) {
+             switch (depType) {
+               case "dependencies":

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@changesets/assemble-release-plan':
+    hash: 7yy5fjjkdxu3dwnn7xxfsjv3ym
+    path: patches/@changesets__assemble-release-plan.patch
+
 importers:
 
   .:
@@ -4223,7 +4228,7 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.6.3
 
-  '@changesets/assemble-release-plan@6.0.3':
+  '@changesets/assemble-release-plan@6.0.3(patch_hash=7yy5fjjkdxu3dwnn7xxfsjv3ym)':
     dependencies:
       '@babel/runtime': 7.25.4
       '@changesets/errors': 0.2.0
@@ -4249,7 +4254,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.25.4
       '@changesets/apply-release-plan': 7.0.4
-      '@changesets/assemble-release-plan': 6.0.3
+      '@changesets/assemble-release-plan': 6.0.3(patch_hash=7yy5fjjkdxu3dwnn7xxfsjv3ym)
       '@changesets/changelog-git': 0.2.0
       '@changesets/config': 3.0.2
       '@changesets/errors': 0.2.0
@@ -4312,7 +4317,7 @@ snapshots:
   '@changesets/get-release-plan@4.0.3':
     dependencies:
       '@babel/runtime': 7.25.4
-      '@changesets/assemble-release-plan': 6.0.3
+      '@changesets/assemble-release-plan': 6.0.3(patch_hash=7yy5fjjkdxu3dwnn7xxfsjv3ym)
       '@changesets/config': 3.0.2
       '@changesets/pre': 2.0.0
       '@changesets/read': 0.6.0


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a patch for the `@changesets/assemble-release-plan` package and updating its dependencies in both `package.json` and `pnpm-lock.yaml`. It also modifies the logic in the `changesets-assemble-release-plan` files to handle version bumps more effectively.

### Detailed summary
- Added `patchedDependencies` for `@changesets/assemble-release-plan` in `package.json`.
- Updated logic in `dist/changesets-assemble-release-plan.esm.js` and `dist/changesets-assemble-release-plan.cjs.js` to handle `nextRelease.type`.
- Updated `pnpm-lock.yaml` to include patch information for `@changesets/assemble-release-plan`. 
- Changed version references in `pnpm-lock.yaml` to include `patch_hash`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->