### PR TITLE
feat: add 31 third adapter on arbitrum

### DIFF
--- a/.changeset/weak-falcons-mate.md
+++ b/.changeset/weak-falcons-mate.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Add 31Third adapter on Arbitrum

--- a/packages/environment/src/deployments/arbitrum.ts
+++ b/packages/environment/src/deployments/arbitrum.ts
@@ -213,7 +213,7 @@ export default defineDeployment<Deployment.ARBITRUM>({
         TermFinanceV1LendingPositionParser: "0x0000000000000000000000000000000000000000",
         TheGraphDelegationPositionLib: "0x92da9df390d3e9199d105289b297eca357ecc9b7",
         TheGraphDelegationPositionParser: "0xc2822eca13a7760141041a173c1b9b13e22515f6",
-        ThreeOneThirdAdapter: "0x0000000000000000000000000000000000000000",
+        ThreeOneThirdAdapter: "0x908c0c476c0dc8f7b6d6b6aa34f0349a714380b8",
         TransferAssetsAdapter: "0xe8db4924569a3c61aadfb721bbb009e3127196bd",
         UintListRegistry: "0xc438e48f5d2f99eb4a2b9865f8cccfc9915f227a",
         UniswapV2ExchangeAdapter: "0x0000000000000000000000000000000000000000",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding the `31Third` adapter to the `Arbitrum` deployment in the `environment` package.

### Detailed summary
- Updated the `ThreeOneThirdAdapter` address from `"0x0000000000000000000000000000000000000000"` to `"0x908c0c476c0dc8f7b6d6b6aa34f0349a714380b8"` in `packages/environment/src/deployments/arbitrum.ts`. 
- Added a note about the addition of the `31Third` adapter.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->