### PR TITLE
chore: rename dlcBTC to iBTC

### DIFF
--- a/packages/environment/src/assets/arbitrum.ts
+++ b/packages/environment/src/assets/arbitrum.ts
@@ -685,9 +685,9 @@ export default defineAssetList(Network.ARBITRUM, [
   {
     decimals: 8,
     id: "0x050c24dbf1eec17babe5fc585f06116a259cc77a",
-    name: "dlcBTC",
+    name: "iBTC",
     releases: [sulu],
-    symbol: "dlcBTC",
+    symbol: "IBTC",
     type: AssetType.PRIMITIVE,
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -2668,9 +2668,9 @@ export default defineAssetList(Network.ETHEREUM, [
   {
     decimals: 8,
     id: "0x20157dbabb84e3bbfe68c349d0d44e48ae7b5ad2",
-    name: "dlcBTC",
+    name: "iBTC",
     releases: [sulu],
-    symbol: "DLCBTC",
+    symbol: "IBTC",
     type: AssetType.PRIMITIVE,
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,


### PR DESCRIPTION
Apparently this was changed on-chain, see nightly test fail: https://github.com/enzymefinance/sdk/actions/runs/12041206275