### PR TITLE
feat: update 31Third adapter addresses

### DIFF
--- a/.changeset/soft-buttons-fry.md
+++ b/.changeset/soft-buttons-fry.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Update 31Third adapter addresses

--- a/packages/environment/src/deployments/arbitrum.ts
+++ b/packages/environment/src/deployments/arbitrum.ts
@@ -215,7 +215,7 @@ export default defineDeployment<Deployment.ARBITRUM>({
         TermFinanceV1LendingPositionParser: "0x0000000000000000000000000000000000000000",
         TheGraphDelegationPositionLib: "0x92da9df390d3e9199d105289b297eca357ecc9b7",
         TheGraphDelegationPositionParser: "0xc2822eca13a7760141041a173c1b9b13e22515f6",
-        ThreeOneThirdAdapter: "0x908c0c476c0dc8f7b6d6b6aa34f0349a714380b8",
+        ThreeOneThirdAdapter: "0x5a1c0e89133c4cd844a8b345370565f1368a79a8",
         TransferAssetsAdapter: "0xe8db4924569a3c61aadfb721bbb009e3127196bd",
         UintListRegistry: "0xc438e48f5d2f99eb4a2b9865f8cccfc9915f227a",
         UniswapV2ExchangeAdapter: "0x0000000000000000000000000000000000000000",

--- a/packages/environment/src/deployments/ethereum.ts
+++ b/packages/environment/src/deployments/ethereum.ts
@@ -234,7 +234,7 @@ export default defineDeployment<Deployment.ETHEREUM>({
         TermFinanceV1LendingPositionParser: "0xa95c7bab91692df52255b8ad50c5ed2bcc9064ad",
         TheGraphDelegationPositionLib: "0x6fff66d55698a601e91989c44349da8a2a9a7848",
         TheGraphDelegationPositionParser: "0x2226d7687109d6b6a0882f8eef2b4a4c90dc677e",
-        ThreeOneThirdAdapter: "0x908c0c476c0dc8f7b6d6b6aa34f0349a714380b8",
+        ThreeOneThirdAdapter: "0x5a1c0e89133c4cd844a8b345370565f1368a79a8",
         TransferAssetsAdapter: "0xe0309fa2412b811a0bd40a73297093707259217f",
         UintListRegistry: "0x6ffd6fc068e7b365af18da4fdc39d3289159407b",
         UniswapV2ExchangeAdapter: "0x8c36435a653041bfd65515cc82502663c1ce6f0e",

--- a/packages/environment/src/deployments/polygon.ts
+++ b/packages/environment/src/deployments/polygon.ts
@@ -219,7 +219,7 @@ export default defineDeployment<Deployment.POLYGON>({
         TermFinanceV1LendingPositionParser: "0x0000000000000000000000000000000000000000",
         TheGraphDelegationPositionLib: "0x0000000000000000000000000000000000000000",
         TheGraphDelegationPositionParser: "0x0000000000000000000000000000000000000000",
-        ThreeOneThirdAdapter: "0x908c0c476c0dc8f7b6d6b6aa34f0349a714380b8",
+        ThreeOneThirdAdapter: "0x5a1c0e89133c4cd844a8b345370565f1368a79a8",
         TransferAssetsAdapter: "0x52e83a4c9a123500e8324b9f489a681ffda92a17",
         UintListRegistry: "0x6ddd871c1607348ebb5be250f882255390166519",
         UniswapV2ExchangeAdapter: "0x0000000000000000000000000000000000000000",

--- a/packages/environment/src/deployments/testnet.ts
+++ b/packages/environment/src/deployments/testnet.ts
@@ -158,7 +158,7 @@ export default defineDeployment<Deployment.TESTNET>({
         TermFinanceV1LendingPositionParser: "0x0000000000000000000000000000000000000000",
         TheGraphDelegationPositionLib: "0x0000000000000000000000000000000000000000",
         TheGraphDelegationPositionParser: "0x0000000000000000000000000000000000000000",
-        ThreeOneThirdAdapter: "0x1112a89180fc465b648866b98f0e54237b07eaee",
+        ThreeOneThirdAdapter: "0x0c4dc97e6c0d94327f3ca1873ae5868f5d0a6f05",
         TransferAssetsAdapter: "0x0000000000000000000000000000000000000000",
         UintListRegistry: "0xe296ea33a38108580dcae364239fb0c50c53591b",
         UniswapV2ExchangeAdapter: "0x0000000000000000000000000000000000000000",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the addresses of the `ThreeOneThirdAdapter` across multiple deployment files in the `packages/environment/src/deployments` directory.

### Detailed summary
- Updated `ThreeOneThirdAdapter` address in:
  - `packages/environment/src/deployments/polygon.ts`: from `"0x908c0c476c0dc8f7b6d6b6aa34f0349a714380b8"` to `"0x5a1c0e89133c4cd844a8b345370565f1368a79a8"`
  - `packages/environment/src/deployments/testnet.ts`: from `"0x1112a89180fc465b648866b98f0e54237b07eaee"` to `"0x0c4dc97e6c0d94327f3ca1873ae5868f5d0a6f05"`
  - `packages/environment/src/deployments/arbitrum.ts`: from `"0x908c0c476c0dc8f7b6d6b6aa34f0349a714380b8"` to `"0x5a1c0e89133c4cd844a8b345370565f1368a79a8"`
  - `packages/environment/src/deployments/ethereum.ts`: from `"0x908c0c476c0dc8f7b6d6b6aa34f0349a714380b8"` to `"0x5a1c0e89133c4cd844a8b345370565f1368a79a8"`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->