### PR TITLE
feat: use USD based price feeds for stablecoins

### DIFF
--- a/.changeset/curvy-carpets-press.md
+++ b/.changeset/curvy-carpets-press.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Use USD based feeds for stablecoins

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -52,8 +52,8 @@ export default defineAssetList(Network.ETHEREUM, [
     type: AssetType.PRIMITIVE,
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0x986b5e1e1755e3c2440e960477f25201b0a8bbd4",
-      rateAsset: RateAsset.ETH,
+      aggregator: "0x8fffffd4afb6115b954bd326cbe7b4ba576818f6",
+      rateAsset: RateAsset.USD,
       peggedTo: "USDC",
       nonStandard: true,
     },
@@ -2752,8 +2752,8 @@ export default defineAssetList(Network.ETHEREUM, [
     type: AssetType.PRIMITIVE,
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0x14d04fff8d21bd62987a5ce9ce543d2f1edf5d3e",
-      rateAsset: RateAsset.ETH,
+      aggregator: "0xb9e1e3a9feff48998e45fa90847ed4d467e8bcfd",
+      rateAsset: RateAsset.USD,
     },
   },
   {
@@ -3369,8 +3369,8 @@ export default defineAssetList(Network.ETHEREUM, [
     type: AssetType.PRIMITIVE,
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0x986b5e1e1755e3c2440e960477f25201b0a8bbd4",
-      rateAsset: RateAsset.ETH,
+      aggregator: "0x8fffffd4afb6115b954bd326cbe7b4ba576818f6",
+      rateAsset: RateAsset.USD,
     },
   },
   {
@@ -4106,8 +4106,8 @@ export default defineAssetList(Network.ETHEREUM, [
     underlying: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0x986b5e1e1755e3c2440e960477f25201b0a8bbd4",
-      rateAsset: RateAsset.ETH,
+      aggregator: "0x8fffffd4afb6115b954bd326cbe7b4ba576818f6",
+      rateAsset: RateAsset.USD,
     },
   },
   {
@@ -4120,8 +4120,8 @@ export default defineAssetList(Network.ETHEREUM, [
     underlying: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0x986b5e1e1755e3c2440e960477f25201b0a8bbd4",
-      rateAsset: RateAsset.ETH,
+      aggregator: "0x8fffffd4afb6115b954bd326cbe7b4ba576818f6",
+      rateAsset: RateAsset.USD,
     },
   },
   {
@@ -4818,8 +4818,8 @@ export default defineAssetList(Network.ETHEREUM, [
     type: AssetType.PRIMITIVE,
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0xee9f2375b4bdf6387aa8265dd4fb8f16512a1d46",
-      rateAsset: RateAsset.ETH,
+      aggregator: "0x3e7d1eab13ad0104d2750b8863b489d65364e32d",
+      rateAsset: RateAsset.USD,
     },
   },
   {

--- a/packages/environment/src/assets/polygon.ts
+++ b/packages/environment/src/assets/polygon.ts
@@ -353,8 +353,8 @@ export default defineAssetList(Network.POLYGON, [
     underlying: "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0xefb7e6be8356ccc6827799b6a7348ee674a80eae",
-      rateAsset: RateAsset.ETH,
+      aggregator: "0xfe4a8cc5b5b2366c1b58bea3858e81843581b2f7",
+      rateAsset: RateAsset.USD,
     },
   },
   {
@@ -367,8 +367,8 @@ export default defineAssetList(Network.POLYGON, [
     underlying: "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0xefb7e6be8356ccc6827799b6a7348ee674a80eae",
-      rateAsset: RateAsset.ETH,
+      aggregator: "0xfe4a8cc5b5b2366c1b58bea3858e81843581b2f7",
+      rateAsset: RateAsset.USD,
     },
   },
   {
@@ -499,8 +499,8 @@ export default defineAssetList(Network.POLYGON, [
     type: AssetType.PRIMITIVE,
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0xefb7e6be8356ccc6827799b6a7348ee674a80eae",
-      rateAsset: RateAsset.ETH,
+      aggregator: "0xfe4a8cc5b5b2366c1b58bea3858e81843581b2f7",
+      rateAsset: RateAsset.USD,
     },
   },
   {
@@ -677,8 +677,8 @@ export default defineAssetList(Network.POLYGON, [
     type: AssetType.PRIMITIVE,
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0xefb7e6be8356ccc6827799b6a7348ee674a80eae",
-      rateAsset: RateAsset.ETH,
+      aggregator: "0xfe4a8cc5b5b2366c1b58bea3858e81843581b2f7",
+      rateAsset: RateAsset.USD,
     },
   },
   {
@@ -845,8 +845,8 @@ export default defineAssetList(Network.POLYGON, [
     underlying: "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0xf9d5aac6e5572aefa6bd64108ff86a222f69b64d",
-      rateAsset: RateAsset.ETH,
+      aggregator: "0x0a6513e40db6eb1b165753ad52e80663aea50545",
+      rateAsset: RateAsset.USD,
     },
   },
   {
@@ -859,8 +859,8 @@ export default defineAssetList(Network.POLYGON, [
     underlying: "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0xf9d5aac6e5572aefa6bd64108ff86a222f69b64d",
-      rateAsset: RateAsset.ETH,
+      aggregator: "0x0a6513e40db6eb1b165753ad52e80663aea50545",
+      rateAsset: RateAsset.USD,
     },
   },
   {
@@ -1139,8 +1139,8 @@ export default defineAssetList(Network.POLYGON, [
     type: AssetType.PRIMITIVE,
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0xf9d5aac6e5572aefa6bd64108ff86a222f69b64d",
-      rateAsset: RateAsset.ETH,
+      aggregator: "0x0a6513e40db6eb1b165753ad52e80663aea50545",
+      rateAsset: RateAsset.USD,
     },
   },
   {
@@ -1553,8 +1553,8 @@ export default defineAssetList(Network.POLYGON, [
     underlying: "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0xefb7e6be8356ccc6827799b6a7348ee674a80eae",
-      rateAsset: RateAsset.ETH,
+      aggregator: "0xfe4a8cc5b5b2366c1b58bea3858e81843581b2f7",
+      rateAsset: RateAsset.USD,
     },
   },
   {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `priceFeed` configurations for various assets in both the `ethereum.ts` and `polygon.ts` files. The changes involve modifying the `aggregator` addresses and changing the `rateAsset` from `RateAsset.ETH` to `RateAsset.USD`.

### Detailed summary
- Updated `aggregator` addresses in `ethereum.ts`:
  - Changed from `"0x986b5e1e1755e3c2440e960477f25201b0a8bbd4"` to `"0x8fffffd4afb6115b954bd326cbe7b4ba576818f6"` for one asset.
  - Changed from `"0x14d04fff8d21bd62987a5ce9ce543d2f1edf5d3e"` to `"0xb9e1e3a9feff48998e45fa90847ed4d467e8bcfd"` for another asset.
  - Repeated similar changes for multiple assets, with all aggregators updated to new addresses.
- Changed `rateAsset` from `RateAsset.ETH` to `RateAsset.USD` for all affected assets in `ethereum.ts`.
- Updated `aggregator` addresses in `polygon.ts`:
  - Changed from `"0xefb7e6be8356ccc6827799b6a7348ee674a80eae"` to `"0xfe4a8cc5b5b2366c1b58bea3858e81843581b2f7"` for several assets.
  - Similar updates made across multiple assets.
- Changed `rateAsset` from `RateAsset.ETH` to `RateAsset.USD` for all affected assets in `polygon.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->