### PR TITLE
feat: add aioz token

### DIFF
--- a/.changeset/cuddly-badgers-turn.md
+++ b/.changeset/cuddly-badgers-turn.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Add AIOZ token

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7411,4 +7411,15 @@ export default defineAssetList(Network.ETHEREUM, [
       rateAsset: RateAsset.USD,
     },
   },
+  {
+    decimals: 18,
+    id: "0x626e8036deb333b408be468f951bdb42433cbf18",
+    name: "AIOZ Network",
+    releases: [],
+    symbol: "AIOZ",
+    type: AssetType.PRIMITIVE,
+    priceFeed: {
+      type: PriceFeedType.NONE,
+    },
+  },
 ]);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding support for the `AIOZ` token in the `environment` package.

### Detailed summary
- Updated the patch for `@enzymefinance/environment`.
- Added a new asset entry for `AIOZ Network` in `packages/environment/src/assets/ethereum.ts` with the following details:
  - `decimals`: 18
  - `id`: "0x626e8036deb333b408be468f951bdb42433cbf18"
  - `name`: "AIOZ Network"
  - `symbol`: "AIOZ"
  - `type`: `AssetType.PRIMITIVE`
  - `priceFeed`: `{ type: PriceFeedType.NONE }`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->