### PR TITLE
fix: fix Aave v3 asset type

### DIFF
--- a/.changeset/neat-tables-arrive.md
+++ b/.changeset/neat-tables-arrive.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Aave v3 asset type

--- a/packages/environment/src/assets/base.ts
+++ b/packages/environment/src/assets/base.ts
@@ -99,7 +99,8 @@ export default defineAssetList(Network.BASE, [
     name: "Aave Base WETH",
     releases: [sulu],
     symbol: "aBasWETH",
-    type: AssetType.PRIMITIVE,
+    type: AssetType.AAVE_V3,
+    underlying: "0x4200000000000000000000000000000000000006",
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
       aggregator: "0x71041dddad3595f9ced3dccfbe3d1f4b0a16bb70",
@@ -112,7 +113,8 @@ export default defineAssetList(Network.BASE, [
     name: "Aave Base USDC",
     releases: [sulu],
     symbol: "aBasUSDC",
-    type: AssetType.PRIMITIVE,
+    type: AssetType.AAVE_V3,
+    underlying: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
       aggregator: "0x7e860098f58bbfc8648a4311b374b1d669a2bc6b",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates asset definitions in the `packages/environment/src/assets/base.ts` file to introduce a new asset type for Aave v3. It modifies existing assets to reflect this change and adds underlying addresses for them.

### Detailed summary
- Changed asset `type` from `AssetType.PRIMITIVE` to `AssetType.AAVE_V3` for:
  - `Aave Base WETH`
  - `Aave Base USDC`
- Added `underlying` addresses for both assets:
  - `aBasWETH`: `"0x4200000000000000000000000000000000000006"`
  - `aBasUSDC`: `"0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->