### PR TITLE
chore: fix price feed test

### DIFF
--- a/packages/environment/test/assets/price-feed.test.ts
+++ b/packages/environment/test/assets/price-feed.test.ts
@@ -73,7 +73,7 @@ suite.each(assets)("$symbol ($name): $id", (asset) => {
           aggregatorDecimals(client, { aggregator: asset.priceFeed.aggregator }),
         ]);
 
-        expect(description).toMatch(/^Red(?:s|S)tone Price Feed(?: for SolvBTC)*$/);
+        expect(description).toMatch(/^Red(?:s|S)tone Price Feed/);
         expect(decimals).toBe(asset.priceFeed.rateAsset === 0 ? 18 : 8);
 
         break;


### PR DESCRIPTION
Fixes the price-feed test because RedStone changed the name of a price feed.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating a test in the `price-feed.test.ts` file to modify the expected format of the `description` string.

### Detailed summary
- Changed the regex in `expect(description).toMatch(...)` from `/^Red(?:s|S)tone Price Feed(?: for SolvBTC)*$/` to `/^Red(?:s|S)tone Price Feed/` to allow for more flexible matching of the `description`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->