### PR TITLE
chore: environment update

### DIFF
--- a/.changeset/warm-cats-love.md
+++ b/.changeset/warm-cats-love.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Change ETHx price feed

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -3463,8 +3463,8 @@ export default defineAssetList(Network.ETHEREUM, [
     symbol: "ETHx",
     type: AssetType.PRIMITIVE,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_REDSTONE_NON_STANDARD_PRECISION,
-      aggregator: "0x8c7fe497fcd0c4f75da39aef3c69e024915f4239",
+      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ETHX,
+      aggregator: "0x75c4dc3201015c78a60dbe673fc7247549527c1b",
       rateAsset: RateAsset.ETH,
     },
   },

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -190,8 +190,8 @@ export default defineAssetList(Network.ETHEREUM, [
     type: AssetType.AAVE_V3,
     underlying: "0xa35b1b31ce002fbf2058d22f30f95d405200a15b",
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_REDSTONE_NON_STANDARD_PRECISION,
-      aggregator: "0x8c7fe497fcd0c4f75da39aef3c69e024915f4239",
+      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ETHX,
+      aggregator: "0x75c4dc3201015c78a60dbe673fc7247549527c1b",
       rateAsset: RateAsset.ETH,
     },
   },

--- a/packages/environment/src/price-feeds.ts
+++ b/packages/environment/src/price-feeds.ts
@@ -4,6 +4,7 @@ export enum PriceFeedType {
   NONE = "NONE",
   WETH = "WETH",
   PRIMITIVE_CHAINLINK = "PRIMITIVE_CHAINLINK",
+  PRIMITIVE_CHAINLINK_LIKE_ETHX = "PRIMITIVE_CHAINLINK_LIKE_ETHX",
   PRIMITIVE_CHAINLINK_LIKE_WSTETH = "PRIMITIVE_CHAINLINK_LIKE_WSTETH",
   PRIMITIVE_CHAINLINK_LIKE_YNETH = "PRIMITIVE_CHAINLINK_LIKE_YNETH",
   PRIMITIVE_REDSTONE = "PRIMITIVE_REDSTONE",
@@ -27,6 +28,7 @@ export enum PriceFeedType {
 
 export const primitivePriceFeeds = [
   PriceFeedType.PRIMITIVE_CHAINLINK,
+  PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ETHX,
   PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_WSTETH,
   PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_YNETH,
   PriceFeedType.PRIMITIVE_REDSTONE,
@@ -59,6 +61,7 @@ export type PriceFeed =
   | NoPriceFeed
   | WethPriceFeed
   | PrimitiveChainlinkPriceFeed
+  | PrimitiveChainlinkLikeEthxPriceFeed
   | PrimitiveChainlinkLikeWstEthPriceFeed
   | PrimitiveChainlinkLikeYnEthPriceFeed
   | PrimitiveRedstonePriceFeed
@@ -118,6 +121,17 @@ export interface PrimitiveChainlinkLikeWstEthPriceFeed extends PriceFeedBase {
 
 export interface PrimitiveChainlinkLikeYnEthPriceFeed extends PriceFeedBase {
   readonly type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_YNETH;
+  /**
+   * Aggregator address
+   */
+  readonly aggregator: Address;
+  /**
+   * Rate Asset (ETH = 0, USD = 1)
+   */
+  readonly rateAsset: RateAsset.ETH;
+}
+export interface PrimitiveChainlinkLikeEthxPriceFeed extends PriceFeedBase {
+  readonly type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ETHX;
   /**
    * Aggregator address
    */

--- a/packages/environment/test/assets/price-feed.test.ts
+++ b/packages/environment/test/assets/price-feed.test.ts
@@ -109,6 +109,7 @@ suite.each(assets)("$symbol ($name): $id", (asset) => {
       }
 
       case PriceFeedType.PRIMITIVE_CHAINLINK:
+      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ETHX:
       case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_WSTETH:
       case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_YNETH:
       case PriceFeedType.PRIMITIVE_REDSTONE:
@@ -216,6 +217,7 @@ suite.each(assets)("$symbol ($name): $id", (asset) => {
       case PriceFeedType.NONE:
       case PriceFeedType.WETH:
       case PriceFeedType.PRIMITIVE_CHAINLINK:
+      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ETHX:
       case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_WSTETH:
       case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_YNETH:
       case PriceFeedType.PRIMITIVE_REDSTONE:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new price feed type for ETHx, specifically `PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ETHX`, and updates related interfaces and test cases accordingly.

### Detailed summary
- Added `PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ETHX` to `price-feeds.ts`.
- Updated price feed references in `ethereum.ts` and asset definitions.
- Modified test cases in `price-feed.test.ts` to include the new price feed type.
- Created a new interface `PrimitiveChainlinkLikeEthxPriceFeed`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->