### PR TITLE
feat: update gmx lib

### DIFF
--- a/.changeset/silver-mirrors-wash.md
+++ b/.changeset/silver-mirrors-wash.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Update GMX lib

--- a/packages/environment/src/deployments/arbitrum.ts
+++ b/packages/environment/src/deployments/arbitrum.ts
@@ -160,7 +160,7 @@ export default defineDeployment<Deployment.ARBITRUM>({
         GenericAdapter: "0x0000000000000000000000000000000000000000",
         GlobalConfigLib: "0x211e54a2f1e83cabc9d1211a1df0759b7193201a",
         GlobalConfigProxy: "0xf9315b421904eadf2f8fce776958c147ee9bc880",
-        GMXV2LeverageTradingPositionLib: "0x4c7effa8d83c46cc6eca8501610f52781bca162f",
+        GMXV2LeverageTradingPositionLib: "0x64e4a778f82a49738714e390ae97f17434fd2156",
         GMXV2LeverageTradingPositionParser: "0x0645b362a0d43e005f46713d1857e193f665810e",
         IntegrationManager: "0x55df97aca98c2a708721f28ea1ca42a2be7ff934",
         KilnStakingPositionLib: "0x0000000000000000000000000000000000000000",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `GMX` library in the `environment` package for the Arbitrum deployment, specifically changing the address of the `GMXV2LeverageTradingPositionLib`.

### Detailed summary
- Updated the `GMXV2LeverageTradingPositionLib` address to `0x64e4a778f82a49738714e390ae97f17434fd2156`.
- Retained other library addresses including `GlobalConfigLib`, `GlobalConfigProxy`, `GMXV2LeverageTradingPositionParser`, `IntegrationManager`, and `KilnStakingPositionLib`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->