### PR TITLE
feat: update pendle v2

### DIFF
--- a/.changeset/mean-jeans-sparkle.md
+++ b/.changeset/mean-jeans-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Update pendle v2

--- a/packages/environment/src/assets.ts
+++ b/packages/environment/src/assets.ts
@@ -341,6 +341,10 @@ export interface PendleV2PTAsset extends AssetBase {
    * Underlying Asset.
    */
   readonly underlying: Address;
+  /**
+   * Market.
+   */
+  readonly market: Address;
 }
 
 export function defineAssetList<TNetwork extends Network>(

--- a/packages/environment/src/assets.ts
+++ b/packages/environment/src/assets.ts
@@ -63,7 +63,8 @@ export type Asset =
   | IdleAsset
   | MapleV1Asset
   | MapleV2Asset
-  | PendleV2Asset
+  | PendleV2PTAsset
+  | PendleV2LPAsset
   | PrimitiveAsset
   | StaderAsset
   | SynthetixAsset
@@ -80,6 +81,7 @@ export enum AssetType {
   CURVE_POOL_LP = "curve-pool-lp",
   CURVE_POOL_GAUGE = "curve-pool-gauge",
   IDLE = "idle",
+  PENDLE_V2_LP = "pendle-v2-lp",
   PENDLE_V2_PT = "pendle-v2-pt",
   PRIMITIVE = "primitive",
   STADER = "stader",
@@ -325,7 +327,15 @@ export interface CurvePoolGaugeAsset extends AssetBase {
   readonly underlyings: Array<Address>;
 }
 
-export interface PendleV2Asset extends AssetBase {
+export interface PendleV2LPAsset extends AssetBase {
+  readonly type: AssetType.PENDLE_V2_LP;
+  /**
+   * Underlying Asset.
+   */
+  readonly underlying: Address;
+}
+
+export interface PendleV2PTAsset extends AssetBase {
   readonly type: AssetType.PENDLE_V2_PT;
   /**
    * Underlying Asset.

--- a/packages/environment/src/assets.ts
+++ b/packages/environment/src/assets.ts
@@ -344,7 +344,7 @@ export interface PendleV2PTAsset extends AssetBase {
   /**
    * Market.
    */
-  readonly market: Address;
+  readonly markets: ReadonlyArray<Address>;
 }
 
 export function defineAssetList<TNetwork extends Network>(

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7428,6 +7428,20 @@ export default defineAssetList(Network.ETHEREUM, [
     },
   },
   {
+    symbol: "PENDLE-LPT",
+    name: "Pendle Market", // sUSDe 29 May 2025
+    id: "0xb162b764044697cf03617c2efbcb1f42e31e4766",
+    type: AssetType.PENDLE_V2_LP,
+    releases: [],
+    decimals: 18,
+    underlying: "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
+    priceFeed: {
+      type: PriceFeedType.PRIMITIVE_PENDLE_V2,
+      aggregator: "0xFF3BC18cCBd5999CE63E788A1c250a88626aD099",
+      rateAsset: RateAsset.USD,
+    },
+  },
+  {
     decimals: 18,
     id: "0x626e8036deb333b408be468f951bdb42433cbf18",
     name: "AIOZ Network",

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7403,7 +7403,7 @@ export default defineAssetList(Network.ETHEREUM, [
     type: AssetType.PENDLE_V2_PT,
     releases: [sulu],
     decimals: 8,
-    market: "0x0000000000000000000000000000000000000000", // TODO: Update this
+    market: "0xeb4d3057738b9ed930f451be473c1ccc42988384",
     underlying: "0xd9d920aa40f578ab794426f5c90f6c731d159def",
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_PENDLE_V2,

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -858,7 +858,7 @@ export default defineAssetList(Network.ETHEREUM, [
     type: AssetType.PRIMITIVE,
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0xdeb288f737066589598e9214e782fa5a8ed689e8", // TODO: update when Price Feed utils available
+      aggregator: "0xdeb288f737066589598e9214e782fa5a8ed689e8", // TODO: update when Price Feed utils available, so we can create WBTC/USD, and WBTC/ETH price feeds
       rateAsset: RateAsset.ETH,
       peggedTo: "BTC",
     },
@@ -3287,7 +3287,7 @@ export default defineAssetList(Network.ETHEREUM, [
     underlying: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0xdeb288f737066589598e9214e782fa5a8ed689e8", // TODO: update when Price Feed utils available
+      aggregator: "0xdeb288f737066589598e9214e782fa5a8ed689e8", // TODO: update when Price Feed utils available, so we can create WBTC/USD, and WBTC/ETH price feeds
       rateAsset: RateAsset.ETH,
       peggedTo: "BTC",
     },
@@ -3302,7 +3302,7 @@ export default defineAssetList(Network.ETHEREUM, [
     underlying: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0xdeb288f737066589598e9214e782fa5a8ed689e8", // TODO: update when Price Feed utils available
+      aggregator: "0xdeb288f737066589598e9214e782fa5a8ed689e8", // TODO: update when Price Feed utils available, so we can create WBTC/USD, and WBTC/ETH price feeds
       rateAsset: RateAsset.ETH,
       peggedTo: "BTC",
     },

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7415,7 +7415,7 @@ export default defineAssetList(Network.ETHEREUM, [
   {
     symbol: "PT-sUSDS-27MAR2025",
     name: "PT Savings USDS 27MAR2025",
-    id: "0x152b8629fee8105248bA3b7ba6afb94f7a468302",
+    id: "0x152b8629fee8105248ba3b7ba6afb94f7a468302",
     type: AssetType.PENDLE_V2_PT,
     releases: [],
     decimals: 18,

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7411,22 +7411,6 @@ export default defineAssetList(Network.ETHEREUM, [
       rateAsset: RateAsset.USD,
     },
   },
-  // TODO: only for testing, remove later
-  {
-    symbol: "PT-sUSDS-27MAR2025",
-    name: "PT Savings USDS 27MAR2025",
-    id: "0x152b8629fee8105248ba3b7ba6afb94f7a468302",
-    type: AssetType.PENDLE_V2_PT,
-    releases: [],
-    decimals: 18,
-    underlying: "0xdc035d45d973e3ec169d2276ddab16f1e407384f",
-    markets: ["0xd3719a10991b6ca2cd32de536d6e81ccd46e9c02", "0x21d85ff3bedff031ef466c7d5295240c8ab2a2b8"],
-    priceFeed: {
-      type: PriceFeedType.PRIMITIVE_PENDLE_V2,
-      aggregator: "0x83a017b13540a85dbfc056b66eb0b35bf72c09e3",
-      rateAsset: RateAsset.ETH,
-    },
-  },
   {
     symbol: "PENDLE-LPT",
     name: "Pendle Market", // sUSDe 29 May 2025

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7411,6 +7411,22 @@ export default defineAssetList(Network.ETHEREUM, [
       rateAsset: RateAsset.USD,
     },
   },
+  // TODO: only for testing, remove later
+  {
+    symbol: "PT-sUSDS-27MAR2025",
+    name: "PT Savings USDS 27MAR2025",
+    id: "0x152b8629fee8105248bA3b7ba6afb94f7a468302",
+    type: AssetType.PENDLE_V2_PT,
+    releases: [],
+    decimals: 18,
+    underlying: "0xdc035d45d973e3ec169d2276ddab16f1e407384f",
+    markets: ["0xd3719a10991b6ca2cd32de536d6e81ccd46e9c02", "0x21d85ff3bedff031ef466c7d5295240c8ab2a2b8"],
+    priceFeed: {
+      type: PriceFeedType.PRIMITIVE_PENDLE_V2,
+      aggregator: "0x83a017b13540a85dbfc056b66eb0b35bf72c09e3",
+      rateAsset: RateAsset.ETH,
+    },
+  },
   {
     decimals: 18,
     id: "0x626e8036deb333b408be468f951bdb42433cbf18",

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -858,7 +858,7 @@ export default defineAssetList(Network.ETHEREUM, [
     type: AssetType.PRIMITIVE,
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0xdeb288f737066589598e9214e782fa5a8ed689e8",
+      aggregator: "0xdeb288f737066589598e9214e782fa5a8ed689e8", // TODO: update when Price Feed utils available
       rateAsset: RateAsset.ETH,
       peggedTo: "BTC",
     },
@@ -3287,7 +3287,7 @@ export default defineAssetList(Network.ETHEREUM, [
     underlying: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0xdeb288f737066589598e9214e782fa5a8ed689e8",
+      aggregator: "0xdeb288f737066589598e9214e782fa5a8ed689e8", // TODO: update when Price Feed utils available
       rateAsset: RateAsset.ETH,
       peggedTo: "BTC",
     },
@@ -3302,7 +3302,7 @@ export default defineAssetList(Network.ETHEREUM, [
     underlying: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0xdeb288f737066589598e9214e782fa5a8ed689e8",
+      aggregator: "0xdeb288f737066589598e9214e782fa5a8ed689e8", // TODO: update when Price Feed utils available
       rateAsset: RateAsset.ETH,
       peggedTo: "BTC",
     },

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7389,6 +7389,7 @@ export default defineAssetList(Network.ETHEREUM, [
     releases: [sulu],
     decimals: 8,
     underlying: "0x8236a87084f8b84306f72007f36f2618a5634494",
+    market: "0x70b70ac0445c3ef04e314dfda6caafd825428221",
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_PENDLE_V2,
       aggregator: "0x83a017b13540a85dbfc056b66eb0b35bf72c09e3",
@@ -7402,6 +7403,7 @@ export default defineAssetList(Network.ETHEREUM, [
     type: AssetType.PENDLE_V2_PT,
     releases: [sulu],
     decimals: 8,
+    market: "0x0000000000000000000000000000000000000000", // TODO: Update this
     underlying: "0xd9d920aa40f578ab794426f5c90f6c731d159def",
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_PENDLE_V2,

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7432,12 +7432,12 @@ export default defineAssetList(Network.ETHEREUM, [
     name: "Pendle Market", // sUSDe 29 May 2025
     id: "0xb162b764044697cf03617c2efbcb1f42e31e4766",
     type: AssetType.PENDLE_V2_LP,
-    releases: [],
+    releases: [sulu],
     decimals: 18,
     underlying: "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_PENDLE_V2,
-      aggregator: "0xFF3BC18cCBd5999CE63E788A1c250a88626aD099",
+      aggregator: "0x0998a52dbf3851c8b97012cfc2acba234a413e86",
       rateAsset: RateAsset.USD,
     },
   },

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7389,7 +7389,7 @@ export default defineAssetList(Network.ETHEREUM, [
     releases: [sulu],
     decimals: 8,
     underlying: "0x8236a87084f8b84306f72007f36f2618a5634494",
-    market: "0x70b70ac0445c3ef04e314dfda6caafd825428221",
+    markets: ["0x70b70ac0445c3ef04e314dfda6caafd825428221"],
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_PENDLE_V2,
       aggregator: "0x83a017b13540a85dbfc056b66eb0b35bf72c09e3",
@@ -7403,7 +7403,7 @@ export default defineAssetList(Network.ETHEREUM, [
     type: AssetType.PENDLE_V2_PT,
     releases: [sulu],
     decimals: 8,
-    market: "0xeb4d3057738b9ed930f451be473c1ccc42988384",
+    markets: ["0xeb4d3057738b9ed930f451be473c1ccc42988384"],
     underlying: "0xd9d920aa40f578ab794426f5c90f6c731d159def",
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_PENDLE_V2,

--- a/packages/environment/test/assets/pendle-v2-lp.test.ts
+++ b/packages/environment/test/assets/pendle-v2-lp.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
 import { AssetType } from "../../src/index.js";
 import { getClient } from "../utils/client.js";
-import { getYieldTokenFromSy, readTokensFromLp } from "../utils/contracts/PendleV2Tokens.js";
+import { getYieldTokenFromSy, readTokensFromMarket } from "../utils/contracts/PendleV2Tokens.js";
 import { environment } from "../utils/fixtures.js";
 
 const client = getClient(environment.network.id);
@@ -11,7 +11,7 @@ const assets = environment.getAssets();
 
 test.each(pendleV2LpAssets)("pendle v2 pt underlying is correct: $symbol ($name): $id", async (asset) => {
   // check if deposit token is correct
-  const { sy } = await readTokensFromLp(client, { lp: asset.id });
+  const { sy } = await readTokensFromMarket(client, { market: asset.id });
   const yieldToken = await getYieldTokenFromSy(client, { asset: sy });
 
   expect(yieldToken.toLowerCase(), "Actual underlying asset does not match expected").toBe(asset.underlying);

--- a/packages/environment/test/assets/pendle-v2-lp.test.ts
+++ b/packages/environment/test/assets/pendle-v2-lp.test.ts
@@ -1,17 +1,17 @@
 import { expect, test } from "vitest";
 import { AssetType } from "../../src/index.js";
 import { getClient } from "../utils/client.js";
-import { getSyFromPt, getYieldTokenFromSy } from "../utils/contracts/PendleV2Tokens.js";
+import { getYieldTokenFromSy, readTokensFromLp } from "../utils/contracts/PendleV2Tokens.js";
 import { environment } from "../utils/fixtures.js";
 
 const client = getClient(environment.network.id);
 
-const pendleV2PtAssets = environment.getAssets({ types: [AssetType.PENDLE_V2_PT] });
+const pendleV2LpAssets = environment.getAssets({ types: [AssetType.PENDLE_V2_LP] });
 const assets = environment.getAssets();
 
-test.each(pendleV2PtAssets)("pendle v2 pt underlying is correct: $symbol ($name): $id", async (asset) => {
+test.each(pendleV2LpAssets)("pendle v2 pt underlying is correct: $symbol ($name): $id", async (asset) => {
   // check if deposit token is correct
-  const sy = await getSyFromPt(client, { asset: asset.id });
+  const { sy } = await readTokensFromLp(client, { lp: asset.id });
   const yieldToken = await getYieldTokenFromSy(client, { asset: sy });
 
   expect(yieldToken.toLowerCase(), "Actual underlying asset does not match expected").toBe(asset.underlying);

--- a/packages/environment/test/assets/pendle-v2-pt.test.ts
+++ b/packages/environment/test/assets/pendle-v2-pt.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
 import { AssetType } from "../../src/index.js";
 import { getClient } from "../utils/client.js";
-import { getSyFromPt, getYieldTokenFromSy } from "../utils/contracts/PendleV2Tokens.js";
+import { getYieldTokenFromSy, readTokensFromMarket } from "../utils/contracts/PendleV2Tokens.js";
 import { environment } from "../utils/fixtures.js";
 
 const client = getClient(environment.network.id);
@@ -11,7 +11,10 @@ const assets = environment.getAssets();
 
 test.each(pendleV2PtAssets)("pendle v2 pt underlying is correct: $symbol ($name): $id", async (asset) => {
   // check if deposit token is correct
-  const sy = await getSyFromPt(client, { asset: asset.id });
+  const { sy, pt } = await readTokensFromMarket(client, { market: asset.market });
+
+  expect(pt.toLowerCase(), "Asset token does not match expected").toBe(asset.id);
+
   const yieldToken = await getYieldTokenFromSy(client, { asset: sy });
 
   expect(yieldToken.toLowerCase(), "Actual underlying asset does not match expected").toBe(asset.underlying);

--- a/packages/environment/test/assets/pendle-v2-pt.test.ts
+++ b/packages/environment/test/assets/pendle-v2-pt.test.ts
@@ -11,7 +11,7 @@ const pendleV2PtAssets = environment.getAssets({ types: [AssetType.PENDLE_V2_PT]
 const assets = environment.getAssets();
 
 test.each(pendleV2PtAssets)("pendle v2 pt underlying is correct: $symbol ($name): $id", async (asset) => {
-  for (const market in asset.markets) {
+  for (const market of asset.markets) {
     // check if deposit token is correct
     const { sy, pt } = await readTokensFromMarket(client, { market: toAddress(market) });
 

--- a/packages/environment/test/assets/pendle-v2-pt.test.ts
+++ b/packages/environment/test/assets/pendle-v2-pt.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "vitest";
 import { AssetType } from "../../src/index.js";
+import { toAddress } from "../../src/utils.js";
 import { getClient } from "../utils/client.js";
 import { getYieldTokenFromSy, readTokensFromMarket } from "../utils/contracts/PendleV2Tokens.js";
 import { environment } from "../utils/fixtures.js";
@@ -10,14 +11,16 @@ const pendleV2PtAssets = environment.getAssets({ types: [AssetType.PENDLE_V2_PT]
 const assets = environment.getAssets();
 
 test.each(pendleV2PtAssets)("pendle v2 pt underlying is correct: $symbol ($name): $id", async (asset) => {
-  // check if deposit token is correct
-  const { sy, pt } = await readTokensFromMarket(client, { market: asset.market });
+  for (const market in asset.markets) {
+    // check if deposit token is correct
+    const { sy, pt } = await readTokensFromMarket(client, { market: toAddress(market) });
 
-  expect(pt.toLowerCase(), "Asset token does not match expected").toBe(asset.id);
+    expect(pt.toLowerCase(), "Asset token does not match expected").toBe(asset.id);
 
-  const yieldToken = await getYieldTokenFromSy(client, { asset: sy });
+    const yieldToken = await getYieldTokenFromSy(client, { asset: sy });
 
-  expect(yieldToken.toLowerCase(), "Actual underlying asset does not match expected").toBe(asset.underlying);
+    expect(yieldToken.toLowerCase(), "Actual underlying asset does not match expected").toBe(asset.underlying);
+  }
 
   // Check that the underlying asset exists.
   expect(

--- a/packages/environment/test/assets/schema.test.ts
+++ b/packages/environment/test/assets/schema.test.ts
@@ -104,6 +104,10 @@ suite.each(assets)("$symbol ($name): $id", (asset) => {
           validate(PendleV2PtSchema, asset);
           break;
         }
+        case AssetType.PENDLE_V2_LP: {
+          validate(PendleV2PtSchema, asset);
+          break;
+        }
         default:
           Assertion.never(asset, "Unknown asset type.");
       }

--- a/packages/environment/test/utils/contracts/PendleV2Tokens.ts
+++ b/packages/environment/test/utils/contracts/PendleV2Tokens.ts
@@ -2,25 +2,6 @@ import { Viem } from "@enzymefinance/sdk/Utils";
 import { type Address, type PublicClient, parseAbi } from "viem";
 import { readContract } from "viem/actions";
 
-const ptAbi = [
-  {
-    inputs: [],
-    name: "SY",
-    outputs: [{ internalType: "address", name: "", type: "address" }],
-    stateMutability: "view",
-    type: "function",
-  },
-] as const;
-
-export function getSyFromPt(client: PublicClient, args: Viem.ContractCallParameters<{ asset: Address }>) {
-  return readContract(client, {
-    ...Viem.extractBlockParameters(args),
-    abi: ptAbi,
-    functionName: "SY",
-    address: args.asset,
-  });
-}
-
 const syAbi = [
   {
     inputs: [],
@@ -40,17 +21,17 @@ export function getYieldTokenFromSy(client: PublicClient, args: Viem.ContractCal
   });
 }
 
-export async function readTokensFromLp(
+export async function readTokensFromMarket(
   client: PublicClient,
   args: Viem.ContractCallParameters<{
-    lp: Address;
+    market: Address;
   }>,
 ) {
   const [sy, pt, yt] = await readContract(client, {
     ...Viem.extractBlockParameters(args),
     abi: parseAbi(["function readTokens() external view returns (address,address,address)"]),
     functionName: "readTokens",
-    address: args.lp,
+    address: args.market,
   });
 
   return { sy, pt, yt };

--- a/packages/environment/test/utils/contracts/PendleV2Tokens.ts
+++ b/packages/environment/test/utils/contracts/PendleV2Tokens.ts
@@ -1,5 +1,5 @@
 import { Viem } from "@enzymefinance/sdk/Utils";
-import type { Address, PublicClient } from "viem";
+import { type Address, type PublicClient, parseAbi } from "viem";
 import { readContract } from "viem/actions";
 
 const ptAbi = [
@@ -38,4 +38,20 @@ export function getYieldTokenFromSy(client: PublicClient, args: Viem.ContractCal
     functionName: "yieldToken",
     address: args.asset,
   });
+}
+
+export async function readTokensFromLp(
+  client: PublicClient,
+  args: Viem.ContractCallParameters<{
+    lp: Address;
+  }>,
+) {
+  const [sy, pt, yt] = await readContract(client, {
+    ...Viem.extractBlockParameters(args),
+    abi: parseAbi(["function readTokens() external view returns (address,address,address)"]),
+    functionName: "readTokens",
+    address: args.lp,
+  });
+
+  return { sy, pt, yt };
 }

--- a/packages/environment/test/utils/schema.ts
+++ b/packages/environment/test/utils/schema.ts
@@ -131,6 +131,11 @@ export const PendleV2PtSchema = CommonAssetSchema.extend({
   underlying: address,
 });
 
+export const PendleV2LpSchema = CommonAssetSchema.extend({
+  type: z.literal(AssetType.PENDLE_V2_LP),
+  underlying: address,
+});
+
 export const AssetSchema = z.union([
   PrimitiveSchema,
   StaderSchema,

--- a/packages/environment/test/utils/schema.ts
+++ b/packages/environment/test/utils/schema.ts
@@ -129,6 +129,7 @@ export const CurvePoolLpSchema = CommonAssetSchema.extend({
 export const PendleV2PtSchema = CommonAssetSchema.extend({
   type: z.literal(AssetType.PENDLE_V2_PT),
   underlying: address,
+  market: address,
 });
 
 export const PendleV2LpSchema = CommonAssetSchema.extend({

--- a/packages/environment/test/utils/schema.ts
+++ b/packages/environment/test/utils/schema.ts
@@ -129,7 +129,7 @@ export const CurvePoolLpSchema = CommonAssetSchema.extend({
 export const PendleV2PtSchema = CommonAssetSchema.extend({
   type: z.literal(AssetType.PENDLE_V2_PT),
   underlying: address,
-  market: address,
+  markets: z.array(address).min(1),
 });
 
 export const PendleV2LpSchema = CommonAssetSchema.extend({

--- a/packages/sdk/src/Portfolio/Integrations/PendleV2.ts
+++ b/packages/sdk/src/Portfolio/Integrations/PendleV2.ts
@@ -480,6 +480,19 @@ export function removeLiquidityWithAdapterDecode(encoded: Hex): RemoveLiquidityW
 }
 
 //--------------------------------------------------------------------------------------------
+// TRANSACTIONS
+//--------------------------------------------------------------------------------------------
+
+export function redeemRewards(args: { user: Address; market: Address }) {
+  return new Viem.PopulatedTransaction({
+    abi: parseAbi(["function redeemRewards(address user)"]),
+    functionName: "redeemRewards",
+    args: [args.user],
+    address: args.market,
+  });
+}
+
+//--------------------------------------------------------------------------------------------
 // EXTERNAL READ FUNCTIONS
 //--------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the handling of `Pendle V2` assets in the codebase, introducing new schemas, interfaces, and tests for `Pendle V2 LP` and `Pendle V2 PT` asset types, as well as modifying relevant functions and test cases.

### Detailed summary
- Added support for `PendleV2LPAsset` and `PendleV2PTAsset` interfaces.
- Introduced `PendleV2LpSchema` and updated `AssetSchema`.
- Implemented `redeemRewards` function in `PendleV2.ts`.
- Updated tests for `pendle-v2-pt` and `pendle-v2-lp` assets.
- Refactored `getSyFromPt` to `readTokensFromMarket`.
- Updated asset definitions with new `markets` field for `Pendle V2` assets.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->