### PR TITLE
feat: gmx remove unused order types

### DIFF
--- a/.changeset/hot-jobs-clap.md
+++ b/.changeset/hot-jobs-clap.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Update gmx order type

--- a/packages/sdk/src/Portfolio/Integrations/GMXV2.ts
+++ b/packages/sdk/src/Portfolio/Integrations/GMXV2.ts
@@ -31,14 +31,10 @@ export const Action = {
 
 export type OrderType = (typeof OrderType)[keyof typeof OrderType];
 export const OrderType = {
-  MarketSwap: 0,
-  LimitSwap: 1,
   MarketIncrease: 2,
-  LimitIncrease: 3,
   MarketDecrease: 4,
   LimitDecrease: 5,
   StopLossDecrease: 6,
-  Liquidation: 7,
 } as const;
 
 export type DecreasePositionSwapType = (typeof DecreasePositionSwapType)[keyof typeof DecreasePositionSwapType];

--- a/packages/sdk/src/Portfolio/Integrations/GMXV2.ts
+++ b/packages/sdk/src/Portfolio/Integrations/GMXV2.ts
@@ -35,6 +35,7 @@ export const OrderType = {
   MarketDecrease: 4,
   LimitDecrease: 5,
   StopLossDecrease: 6,
+  Liquidation: 7,
 } as const;
 
 export type DecreasePositionSwapType = (typeof DecreasePositionSwapType)[keyof typeof DecreasePositionSwapType];


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `OrderType` in the `GMXV2.ts` file by removing some existing order types and refining the structure.

### Detailed summary
- Removed the following `OrderType` entries:
  - `MarketSwap`
  - `LimitSwap`
  - `LimitIncrease`
- Retained and updated the following `OrderType` entries:
  - `MarketIncrease`
  - `MarketDecrease`
  - `LimitDecrease`
  - `StopLossDecrease`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->