### PR TITLE
chore: add unregistered Morpho token

### DIFF
--- a/.changeset/rare-toys-float.md
+++ b/.changeset/rare-toys-float.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Add unregistered Morpho token

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7420,4 +7420,15 @@ export default defineAssetList(Network.ETHEREUM, [
       type: PriceFeedType.NONE,
     },
   },
+  {
+    id: "0x58d97b57bb95320f9a05dc918aef65434969c2b2",
+    name: "Morpho Token",
+    symbol: "MORPHO",
+    decimals: 18,
+    releases: [],
+    type: AssetType.PRIMITIVE,
+    priceFeed: {
+      type: PriceFeedType.NONE,
+    },
+  },
 ]);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding an unregistered token, `Morpho Token`, to the `environment` package, enhancing the asset list within the Ethereum environment.

### Detailed summary
- Added a new asset entry for `Morpho Token` with the following details:
  - `id`: "0x58d97b57bb95320f9a05dc918aef65434969c2b2"
  - `name`: "Morpho Token"
  - `symbol`: "MORPHO"
  - `decimals`: 18
  - `releases`: []
  - `type`: `AssetType.PRIMITIVE`
  - `priceFeed`: `{ type: PriceFeedType.NONE }`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->