### PR TITLE
fix: rename USD+ to xUSD

### DIFF
--- a/.changeset/old-peaches-invent.md
+++ b/.changeset/old-peaches-invent.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Rename USD+ to xUSD

--- a/packages/environment/src/assets/arbitrum.ts
+++ b/packages/environment/src/assets/arbitrum.ts
@@ -581,9 +581,9 @@ export default defineAssetList(Network.ARBITRUM, [
   {
     decimals: 6,
     id: "0xe80772eaf6e2e18b651f160bc9158b2a5cafca65",
-    name: "USD+",
+    name: "xUSD",
     releases: [sulu],
-    symbol: "USD+",
+    symbol: "xUSD",
     type: AssetType.PRIMITIVE,
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,


### PR DESCRIPTION
Change to reflect the new on-chain symbol and name of the asset.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming the asset from `USD+` to `xUSD` in the environment configuration for the Arbitrum network.

### Detailed summary
- Updated the `name` field from `"USD+"` to `"xUSD"` in `packages/environment/src/assets/arbitrum.ts`.
- Updated the `symbol` field from `"USD+"` to `"xUSD"` in `packages/environment/src/assets/arbitrum.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->