### PR TITLE
chore: add Polygon assets

### DIFF
--- a/.changeset/tough-roses-perform.md
+++ b/.changeset/tough-roses-perform.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Add Polygon assets

--- a/packages/environment/src/assets/polygon.ts
+++ b/packages/environment/src/assets/polygon.ts
@@ -341,6 +341,8 @@ export default defineAssetList(Network.POLYGON, [
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
       aggregator: "0x73366fe0aa0ded304479862808e02506fe556a98",
       rateAsset: RateAsset.USD,
+      peggedTo: "EUR",
+      nonStandard: true,
     },
   },
   {
@@ -1566,6 +1568,36 @@ export default defineAssetList(Network.POLYGON, [
     decimals: 18,
     priceFeed: {
       type: PriceFeedType.NONE,
+    },
+  },
+  {
+    id: "0x6a8742d7f417431ae4218e94678d91f2ace24a66",
+    name: "UI Space Y Stock",
+    symbol: "UISTEST",
+    decimals: 0,
+    releases: [polygon.sulu],
+    type: AssetType.PRIMITIVE,
+    priceFeed: {
+      type: PriceFeedType.PRIMITIVE_CHAINLINK,
+      aggregator: "0x73366fe0aa0ded304479862808e02506fe556a98",
+      rateAsset: RateAsset.USD,
+      peggedTo: "EUR",
+      nonStandard: true,
+    },
+  },
+  {
+    id: "0xdd52fb974e8b486da82e69d56da8c6f8bf35b0e0",
+    name: "UI Real Estate",
+    symbol: "UIRETEST",
+    decimals: 0,
+    releases: [polygon.sulu],
+    type: AssetType.PRIMITIVE,
+    priceFeed: {
+      type: PriceFeedType.PRIMITIVE_CHAINLINK,
+      aggregator: "0x73366fe0aa0ded304479862808e02506fe556a98",
+      rateAsset: RateAsset.USD,
+      peggedTo: "EUR",
+      nonStandard: true,
     },
   },
 ]);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding new assets for the `Polygon` network in the `environment` package, specifically introducing two new financial assets with their respective properties.

### Detailed summary
- Added two new assets for the `Polygon` network:
  - `UI Space Y Stock` (`UISTEST`) with a `PriceFeedType.PRIMITIVE_CHAINLINK`.
  - `UI Real Estate` (`UIRETEST`) with a `PriceFeedType.PRIMITIVE_CHAINLINK`.
- Both assets have properties like `id`, `name`, `symbol`, `decimals`, and `priceFeed` details.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->