### PR TITLE
chore: update schema test

### DIFF
--- a/packages/environment/test/utils/schema.ts
+++ b/packages/environment/test/utils/schema.ts
@@ -16,7 +16,7 @@ import { PriceFeedType } from "../../src/price-feeds.js";
 const address = z.string().regex(/^0x[0-9a-f]{40}$/) as z.Schema<Address>;
 
 export const CommonAssetSchema = z.object({
-  decimals: z.number().min(2).max(18),
+  decimals: z.number().int().min(0).max(18),
   id: address,
   name: z.string(),
   network: z.nativeEnum(Network),


### PR DESCRIPTION
Updating schema test because two newly added assets on Polygon have `decimals: 0`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `decimals` field in the `CommonAssetSchema` to ensure it only accepts integer values starting from 0, instead of allowing decimal numbers.

### Detailed summary
- Changed the `decimals` field type from `z.number()` to `z.number().int()`.
- Updated the minimum value for `decimals` from `2` to `0`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->