### PR TITLE
refactor: move adapter encoding utils to integration helpers

### DIFF
--- a/.changeset/tame-pandas-knock.md
+++ b/.changeset/tame-pandas-knock.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Move adapter encoding utils to integration helpers

--- a/packages/sdk/src/Portfolio/Integrations/PendleV2.ts
+++ b/packages/sdk/src/Portfolio/Integrations/PendleV2.ts
@@ -319,47 +319,6 @@ export function claimRewardsDecode(encoded: Hex): ClaimRewardsArgs {
 }
 
 //--------------------------------------------------------------------------------------------
-// ADAPTER - ACTIONS
-//--------------------------------------------------------------------------------------------
-
-export type AdapterAction = (typeof AdapterAction)[keyof typeof AdapterAction];
-export const AdapterAction = {
-  BuyPrincipalToken: 0n,
-  SellPrincipalToken: 1n,
-  AddLiquidity: 2n,
-  RemoveLiquidity: 3n,
-} as const;
-
-const adapterActionEncoding = [
-  {
-    name: "actionId",
-    type: "uint256",
-  },
-  {
-    name: "encodedActionArgs",
-    type: "bytes",
-  },
-] as const;
-
-export type AdapterActionArgs = {
-  actionId: bigint;
-  encodedActionArgs: Hex;
-};
-
-export function encodeAdapterAction(args: AdapterActionArgs): Hex {
-  return encodeAbiParameters(adapterActionEncoding, [args.actionId, args.encodedActionArgs]);
-}
-
-export function decodeAdapterAction(encoded: Hex): AdapterActionArgs {
-  const [actionId, encodedActionArgs] = decodeAbiParameters(adapterActionEncoding, encoded);
-
-  return {
-    actionId,
-    encodedActionArgs,
-  };
-}
-
-//--------------------------------------------------------------------------------------------
 // ADAPTER - BUY PRINCIPLE TOKEN
 //--------------------------------------------------------------------------------------------
 
@@ -375,11 +334,11 @@ export function buyPrincipleTokenWithAdapterEncode(args: BuyPrincipleTokenWithAd
 
   const encodedActionArgs = buyPrincipleTokenEncode(actionArgs);
 
-  return encodeAbiParameters(adapterActionEncoding, [actionId, encodedActionArgs]);
+  return encodeAbiParameters(IntegrationManager.adapterActionEncoding, [actionId, encodedActionArgs]);
 }
 
 export function buyPrincipleTokenWithAdapterDecode(encoded: Hex): BuyPrincipleTokenWithAdapterArgs {
-  const { actionId, encodedActionArgs } = decodeAdapterAction(encoded);
+  const { actionId, encodedActionArgs } = IntegrationManager.decodeAdapterAction(encoded);
 
   const decodedActionArgs = buyPrincipleTokenDecode(encodedActionArgs);
 
@@ -405,11 +364,11 @@ export function sellPrincipleTokenWithAdapterEncode(args: SellPrincipleTokenWith
 
   const encodedActionArgs = sellPrincipleTokenEncode(actionArgs);
 
-  return encodeAbiParameters(adapterActionEncoding, [actionId, encodedActionArgs]);
+  return encodeAbiParameters(IntegrationManager.adapterActionEncoding, [actionId, encodedActionArgs]);
 }
 
 export function sellPrincipleTokenWithAdapterDecode(encoded: Hex): SellPrincipleTokenWithAdapterArgs {
-  const { actionId, encodedActionArgs } = decodeAdapterAction(encoded);
+  const { actionId, encodedActionArgs } = IntegrationManager.decodeAdapterAction(encoded);
 
   const decodedActionArgs = sellPrincipleTokenDecode(encodedActionArgs);
 
@@ -435,11 +394,11 @@ export function addLiquidityWithAdapterEncode(args: AddLiquidityWithAdapterArgs)
 
   const encodedActionArgs = addLiquidityEncode(actionArgs);
 
-  return encodeAbiParameters(adapterActionEncoding, [actionId, encodedActionArgs]);
+  return encodeAbiParameters(IntegrationManager.adapterActionEncoding, [actionId, encodedActionArgs]);
 }
 
 export function addLiquidityWithAdapterDecode(encoded: Hex): AddLiquidityWithAdapterArgs {
-  const { actionId, encodedActionArgs } = decodeAdapterAction(encoded);
+  const { actionId, encodedActionArgs } = IntegrationManager.decodeAdapterAction(encoded);
 
   const decodedActionArgs = addLiquidityDecode(encodedActionArgs);
 
@@ -465,11 +424,11 @@ export function removeLiquidityWithAdapterEncode(args: RemoveLiquidityWithAdapte
 
   const encodedActionArgs = removeLiquidityEncode(actionArgs);
 
-  return encodeAbiParameters(adapterActionEncoding, [actionId, encodedActionArgs]);
+  return encodeAbiParameters(IntegrationManager.adapterActionEncoding, [actionId, encodedActionArgs]);
 }
 
 export function removeLiquidityWithAdapterDecode(encoded: Hex): RemoveLiquidityWithAdapterArgs {
-  const { actionId, encodedActionArgs } = decodeAdapterAction(encoded);
+  const { actionId, encodedActionArgs } = IntegrationManager.decodeAdapterAction(encoded);
 
   const decodedActionArgs = removeLiquidityDecode(encodedActionArgs);
 

--- a/packages/sdk/src/_internal/IntegrationManager.ts
+++ b/packages/sdk/src/_internal/IntegrationManager.ts
@@ -235,3 +235,44 @@ export function removeTracketAssets(args: RemoveTrackedAssetsParams) {
     }),
   });
 }
+
+//--------------------------------------------------------------------------------------------
+// ADAPTER - ACTIONS
+//--------------------------------------------------------------------------------------------
+
+export type AdapterAction = (typeof AdapterAction)[keyof typeof AdapterAction];
+export const AdapterAction = {
+  BuyPrincipalToken: 0n,
+  SellPrincipalToken: 1n,
+  AddLiquidity: 2n,
+  RemoveLiquidity: 3n,
+} as const;
+
+export const adapterActionEncoding = [
+  {
+    name: "actionId",
+    type: "uint256",
+  },
+  {
+    name: "encodedActionArgs",
+    type: "bytes",
+  },
+] as const;
+
+export type AdapterActionArgs = {
+  actionId: bigint;
+  encodedActionArgs: Hex;
+};
+
+export function encodeAdapterAction(args: AdapterActionArgs): Hex {
+  return encodeAbiParameters(adapterActionEncoding, [args.actionId, args.encodedActionArgs]);
+}
+
+export function decodeAdapterAction(encoded: Hex): AdapterActionArgs {
+  const [actionId, encodedActionArgs] = decodeAbiParameters(adapterActionEncoding, encoded);
+
+  return {
+    actionId,
+    encodedActionArgs,
+  };
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on moving the `adapter` encoding utilities from the `PendleV2` integration file to the `IntegrationManager` for better organization and reusability.

### Detailed summary
- Moved `AdapterAction`, `adapterActionEncoding`, and related types/functions to `IntegrationManager.ts`.
- Updated references in `PendleV2.ts` to use `IntegrationManager` for encoding/decoding actions.
- Removed redundant definitions from `PendleV2.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->