### PR TITLE
feat: add get fund deployer

### DIFF
--- a/.changeset/pink-parrots-fry.md
+++ b/.changeset/pink-parrots-fry.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Add get fund deployer

--- a/packages/sdk/src/Vault.ts
+++ b/packages/sdk/src/Vault.ts
@@ -97,6 +97,34 @@ export function setSymbol(args: SetSymbolParams) {
   });
 }
 
+export function addAssetManagers(
+  args: Viem.ContractCallParameters<{
+    vaultProxy: Address;
+    managers: ReadonlyArray<Address>;
+  }>,
+) {
+  return new Viem.PopulatedTransaction({
+    abi: Abis.IVaultLib,
+    functionName: "addAssetManagers",
+    address: args.vaultProxy,
+    args: [args.managers],
+  });
+}
+
+export function removeAssetManagers(
+  args: Viem.ContractCallParameters<{
+    vaultProxy: Address;
+    managers: ReadonlyArray<Address>;
+  }>,
+) {
+  return new Viem.PopulatedTransaction({
+    abi: Abis.IVaultLib,
+    functionName: "removeAssetManagers",
+    address: args.vaultProxy,
+    args: [args.managers],
+  });
+}
+
 //--------------------------------------------------------------------------------------------
 // READ FUNCTIONS
 //--------------------------------------------------------------------------------------------
@@ -227,30 +255,16 @@ export function sharesAreFreelyTransferable(
   });
 }
 
-export function addAssetManagers(
+export function getFundDeployer(
+  client: Client,
   args: Viem.ContractCallParameters<{
     vaultProxy: Address;
-    managers: ReadonlyArray<Address>;
   }>,
 ) {
-  return new Viem.PopulatedTransaction({
+  return readContract(client, {
+    ...Viem.extractBlockParameters(args),
     abi: Abis.IVaultLib,
-    functionName: "addAssetManagers",
+    functionName: "getFundDeployer",
     address: args.vaultProxy,
-    args: [args.managers],
-  });
-}
-
-export function removeAssetManagers(
-  args: Viem.ContractCallParameters<{
-    vaultProxy: Address;
-    managers: ReadonlyArray<Address>;
-  }>,
-) {
-  return new Viem.PopulatedTransaction({
-    abi: Abis.IVaultLib,
-    functionName: "removeAssetManagers",
-    address: args.vaultProxy,
-    args: [args.managers],
   });
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new function to retrieve the fund deployer address and removes the existing functions for adding and removing asset managers in the `Vault.ts` file.

### Detailed summary
- Added `getFundDeployer` function to retrieve the fund deployer address.
- Removed `addAssetManagers` function.
- Removed `removeAssetManagers` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->