### PR TITLE
chore: fix USDT symbol on arbitrum

### DIFF
--- a/.changeset/lazy-suits-nail.md
+++ b/.changeset/lazy-suits-nail.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Fix USDT symbol on Arbitrum

--- a/packages/environment/src/assets/arbitrum.ts
+++ b/packages/environment/src/assets/arbitrum.ts
@@ -360,7 +360,7 @@ export default defineAssetList(Network.ARBITRUM, [
     id: "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
     name: "Tether USD",
     releases: [sulu],
-    symbol: "USDT",
+    symbol: "USD₮0",
     type: AssetType.PRIMITIVE,
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,

--- a/packages/environment/src/assets/arbitrum.ts
+++ b/packages/environment/src/assets/arbitrum.ts
@@ -358,7 +358,7 @@ export default defineAssetList(Network.ARBITRUM, [
   {
     decimals: 6,
     id: "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
-    name: "Tether USD",
+    name: "USD₮0",
     releases: [sulu],
     symbol: "USD₮0",
     type: AssetType.PRIMITIVE,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the symbol and name for Tether USD in the Arbitrum environment to reflect a new branding.

### Detailed summary
- Updated `name` from `"Tether USD"` to `"USD₮0"` in `packages/environment/src/assets/arbitrum.ts`
- Updated `symbol` from `"USDT"` to `"USD₮0"` in `packages/environment/src/assets/arbitrum.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->