### PR TITLE
chore: fix upload artifacts pages

### DIFF
--- a/.github/workflows/reusable-docs.yaml
+++ b/.github/workflows/reusable-docs.yaml
@@ -18,7 +18,7 @@ jobs:
         run: pnpm run --filter docs build
       - name: Upload pages artifact
         if: github.repository_owner == 'enzymefinance' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs/dist
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the GitHub Actions workflow for uploading documentation artifacts. It changes the action used for uploading from `actions/upload-artifact@v4` to `actions/upload-pages-artifact@v3`.

### Detailed summary
- Changed the action from `actions/upload-artifact@v4` to `actions/upload-pages-artifact@v3`.
- The conditional check for the upload remains the same, targeting the `main` branch of the repository owned by `enzymefinance`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->