### PR TITLE
chore: update API client

### DIFF
--- a/.changeset/young-eggs-turn.md
+++ b/.changeset/young-eggs-turn.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/api": patch
+---
+
+Update codegen

--- a/packages/api/src/generated/enzyme/enzyme/v1/depositor_time_series_item_pb.ts
+++ b/packages/api/src/generated/enzyme/enzyme/v1/depositor_time_series_item_pb.ts
@@ -31,6 +31,13 @@ export class DepositorTimeSeriesItem extends Message<DepositorTimeSeriesItem> {
    */
   numberOfVaults = 0;
 
+  /**
+   * The net asset value at the timestamp
+   *
+   * @generated from field: float net_asset_value = 4;
+   */
+  netAssetValue = 0;
+
   constructor(data?: PartialMessage<DepositorTimeSeriesItem>) {
     super();
     proto3.util.initPartial(data, this);
@@ -42,6 +49,7 @@ export class DepositorTimeSeriesItem extends Message<DepositorTimeSeriesItem> {
     { no: 1, name: "timestamp", kind: "message", T: Timestamp },
     { no: 2, name: "gross_asset_value", kind: "scalar", T: 2 /* ScalarType.FLOAT */ },
     { no: 3, name: "number_of_vaults", kind: "scalar", T: 2 /* ScalarType.FLOAT */ },
+    { no: 4, name: "net_asset_value", kind: "scalar", T: 2 /* ScalarType.FLOAT */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DepositorTimeSeriesItem {

--- a/packages/api/src/generated/enzyme/enzyme/v1/enums_pb.ts
+++ b/packages/api/src/generated/enzyme/enzyme/v1/enums_pb.ts
@@ -80,6 +80,13 @@ export enum Network {
    * @generated from enum value: NETWORK_ARBITRUM = 3;
    */
   ARBITRUM = 3,
+
+  /**
+   * Base network
+   *
+   * @generated from enum value: NETWORK_BASE = 4;
+   */
+  BASE = 4,
 }
 // Retrieve enum metadata with: proto3.getEnumType(Network)
 proto3.util.setEnumType(Network, "enzyme.enzyme.v1.Network", [
@@ -87,6 +94,7 @@ proto3.util.setEnumType(Network, "enzyme.enzyme.v1.Network", [
   { no: 1, name: "NETWORK_ETHEREUM" },
   { no: 2, name: "NETWORK_POLYGON" },
   { no: 3, name: "NETWORK_ARBITRUM" },
+  { no: 4, name: "NETWORK_BASE" },
 ]);
 
 /**
@@ -129,6 +137,13 @@ export enum Deployment {
    * @generated from enum value: DEPLOYMENT_ARBITRUM = 4;
    */
   ARBITRUM = 4,
+
+  /**
+   * Base production deployment
+   *
+   * @generated from enum value: DEPLOYMENT_BASE = 5;
+   */
+  BASE = 5,
 }
 // Retrieve enum metadata with: proto3.getEnumType(Deployment)
 proto3.util.setEnumType(Deployment, "enzyme.enzyme.v1.Deployment", [
@@ -137,6 +152,7 @@ proto3.util.setEnumType(Deployment, "enzyme.enzyme.v1.Deployment", [
   { no: 2, name: "DEPLOYMENT_POLYGON" },
   { no: 3, name: "DEPLOYMENT_TESTNET" },
   { no: 4, name: "DEPLOYMENT_ARBITRUM" },
+  { no: 5, name: "DEPLOYMENT_BASE" },
 ]);
 
 /**

--- a/packages/api/src/generated/enzyme/enzyme/v1/enzyme_pb.ts
+++ b/packages/api/src/generated/enzyme/enzyme/v1/enzyme_pb.ts
@@ -161,6 +161,13 @@ export class GetDepositorTimeSeriesRequest extends Message<GetDepositorTimeSerie
    */
   resolution = Resolution.UNSPECIFIED;
 
+  /**
+   * The addresses of the vaults
+   *
+   * @generated from field: repeated string vault_addresses = 6;
+   */
+  vaultAddresses: string[] = [];
+
   constructor(data?: PartialMessage<GetDepositorTimeSeriesRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -174,6 +181,7 @@ export class GetDepositorTimeSeriesRequest extends Message<GetDepositorTimeSerie
     { no: 3, name: "currency", kind: "enum", T: proto3.getEnumType(Currency) },
     { no: 4, name: "range", kind: "message", T: TimeWindow },
     { no: 5, name: "resolution", kind: "enum", T: proto3.getEnumType(Resolution) },
+    { no: 6, name: "vault_addresses", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetDepositorTimeSeriesRequest {
@@ -1343,6 +1351,13 @@ export class GetVaultActivitiesRequest extends Message<GetVaultActivitiesRequest
    */
   currency = Currency.UNSPECIFIED;
 
+  /**
+   * The time range (from/to) of the time series
+   *
+   * @generated from field: enzyme.enzyme.v1.TimeWindow range = 4;
+   */
+  range?: TimeWindow;
+
   constructor(data?: PartialMessage<GetVaultActivitiesRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -1354,6 +1369,7 @@ export class GetVaultActivitiesRequest extends Message<GetVaultActivitiesRequest
     { no: 1, name: "deployment", kind: "enum", T: proto3.getEnumType(Deployment) },
     { no: 2, name: "address", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "currency", kind: "enum", T: proto3.getEnumType(Currency) },
+    { no: 4, name: "range", kind: "message", T: TimeWindow },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetVaultActivitiesRequest {

--- a/packages/api/src/generated/enzyme/enzyme/v1/external_position_item_pb.ts
+++ b/packages/api/src/generated/enzyme/enzyme/v1/external_position_item_pb.ts
@@ -232,6 +232,12 @@ export class ExternalPositionAdditionalInfo extends Message<ExternalPositionAddi
      */
     value: GMXV2LeverageTradingAdditionalInfo;
     case: "gmxV2LeverageTrading";
+  } | {
+    /**
+     * @generated from field: enzyme.enzyme.v1.StaderWithdrawalsAdditionalInfo stader_withdrawals = 15;
+     */
+    value: StaderWithdrawalsAdditionalInfo;
+    case: "staderWithdrawals";
   } | { case: undefined; value?: undefined } = { case: undefined };
 
   constructor(data?: PartialMessage<ExternalPositionAdditionalInfo>) {
@@ -256,6 +262,7 @@ export class ExternalPositionAdditionalInfo extends Message<ExternalPositionAddi
     { no: 12, name: "pendle_v2", kind: "message", T: PendleV2AdditionalInfo, oneof: "additional_info" },
     { no: 13, name: "alice", kind: "message", T: AliceAdditionalInfo, oneof: "additional_info" },
     { no: 14, name: "gmx_v2_leverage_trading", kind: "message", T: GMXV2LeverageTradingAdditionalInfo, oneof: "additional_info" },
+    { no: 15, name: "stader_withdrawals", kind: "message", T: StaderWithdrawalsAdditionalInfo, oneof: "additional_info" },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ExternalPositionAdditionalInfo {
@@ -1025,6 +1032,92 @@ export class LidoWithdrawalsAdditionalInfo extends Message<LidoWithdrawalsAdditi
 
   static equals(a: LidoWithdrawalsAdditionalInfo | PlainMessage<LidoWithdrawalsAdditionalInfo> | undefined, b: LidoWithdrawalsAdditionalInfo | PlainMessage<LidoWithdrawalsAdditionalInfo> | undefined): boolean {
     return proto3.util.equals(LidoWithdrawalsAdditionalInfo, a, b);
+  }
+}
+
+/**
+ * @generated from message enzyme.enzyme.v1.StaderWithdrawalsRequest
+ */
+export class StaderWithdrawalsRequest extends Message<StaderWithdrawalsRequest> {
+  /**
+   * The amount of requested tokens
+   *
+   * @generated from field: float ethx_amount = 1;
+   */
+  ethxAmount = 0;
+
+  /**
+   * The id of withdrawal request
+   *
+   * @generated from field: int32 request_id = 2;
+   */
+  requestId = 0;
+
+  constructor(data?: PartialMessage<StaderWithdrawalsRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "enzyme.enzyme.v1.StaderWithdrawalsRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "ethx_amount", kind: "scalar", T: 2 /* ScalarType.FLOAT */ },
+    { no: 2, name: "request_id", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): StaderWithdrawalsRequest {
+    return new StaderWithdrawalsRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): StaderWithdrawalsRequest {
+    return new StaderWithdrawalsRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): StaderWithdrawalsRequest {
+    return new StaderWithdrawalsRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: StaderWithdrawalsRequest | PlainMessage<StaderWithdrawalsRequest> | undefined, b: StaderWithdrawalsRequest | PlainMessage<StaderWithdrawalsRequest> | undefined): boolean {
+    return proto3.util.equals(StaderWithdrawalsRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message enzyme.enzyme.v1.StaderWithdrawalsAdditionalInfo
+ */
+export class StaderWithdrawalsAdditionalInfo extends Message<StaderWithdrawalsAdditionalInfo> {
+  /**
+   * The list of requests
+   *
+   * @generated from field: repeated enzyme.enzyme.v1.StaderWithdrawalsRequest requests = 1;
+   */
+  requests: StaderWithdrawalsRequest[] = [];
+
+  constructor(data?: PartialMessage<StaderWithdrawalsAdditionalInfo>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "enzyme.enzyme.v1.StaderWithdrawalsAdditionalInfo";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "requests", kind: "message", T: StaderWithdrawalsRequest, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): StaderWithdrawalsAdditionalInfo {
+    return new StaderWithdrawalsAdditionalInfo().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): StaderWithdrawalsAdditionalInfo {
+    return new StaderWithdrawalsAdditionalInfo().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): StaderWithdrawalsAdditionalInfo {
+    return new StaderWithdrawalsAdditionalInfo().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: StaderWithdrawalsAdditionalInfo | PlainMessage<StaderWithdrawalsAdditionalInfo> | undefined, b: StaderWithdrawalsAdditionalInfo | PlainMessage<StaderWithdrawalsAdditionalInfo> | undefined): boolean {
+    return proto3.util.equals(StaderWithdrawalsAdditionalInfo, a, b);
   }
 }
 

--- a/packages/api/src/generated/enzyme/enzyme/v1/policy_configuration_pb.ts
+++ b/packages/api/src/generated/enzyme/enzyme/v1/policy_configuration_pb.ts
@@ -107,6 +107,12 @@ export class PolicyConfiguration extends Message<PolicyConfiguration> {
     case: "allowedRedeemersForSpecificAssetsPolicy";
   } | {
     /**
+     * @generated from field: enzyme.enzyme.v1.DisallowedAdapterIncomingAssetsPolicyConfiguration disallowed_adapter_incoming_assets_policy = 24;
+     */
+    value: DisallowedAdapterIncomingAssetsPolicyConfiguration;
+    case: "disallowedAdapterIncomingAssetsPolicy";
+  } | {
+    /**
      * Pre-Sulu policies 
      *
      * @generated from field: enzyme.enzyme.v1.AdapterBlackistPolicy adapter_blacklist_policy = 14;
@@ -186,6 +192,7 @@ export class PolicyConfiguration extends Message<PolicyConfiguration> {
     { no: 13, name: "only_untrack_dust_or_priceless_assets_policy", kind: "message", T: OnlyUntrackDustOrPricelessAssetsPolicy, oneof: "policy" },
     { no: 22, name: "no_depeg_on_redeem_shares_for_specific_assets_policy", kind: "message", T: NoDepegOnRedeemSharesForSpecificAssetsPolicy, oneof: "policy" },
     { no: 23, name: "allowed_redeemers_for_specific_assets_policy", kind: "message", T: AllowedRedeemersForSpecificAssetsPolicy, oneof: "policy" },
+    { no: 24, name: "disallowed_adapter_incoming_assets_policy", kind: "message", T: DisallowedAdapterIncomingAssetsPolicyConfiguration, oneof: "policy" },
     { no: 14, name: "adapter_blacklist_policy", kind: "message", T: AdapterBlackistPolicy, oneof: "policy" },
     { no: 15, name: "adapter_whitelist_policy", kind: "message", T: AdapterWhitelistPolicy, oneof: "policy" },
     { no: 16, name: "asset_blacklist_policy", kind: "message", T: AssetBlacklistPolicy, oneof: "policy" },
@@ -773,6 +780,61 @@ export class CumulativeSlippageTolarancePolicy extends Message<CumulativeSlippag
 
   static equals(a: CumulativeSlippageTolarancePolicy | PlainMessage<CumulativeSlippageTolarancePolicy> | undefined, b: CumulativeSlippageTolarancePolicy | PlainMessage<CumulativeSlippageTolarancePolicy> | undefined): boolean {
     return proto3.util.equals(CumulativeSlippageTolarancePolicy, a, b);
+  }
+}
+
+/**
+ * @generated from message enzyme.enzyme.v1.DisallowedAdapterIncomingAssetsPolicyConfiguration
+ */
+export class DisallowedAdapterIncomingAssetsPolicyConfiguration extends Message<DisallowedAdapterIncomingAssetsPolicyConfiguration> {
+  /**
+   * @generated from field: string address = 1;
+   */
+  address = "";
+
+  /**
+   * @generated from field: google.protobuf.Timestamp created_at = 2;
+   */
+  createdAt?: Timestamp;
+
+  /**
+   * @generated from field: bool enabled = 3;
+   */
+  enabled = false;
+
+  /**
+   * @generated from field: repeated enzyme.enzyme.v1.AddressList address_lists = 4;
+   */
+  addressLists: AddressList[] = [];
+
+  constructor(data?: PartialMessage<DisallowedAdapterIncomingAssetsPolicyConfiguration>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "enzyme.enzyme.v1.DisallowedAdapterIncomingAssetsPolicyConfiguration";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "address", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "created_at", kind: "message", T: Timestamp },
+    { no: 3, name: "enabled", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 4, name: "address_lists", kind: "message", T: AddressList, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DisallowedAdapterIncomingAssetsPolicyConfiguration {
+    return new DisallowedAdapterIncomingAssetsPolicyConfiguration().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): DisallowedAdapterIncomingAssetsPolicyConfiguration {
+    return new DisallowedAdapterIncomingAssetsPolicyConfiguration().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): DisallowedAdapterIncomingAssetsPolicyConfiguration {
+    return new DisallowedAdapterIncomingAssetsPolicyConfiguration().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: DisallowedAdapterIncomingAssetsPolicyConfiguration | PlainMessage<DisallowedAdapterIncomingAssetsPolicyConfiguration> | undefined, b: DisallowedAdapterIncomingAssetsPolicyConfiguration | PlainMessage<DisallowedAdapterIncomingAssetsPolicyConfiguration> | undefined): boolean {
+    return proto3.util.equals(DisallowedAdapterIncomingAssetsPolicyConfiguration, a, b);
   }
 }
 

--- a/packages/api/src/generated/enzyme/enzyme/v1/vault_activities_pb.ts
+++ b/packages/api/src/generated/enzyme/enzyme/v1/vault_activities_pb.ts
@@ -297,6 +297,12 @@ export class VaultActivities extends Message<VaultActivities> {
      */
     value: GMXV2PositionChange;
     case: "gmxV2PositionChange";
+  } | {
+    /**
+     * @generated from field: enzyme.enzyme.v1.StaderWithdrawalsPositionChange stader_withdrawals_position_change = 48;
+     */
+    value: StaderWithdrawalsPositionChange;
+    case: "staderWithdrawalsPositionChange";
   } | { case: undefined; value?: undefined } = { case: undefined };
 
   constructor(data?: PartialMessage<VaultActivities>) {
@@ -354,6 +360,7 @@ export class VaultActivities extends Message<VaultActivities> {
     { no: 45, name: "tracked_asset_removed", kind: "message", T: TrackedAssetRemoved, oneof: "vaultActivity" },
     { no: 46, name: "alice_position_change", kind: "message", T: AlicePositionChange, oneof: "vaultActivity" },
     { no: 47, name: "gmx_v2_position_change", kind: "message", T: GMXV2PositionChange, oneof: "vaultActivity" },
+    { no: 48, name: "stader_withdrawals_position_change", kind: "message", T: StaderWithdrawalsPositionChange, oneof: "vaultActivity" },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): VaultActivities {
@@ -1861,7 +1868,8 @@ export class LidoWithdrawalsPositionChange extends Message<LidoWithdrawalsPositi
   lidoWithdrawalsPositionChangeType = "";
 
   /**
-   * @generated from field: repeated string amounts = 7;
+   * @generated from field: repeated string amounts = 7 [deprecated = true];
+   * @deprecated
    */
   amounts: string[] = [];
 
@@ -1869,6 +1877,11 @@ export class LidoWithdrawalsPositionChange extends Message<LidoWithdrawalsPositi
    * @generated from field: repeated string request_ids = 8;
    */
   requestIds: string[] = [];
+
+  /**
+   * @generated from field: repeated enzyme.enzyme.v1.AssetAmount asset_amounts = 9;
+   */
+  assetAmounts: AssetAmount[] = [];
 
   constructor(data?: PartialMessage<LidoWithdrawalsPositionChange>) {
     super();
@@ -1886,6 +1899,7 @@ export class LidoWithdrawalsPositionChange extends Message<LidoWithdrawalsPositi
     { no: 6, name: "lido_withdrawals_position_change_type", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 7, name: "amounts", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
     { no: 8, name: "request_ids", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+    { no: 9, name: "asset_amounts", kind: "message", T: AssetAmount, repeated: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): LidoWithdrawalsPositionChange {
@@ -2582,6 +2596,11 @@ export class SharesBoughtEvent extends Message<SharesBoughtEvent> {
    */
   sharesIssued = "";
 
+  /**
+   * @generated from field: float timestamp = 4;
+   */
+  timestamp = 0;
+
   constructor(data?: PartialMessage<SharesBoughtEvent>) {
     super();
     proto3.util.initPartial(data, this);
@@ -2593,6 +2612,7 @@ export class SharesBoughtEvent extends Message<SharesBoughtEvent> {
     { no: 1, name: "activity_type", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "deposit_asset_amount", kind: "message", T: AssetAmount },
     { no: 3, name: "shares_issued", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 4, name: "timestamp", kind: "scalar", T: 2 /* ScalarType.FLOAT */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): SharesBoughtEvent {
@@ -2626,6 +2646,16 @@ export class SharesRedeemedEvent extends Message<SharesRedeemedEvent> {
    */
   payoutAssetAmounts: AssetAmount[] = [];
 
+  /**
+   * @generated from field: string shares_redeemed = 3;
+   */
+  sharesRedeemed = "";
+
+  /**
+   * @generated from field: float timestamp = 4;
+   */
+  timestamp = 0;
+
   constructor(data?: PartialMessage<SharesRedeemedEvent>) {
     super();
     proto3.util.initPartial(data, this);
@@ -2636,6 +2666,8 @@ export class SharesRedeemedEvent extends Message<SharesRedeemedEvent> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "activity_type", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "payout_asset_amounts", kind: "message", T: AssetAmount, repeated: true },
+    { no: 3, name: "shares_redeemed", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 4, name: "timestamp", kind: "scalar", T: 2 /* ScalarType.FLOAT */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): SharesRedeemedEvent {
@@ -2889,6 +2921,85 @@ export class PendleV2PositionChange extends Message<PendleV2PositionChange> {
 
   static equals(a: PendleV2PositionChange | PlainMessage<PendleV2PositionChange> | undefined, b: PendleV2PositionChange | PlainMessage<PendleV2PositionChange> | undefined): boolean {
     return proto3.util.equals(PendleV2PositionChange, a, b);
+  }
+}
+
+/**
+ * @generated from message enzyme.enzyme.v1.StaderWithdrawalsPositionChange
+ */
+export class StaderWithdrawalsPositionChange extends Message<StaderWithdrawalsPositionChange> {
+  /**
+   * @generated from field: string id = 1;
+   */
+  id = "";
+
+  /**
+   * @generated from field: float timestamp = 2;
+   */
+  timestamp = 0;
+
+  /**
+   * @generated from field: string activity_type = 3;
+   */
+  activityType = "";
+
+  /**
+   * @generated from field: string vault = 4;
+   */
+  vault = "";
+
+  /**
+   * @generated from field: string external_position = 5;
+   */
+  externalPosition = "";
+
+  /**
+   * @generated from field: string stader_withdrawals_position_change_type = 6;
+   */
+  staderWithdrawalsPositionChangeType = "";
+
+  /**
+   * @generated from field: enzyme.enzyme.v1.AssetAmount amount = 7;
+   */
+  amount?: AssetAmount;
+
+  /**
+   * @generated from field: string request_id = 8;
+   */
+  requestId = "";
+
+  constructor(data?: PartialMessage<StaderWithdrawalsPositionChange>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "enzyme.enzyme.v1.StaderWithdrawalsPositionChange";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "timestamp", kind: "scalar", T: 2 /* ScalarType.FLOAT */ },
+    { no: 3, name: "activity_type", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 4, name: "vault", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 5, name: "external_position", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 6, name: "stader_withdrawals_position_change_type", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 7, name: "amount", kind: "message", T: AssetAmount },
+    { no: 8, name: "request_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): StaderWithdrawalsPositionChange {
+    return new StaderWithdrawalsPositionChange().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): StaderWithdrawalsPositionChange {
+    return new StaderWithdrawalsPositionChange().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): StaderWithdrawalsPositionChange {
+    return new StaderWithdrawalsPositionChange().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: StaderWithdrawalsPositionChange | PlainMessage<StaderWithdrawalsPositionChange> | undefined, b: StaderWithdrawalsPositionChange | PlainMessage<StaderWithdrawalsPositionChange> | undefined): boolean {
+    return proto3.util.equals(StaderWithdrawalsPositionChange, a, b);
   }
 }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the code generation for the `enzyme` API, enhancing various data structures and adding new fields and messages related to vault activities and withdrawal processes.

### Detailed summary
- Added `net_asset_value` to `DepositorTimeSeriesItem`.
- Introduced `vault_addresses` to `GetDepositorTimeSeriesRequest`.
- Added `BASE` to `Network` and `Deployment` enums.
- Created `DisallowedAdapterIncomingAssetsPolicyConfiguration` message.
- Added `StaderWithdrawalsRequest` and `StaderWithdrawalsAdditionalInfo` messages.
- Included `StaderWithdrawalsPositionChange` message in vault activities.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->