### PR TITLE
fix: aggregator and tests

### DIFF
--- a/.changeset/hip-colts-confess.md
+++ b/.changeset/hip-colts-confess.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Fix aggregator, and tests

--- a/packages/environment/src/assets/polygon.ts
+++ b/packages/environment/src/assets/polygon.ts
@@ -1000,8 +1000,8 @@ export default defineAssetList(Network.POLYGON, [
     underlying: "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
     priceFeed: {
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0x327e23a4855b6f663a28c5161541d69af8973302",
-      rateAsset: RateAsset.ETH,
+      aggregator: "0xab594600376ec9fd91f8e885dadf0ce036862de0",
+      rateAsset: RateAsset.USD,
     },
   },
   {

--- a/packages/environment/test/assets/aave-v3-like.test.ts
+++ b/packages/environment/test/assets/aave-v3-like.test.ts
@@ -18,9 +18,16 @@ const unusualPriceFeedsAssetsForNetwork: Record<Network, Array<Address>> = {
     "0x0b925ed163218f6662a35e0f0371ac234f9e9371", // Aave Ethereum wstETH"
     "0x4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8", // Aave Ethereum WETH
   ],
-  [Network.POLYGON]: [],
-  [Network.BASE]: [],
-  [Network.ARBITRUM]: [],
+  [Network.POLYGON]: [
+    "0x28424507fefb6f7f8e9d3860f56504e4e5f5f390", // Aave WETH
+    "0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8", // Aave Polygon WETH
+  ],
+  [Network.BASE]: [
+    "0xd4a0e0b9149bcee3c920d2e00b5de09138fd8bb7", // Aave Base WETH
+  ],
+  [Network.ARBITRUM]: [
+    "0xe50fa9b3c56ffb159cb0fca61f5c9d750e8128c8", // Aave Arbitrum WETH
+  ],
 } as const;
 
 test.each(aaveV3LikeAssets)("aave V3 like underlying is correct: $symbol ($name): $id", async (asset) => {

--- a/packages/environment/test/assets/pendle-v2-price.test.ts
+++ b/packages/environment/test/assets/pendle-v2-price.test.ts
@@ -46,6 +46,6 @@ suite("prices are correct", async () => {
       "OffChain price does not match onChain price",
     );
   });
-});
 
-test.skip("empty test suite fallback");
+  test.skip("empty test suite fallback");
+});

--- a/packages/environment/test/assets/pendle-v2-price.test.ts
+++ b/packages/environment/test/assets/pendle-v2-price.test.ts
@@ -38,7 +38,7 @@ suite("prices are correct", async () => {
     const usdDecimals = 8;
     const priceOnchainInUsdFormatted = Number(formatUnits(priceOnchainInUsd, usdDecimals));
 
-    const deviationAllowed = priceOffChain * 0.005; // 0.5% deviation allowed
+    const deviationAllowed = priceOffChain * 0.01; // 1% deviation allowed
 
     expect(priceOffChain).closeTo(
       priceOnchainInUsdFormatted,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing the `aggregator` addresses, updating `rateAsset` values, and adjusting test cases for price feeds in the `environment` package. It also refines the handling of price feed descriptions.

### Detailed summary
- Updated `aggregator` address in `packages/environment/src/assets/polygon.ts`.
- Changed `rateAsset` from `ETH` to `USD` in `packages/environment/src/assets/polygon.ts`.
- Increased allowed price deviation from 0.5% to 1% in `packages/environment/test/assets/pendle-v2-price.test.ts`.
- Added new `aggregator` addresses for various networks in `packages/environment/test/assets/aave-v3-like.test.ts`.
- Introduced logic for handling `UsdEthSimulatedAggregator` in `packages/environment/test/assets/price-feed.test.ts`.
- Updated assertions related to price feed descriptions and decimals in `packages/environment/test/assets/price-feed.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->