### PR TITLE
chore: add ETHFI asset

### DIFF
--- a/.changeset/silver-rockets-rush.md
+++ b/.changeset/silver-rockets-rush.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Add ETHFI

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7678,4 +7678,15 @@ export default defineAssetList(Network.ETHEREUM, [
       rateAsset: RateAsset.ETH,
     },
   },
+  {
+    id: "0xfe0c30065b384f05761f15d0cc899d4f9f9cc0eb",
+    name: "ether.fi governance token",
+    symbol: "ETHFI",
+    decimals: 18,
+    releases: [],
+    type: AssetType.PRIMITIVE,
+    priceFeed: {
+      type: PriceFeedType.NONE,
+    },
+  },
 ]);


### PR DESCRIPTION
Adding ETHFI, so that the Nexus vault can sell this untracked asset.