### PR TITLE
chore: deregister FTM

### DIFF
--- a/.changeset/warm-bananas-pretend.md
+++ b/.changeset/warm-bananas-pretend.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Deregister FTM

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -1816,13 +1816,11 @@ export default defineAssetList(Network.ETHEREUM, [
     decimals: 18,
     id: "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
     name: "Fantom Token",
-    releases: [sulu, encore],
+    releases: [encore],
     symbol: "FTM",
     type: AssetType.PRIMITIVE,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0x2de7e4a9488488e0058b95854cc2f7955b35dc9b",
-      rateAsset: RateAsset.ETH,
+      type: PriceFeedType.NONE,
     },
   },
   {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on deregistering the `Fantom Token` (`FTM`) from the environment configuration and updating its price feed type.

### Detailed summary
- Removed `Fantom Token` (`FTM`) from the `releases` array.
- Changed the `priceFeed` type from `PriceFeedType.PRIMITIVE_CHAINLINK` to `PriceFeedType.NONE`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->