### PR TITLE
feat: add deposit wrapper allowed exchanges

### DIFF
--- a/.changeset/stale-spies-nail.md
+++ b/.changeset/stale-spies-nail.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Add deposit wrapper allowed exchanges list

--- a/packages/environment/src/deployments/arbitrum.ts
+++ b/packages/environment/src/deployments/arbitrum.ts
@@ -70,6 +70,7 @@ export default defineDeployment<Deployment.ARBITRUM>({
     adapters: 2n,
     fees: 3n,
     policies: 4n,
+    depositWrapperAllowedExchanges: 5n,
     nonStandardPriceFeedAssets: 16n,
     aTokens: 8n,
   },

--- a/packages/environment/src/deployments/base.ts
+++ b/packages/environment/src/deployments/base.ts
@@ -71,7 +71,7 @@ export default defineDeployment<Deployment.BASE>({
     adapters: 4n,
     fees: 5n,
     policies: 6n,
-    nonStandardPriceFeedAssets: 999n, // 999n set as placeholder, not added yet
+    nonStandardPriceFeedAssets: 12n,
     aTokens: 9n,
   },
   knownUintLists: {},

--- a/packages/environment/src/deployments/base.ts
+++ b/packages/environment/src/deployments/base.ts
@@ -66,11 +66,12 @@ export default defineDeployment<Deployment.BASE>({
   inception: 23178855,
   kind: Kind.TEST,
   knownAddressLists: {
-    noSlippageAdapters: 1n,
-    adapters: 2n,
-    fees: 3n,
-    policies: 4n,
-    nonStandardPriceFeedAssets: 999n,
+    depositWrapperAllowedExchanges: 1n,
+    noSlippageAdapters: 3n,
+    adapters: 4n,
+    fees: 5n,
+    policies: 6n,
+    nonStandardPriceFeedAssets: 999n, // 999n set as placeholder, not added yet
     aTokens: 9n,
   },
   knownUintLists: {},

--- a/packages/environment/src/deployments/ethereum.ts
+++ b/packages/environment/src/deployments/ethereum.ts
@@ -75,6 +75,7 @@ export default defineDeployment<Deployment.ETHEREUM>({
     aTokens: 463n,
     zeroLendRWAStablecoinsATokens: 737n,
     zeroLendLRTBTCATokens: 738n,
+    depositWrapperAllowedExchanges: 553n,
   },
   knownUintLists: {
     allowedMorphoBlueVaults: 3n,

--- a/packages/environment/src/deployments/polygon.ts
+++ b/packages/environment/src/deployments/polygon.ts
@@ -72,6 +72,7 @@ export default defineDeployment<Deployment.POLYGON>({
     policies: 4n,
     nonStandardPriceFeedAssets: 1383n,
     aTokens: 735n,
+    depositWrapperAllowedExchanges: 1121n,
   },
   knownUintLists: {},
   label: "Polygon",

--- a/packages/environment/src/deployments/testnet.ts
+++ b/packages/environment/src/deployments/testnet.ts
@@ -17,6 +17,7 @@ export default defineDeployment<Deployment.TESTNET>({
     policies: 4n,
     nonStandardPriceFeedAssets: 128n,
     aTokens: 115n,
+    depositWrapperAllowedExchanges: 125n,
   },
   knownUintLists: {},
   label: "Testnet",

--- a/packages/environment/src/releases.ts
+++ b/packages/environment/src/releases.ts
@@ -255,6 +255,7 @@ export type KnownAddressListIdMapping<TDeployment extends Deployment> = {
   policies: bigint;
   nonStandardPriceFeedAssets: bigint;
   aTokens: bigint;
+  depositWrapperAllowedExchanges: bigint;
 } & (TDeployment extends Deployment.ETHEREUM ? KnownAddressListIdMappingEthereumSpecific : {});
 
 export type KnownAddressListIdMappingEthereumSpecific = {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new feature by adding a `depositWrapperAllowedExchanges` list to various deployment configurations, enhancing the system's flexibility in managing allowed exchanges for deposits.

### Detailed summary
- Added `depositWrapperAllowedExchanges` to:
  - `arbitrum.ts` with a value of `5n`
  - `testnet.ts` with a value of `125n`
  - `polygon.ts` with a value of `1121n`
  - `ethereum.ts` with a value of `553n`
- Updated type definitions in `releases.ts` to include `depositWrapperAllowedExchanges`.
- Modified `base.ts` to reflect changes in `knownAddressLists`, adjusting values accordingly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->