### PR TITLE
fix: base non standard price feed assets

### DIFF
--- a/.changeset/chatty-actors-cross.md
+++ b/.changeset/chatty-actors-cross.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Fix non standard price feed assets

--- a/packages/environment/src/deployments/base.ts
+++ b/packages/environment/src/deployments/base.ts
@@ -71,7 +71,7 @@ export default defineDeployment<Deployment.BASE>({
     adapters: 4n,
     fees: 5n,
     policies: 6n,
-    nonStandardPriceFeedAssets: 12n,
+    nonStandardPriceFeedAssets: 2n,
     aTokens: 9n,
   },
   knownUintLists: {},


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `nonStandardPriceFeedAssets` value in the `base.ts` file and includes a patch for the `@enzymefinance/environment` package to fix issues related to non-standard price feed assets.

### Detailed summary
- Updated `nonStandardPriceFeedAssets` from `12n` to `2n` in `packages/environment/src/deployments/base.ts`.
- Added a patch entry for `@enzymefinance/environment` in `.changeset/chatty-actors-cross.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->