### PR TITLE
feat: add gsn trusted forwarders

### DIFF
--- a/.changeset/ninety-baboons-wave.md
+++ b/.changeset/ninety-baboons-wave.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Add gsn trusted forwarders

--- a/packages/environment/src/deployments/ethereum.ts
+++ b/packages/environment/src/deployments/ethereum.ts
@@ -76,6 +76,7 @@ export default defineDeployment<Deployment.ETHEREUM>({
     zeroLendRWAStablecoinsATokens: 737n,
     zeroLendLRTBTCATokens: 738n,
     depositWrapperAllowedExchanges: 553n,
+    gsnTrustedForwarders: 598n,
   },
   knownUintLists: {
     allowedMorphoBlueVaults: 3n,

--- a/packages/environment/src/deployments/polygon.ts
+++ b/packages/environment/src/deployments/polygon.ts
@@ -73,6 +73,7 @@ export default defineDeployment<Deployment.POLYGON>({
     nonStandardPriceFeedAssets: 1383n,
     aTokens: 735n,
     depositWrapperAllowedExchanges: 1121n,
+    gsnTrustedForwarders: 1269n,
   },
   knownUintLists: {},
   label: "Polygon",

--- a/packages/environment/src/deployments/testnet.ts
+++ b/packages/environment/src/deployments/testnet.ts
@@ -18,6 +18,7 @@ export default defineDeployment<Deployment.TESTNET>({
     nonStandardPriceFeedAssets: 128n,
     aTokens: 115n,
     depositWrapperAllowedExchanges: 125n,
+    gsnTrustedForwarders: 122n,
   },
   knownUintLists: {},
   label: "Testnet",

--- a/packages/environment/src/releases.ts
+++ b/packages/environment/src/releases.ts
@@ -256,12 +256,21 @@ export type KnownAddressListIdMapping<TDeployment extends Deployment> = {
   nonStandardPriceFeedAssets: bigint;
   aTokens: bigint;
   depositWrapperAllowedExchanges: bigint;
-} & (TDeployment extends Deployment.ETHEREUM ? KnownAddressListIdMappingEthereumSpecific : {});
+} & (TDeployment extends Deployment.ETHEREUM
+  ? KnownAddressListIdMappingEthereumSpecific
+  : TDeployment extends Deployment.POLYGON | Deployment.TESTNET
+    ? KnownAddressListIdMappingPolygonSpecific
+    : {});
 
 export type KnownAddressListIdMappingEthereumSpecific = {
+  gsnTrustedForwarders: bigint;
   kilnStakingContracts: bigint;
   zeroLendRWAStablecoinsATokens: bigint;
   zeroLendLRTBTCATokens: bigint;
+};
+
+export type KnownAddressListIdMappingPolygonSpecific = {
+  gsnTrustedForwarders: bigint;
 };
 
 export interface KnownUintListIdMapping {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces support for GSN (Gas Station Network) trusted forwarders across different deployment environments, enhancing the infrastructure for transactions on the blockchain.

### Detailed summary
- Added `gsnTrustedForwarders` field in `testnet.ts`, `polygon.ts`, and `ethereum.ts` deployments.
- Updated type definitions in `releases.ts` to include `gsnTrustedForwarders` in `KnownAddressListIdMappingEthereumSpecific` and created `KnownAddressListIdMappingPolygonSpecific`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->