### PR TITLE
feat: base adjustments

### DIFF
--- a/.changeset/wise-boxes-boil.md
+++ b/.changeset/wise-boxes-boil.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Base adjustments

--- a/packages/environment/src/assets.ts
+++ b/packages/environment/src/assets.ts
@@ -225,6 +225,7 @@ export enum Erc4626Protocol {
   SKY = "SKY",
   SPARK = "SPARK",
   VAULTCRAFT = "VAULTCRAFT",
+  ORIGIN = "ORIGIN",
 }
 
 export enum BalancerStakingType {

--- a/packages/environment/src/assets/base.ts
+++ b/packages/environment/src/assets/base.ts
@@ -225,7 +225,9 @@ export default defineAssetList(Network.BASE, [
     symbol: "wsuperOETHb",
     decimals: 18,
     releases: [sulu],
-    type: AssetType.PRIMITIVE,
+    underlying: "0xdbfefd2e8460a6ee4955a68582f85708baea60a3",
+    protocol: Erc4626Protocol.ORIGIN,
+    type: AssetType.ERC_4626,
     priceFeed: {
       type: PriceFeedType.DERIVATIVE_ERC4626,
       address: "0x6889790fb10a03bbf9dc86f1bed3219b509f5367",

--- a/packages/environment/src/deployments/base.ts
+++ b/packages/environment/src/deployments/base.ts
@@ -64,7 +64,7 @@ export default defineDeployment<Deployment.BASE>({
     zeroLendRWAStablecoinsAaveV3RewardsController: "0x0000000000000000000000000000000000000000",
   },
   inception: 23178791,
-  kind: Kind.TEST,
+  kind: Kind.LIVE,
   knownAddressLists: {
     depositWrapperAllowedExchanges: 1n,
     noSlippageAdapters: 3n,

--- a/packages/environment/src/deployments/base.ts
+++ b/packages/environment/src/deployments/base.ts
@@ -74,7 +74,7 @@ export default defineDeployment<Deployment.BASE>({
     nonStandardPriceFeedAssets: 2n,
     aTokens: 9n,
   },
-  knownUintLists: {},
+  knownUintLists: { allowedMorphoBlueVaults: 1n },
   label: "Base",
   namedTokens: {
     comp: "0x9e1028f5f1d5ede59748ffcee5532509976840e0",
@@ -181,7 +181,7 @@ export default defineDeployment<Deployment.BASE>({
         MinAssetBalancesPostRedemptionPolicy: "0x0af17b9abe72d68ca78aa9ea1efc2def0ed1dd8a",
         MinMaxInvestmentPolicy: "0xe16990bcfc59ec6cc00fa1e20707871ae22fd6f7",
         MinSharesSupplyFee: "0xa32d9085c8c56515a1a03648b5c417badbe7732d",
-        MorphoBluePositionLib: "0x38953a28a729a60ad2c18ddab964193678292695",
+        MorphoBluePositionLib: "0x3cfdd91a5d80cdf175a92db128a54d30e4014f03",
         MorphoBluePositionParser: "0x33691ac33507c8a9ac94ac8f879a6416b04cb53b",
         NoDepegOnRedeemSharesForSpecificAssetsPolicy: "0x33d9d62a9155e96202378b80078bf73d4f1317a9",
         NotionalV2PositionLib: "0x0000000000000000000000000000000000000000",

--- a/packages/environment/src/environment.ts
+++ b/packages/environment/src/environment.ts
@@ -97,7 +97,7 @@ export class Environment<TVersion extends Version = Version, TDeployment extends
   public readonly contracts: VersionContracts<TVersion>;
   public readonly externalContracts: ExternalContractsMapping;
   public readonly knownAddressLists: KnownAddressListIdMapping<TDeployment>;
-  public readonly knownUintLists: KnownUintListIdMapping;
+  public readonly knownUintLists: KnownUintListIdMapping<TDeployment>;
   public readonly assets: Record<Address, Asset> = {};
   public readonly adapters: Record<string, AdapterDefinition> = {};
   public readonly namedTokens: DeploymentNamedAssetsTokens<TDeployment>;

--- a/packages/environment/src/releases.ts
+++ b/packages/environment/src/releases.ts
@@ -273,9 +273,19 @@ export type KnownAddressListIdMappingPolygonSpecific = {
   gsnTrustedForwarders: bigint;
 };
 
-export interface KnownUintListIdMapping {
+export type KnownUintListIdMapping<TDeployment extends Deployment> = {
   allowedMorphoBlueVaults?: bigint;
-}
+} & (TDeployment extends Deployment.ETHEREUM
+  ? KnownUintListIdMappingEthereumSpecific
+  : TDeployment extends Deployment.BASE
+    ? KnownUintListIdMappingBaseChainSpecific
+    : {});
+
+export type KnownUintListIdMappingEthereumSpecific = {
+  allowedMorphoBlueVaults: bigint;
+};
+
+export type KnownUintListIdMappingBaseChainSpecific = KnownUintListIdMappingEthereumSpecific;
 
 export interface ExternalContractsMapping {
   readonly aaveUIIncentiveDataProvider: Address;
@@ -355,7 +365,7 @@ export interface DeploymentDefinition<TDeployment extends Deployment> {
   /**
    * Ids for known uint lists.
    */
-  readonly knownUintLists: KnownUintListIdMapping;
+  readonly knownUintLists: KnownUintListIdMapping<TDeployment>;
   /**
    * The kind of the deployment (e.g. testnet or production).
    */


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adjustments to the `environment` package, including new asset types, protocol definitions, and updates to the deployment structure to accommodate specific deployment types.

### Detailed summary
- Added `ORIGIN` to the `assets.ts` enum.
- Updated `AssetType` to include `ERC_4626` and added `underlying` and `protocol` properties in `base.ts`.
- Modified `KnownUintListIdMapping` to be generic and added specific types for Ethereum and Base Chain.
- Changed `kind` from `TEST` to `LIVE` in `base.ts`.
- Updated `knownUintLists` in deployment to include `allowedMorphoBlueVaults`. 
- Modified `MorphoBluePositionLib` address in deployment configuration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->