### PR TITLE
chore: add paraswapv6 august swapper to external contracts

### DIFF
--- a/.changeset/eighty-moose-remain.md
+++ b/.changeset/eighty-moose-remain.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Add ParaSwapV6AugustusSwapper to external contracts

--- a/packages/environment/src/deployments/arbitrum.ts
+++ b/packages/environment/src/deployments/arbitrum.ts
@@ -40,6 +40,7 @@ export default defineDeployment<Deployment.ARBITRUM>({
     multicall: "0xca11bde05977b3631167028862be2a173976ca11",
     paraswapV5AugustusSwapper: "0xdef171fe48cf0115b1d80b88dc8eab59176fee57",
     paraswapV5TokenTransferProxy: "0x216b4b4ba9f3e719726886d34a177484278bfcae",
+    paraswapV6AugustusSwapper: "0xdef171fe48cf0115b1d80b88dc8eab59176fee57",
     pendlePtLpOracle: "0x0000000000000000000000000000000000000000",
     staderStakingPoolManager: "0x0000000000000000000000000000000000000000",
     staderUserWithdrawManager: "0x0000000000000000000000000000000000000000",

--- a/packages/environment/src/deployments/base.ts
+++ b/packages/environment/src/deployments/base.ts
@@ -38,6 +38,7 @@ export default defineDeployment<Deployment.BASE>({
     morphoBlue: "0xbbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb",
     paraswapV5AugustusSwapper: "0x59c7c832e96d2568bea6db468c1aadcbbda08a52",
     paraswapV5TokenTransferProxy: "0x93aaae79a53759cd164340e4c8766e4db5331cd7",
+    paraswapV6AugustusSwapper: "0xdef171fe48cf0115b1d80b88dc8eab59176fee57",
     pendlePtLpOracle: "0x0000000000000000000000000000000000000000",
     stakeWiseV3KeeperRewards: "0x0000000000000000000000000000000000000000",
     staderUserWithdrawManager: "0x0000000000000000000000000000000000000000",

--- a/packages/environment/src/deployments/ethereum.ts
+++ b/packages/environment/src/deployments/ethereum.ts
@@ -40,6 +40,7 @@ export default defineDeployment<Deployment.ETHEREUM>({
     multicall: "0xca11bde05977b3631167028862be2a173976ca11",
     paraswapV5AugustusSwapper: "0xdef171fe48cf0115b1d80b88dc8eab59176fee57",
     paraswapV5TokenTransferProxy: "0x216b4b4ba9f3e719726886d34a177484278bfcae",
+    paraswapV6AugustusSwapper: "0xdef171fe48cf0115b1d80b88dc8eab59176fee57",
     pendlePtLpOracle: "0x66a1096c6366b2529274df4f5d8247827fe4cea8",
     staderStakingPoolManager: "0xcf5ea1b38380f6af39068375516daf40ed70d299",
     staderUserWithdrawManager: "0x9f0491b32dbce587c50c4c43ab303b06478193a7",

--- a/packages/environment/src/deployments/polygon.ts
+++ b/packages/environment/src/deployments/polygon.ts
@@ -42,6 +42,7 @@ export default defineDeployment<Deployment.POLYGON>({
     staderUserWithdrawManager: "0x0000000000000000000000000000000000000000",
     paraswapV5AugustusSwapper: "0xdef171fe48cf0115b1d80b88dc8eab59176fee57",
     paraswapV5TokenTransferProxy: "0x216b4b4ba9f3e719726886d34a177484278bfcae",
+    paraswapV6AugustusSwapper: "0xdef171fe48cf0115b1d80b88dc8eab59176fee57",
     pendlePtLpOracle: "0x0000000000000000000000000000000000000000",
     stakeWiseV3KeeperRewards: "0x0000000000000000000000000000000000000000",
     theGraphDelegationStakingProxy: "0x0000000000000000000000000000000000000000",

--- a/packages/environment/src/releases.ts
+++ b/packages/environment/src/releases.ts
@@ -321,6 +321,7 @@ export interface ExternalContractsMapping {
   readonly multicall: Address;
   readonly paraswapV5AugustusSwapper: Address;
   readonly paraswapV5TokenTransferProxy: Address;
+  readonly paraswapV6AugustusSwapper: Address;
   readonly pendlePtLpOracle: Address;
   readonly staderStakingPoolManager: Address;
   readonly staderUserWithdrawManager: Address;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces the `paraswapV6AugustusSwapper` to the external contracts, updating various deployment files across different networks to include its address.

### Detailed summary
- Added `paraswapV6AugustusSwapper` as a readonly property in `packages/environment/src/releases.ts`.
- Updated `packages/environment/src/deployments/base.ts` to include the address for `paraswapV6AugustusSwapper`.
- Included `paraswapV6AugustusSwapper` in `packages/environment/src/deployments/arbitrum.ts`.
- Added `paraswapV6AugustusSwapper` in `packages/environment/src/deployments/ethereum.ts`.
- Updated `packages/environment/src/deployments/polygon.ts` to include `paraswapV6AugustusSwapper`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->