### PR TITLE
feat: add rsup

### DIFF
--- a/.changeset/young-roses-rush.md
+++ b/.changeset/young-roses-rush.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Add RSUP

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7931,4 +7931,15 @@ export default defineAssetList(Network.ETHEREUM, [
       rateAsset: RateAsset.ETH,
     },
   },
+  {
+    decimals: 18,
+    id: "0x419905009e4656fdc02418c7df35b1e61ed5f726",
+    name: "RSUP",
+    releases: [],
+    symbol: "Resupply",
+    type: AssetType.PRIMITIVE,
+    priceFeed: {
+      type: PriceFeedType.NONE,
+    },
+  },
 ]);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new asset, `RSUP`, to the Ethereum environment configuration.

### Detailed summary
- Added a new asset configuration for `RSUP` in the `packages/environment/src/assets/ethereum.ts` file.
  - `decimals`: 18
  - `id`: "0x419905009e4656fdc02418c7df35b1e61ed5f726"
  - `name`: "RSUP"
  - `releases`: []
  - `symbol`: "Resupply"
  - `type`: `AssetType.PRIMITIVE`
  - `priceFeed`: 
    - `type`: `PriceFeedType.NONE`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->