### PR TITLE
fix: resupply token

### DIFF
--- a/.changeset/rare-bees-deliver.md
+++ b/.changeset/rare-bees-deliver.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Fix resupply

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7934,9 +7934,9 @@ export default defineAssetList(Network.ETHEREUM, [
   {
     decimals: 18,
     id: "0x419905009e4656fdc02418c7df35b1e61ed5f726",
-    name: "RSUP",
+    name: "Resupply",
     releases: [],
-    symbol: "Resupply",
+    symbol: "RSUP",
     type: AssetType.PRIMITIVE,
     priceFeed: {
       type: PriceFeedType.NONE,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the asset details for `Resupply` in the `packages/environment/src/assets/ethereum.ts` file, specifically fixing its name and symbol.

### Detailed summary
- Changed the `name` of the asset from `"RSUP"` to `"Resupply"`.
- Changed the `symbol` of the asset from `"Resupply"` to `"RSUP"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->