### PR TITLE
feat: add solv btc bbn

### DIFF
--- a/.changeset/perfect-ladybugs-turn.md
+++ b/.changeset/perfect-ladybugs-turn.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Add solv btc bbn

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7386,11 +7386,9 @@ export default defineAssetList(Network.ETHEREUM, [
     releases: [sulu],
     decimals: 18,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_REDSTONE,
-      aggregator: "0x24c8964338deb5204b096039147b8e8c3aea42cc",
+      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_SOLV_BTC_BBN,
+      aggregator: "0xe16a36e1ae4538a579b5a249d042943b90878ef1",
       rateAsset: RateAsset.USD,
-      peggedTo: "SolvBTC",
-      nonStandard: true,
     },
   },
   {

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -190,7 +190,7 @@ export default defineAssetList(Network.ETHEREUM, [
     type: AssetType.AAVE_V3,
     underlying: "0xa35b1b31ce002fbf2058d22f30f95d405200a15b",
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ETHX,
+      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE,
       aggregator: "0x75c4dc3201015c78a60dbe673fc7247549527c1b",
       rateAsset: RateAsset.ETH,
     },
@@ -2594,7 +2594,7 @@ export default defineAssetList(Network.ETHEREUM, [
     symbol: "wstETH",
     type: AssetType.PRIMITIVE,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_WSTETH,
+      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE,
       aggregator: "0x92829c41115311ca43d5c9f722f0e9e7b9fcd30a",
       rateAsset: RateAsset.ETH,
     },
@@ -3475,7 +3475,7 @@ export default defineAssetList(Network.ETHEREUM, [
     symbol: "ETHx",
     type: AssetType.PRIMITIVE,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ETHX,
+      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE,
       aggregator: "0x75c4dc3201015c78a60dbe673fc7247549527c1b",
       rateAsset: RateAsset.ETH,
     },
@@ -6597,7 +6597,7 @@ export default defineAssetList(Network.ETHEREUM, [
     symbol: "ynETH",
     type: AssetType.PRIMITIVE,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_YNETH,
+      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE,
       aggregator: "0xa8f6033ce40fab29c228f32ef44d38cb3043c5bc",
       rateAsset: RateAsset.ETH,
       nonStandard: true,
@@ -7386,7 +7386,7 @@ export default defineAssetList(Network.ETHEREUM, [
     releases: [sulu],
     decimals: 18,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_SOLV_BTC_BBN,
+      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE,
       aggregator: "0xe16a36e1ae4538a579b5a249d042943b90878ef1",
       rateAsset: RateAsset.USD,
     },
@@ -7594,7 +7594,7 @@ export default defineAssetList(Network.ETHEREUM, [
     releases: [sulu],
     type: AssetType.PRIMITIVE,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_USDN,
+      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE,
       aggregator: "0xd5004c5d3017862839e83981b110f27ee7b36eaa",
       rateAsset: RateAsset.USD,
     },
@@ -7734,7 +7734,7 @@ export default defineAssetList(Network.ETHEREUM, [
     symbol: "tETH",
     type: AssetType.PRIMITIVE,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_QUOTED,
+      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE,
       aggregator: "0x8610172c4ea038a69565d9522db7187b34003761",
       rateAsset: RateAsset.ETH,
     },
@@ -7819,7 +7819,7 @@ export default defineAssetList(Network.ETHEREUM, [
     decimals: 18,
     underlying: "0x66a1e37c9b0eaddca17d3662d6c05f4decf3e110",
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ERC4626,
+      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE,
       aggregator: "0xe825080d444aa2772ece2648b48c320f8ddfbe62",
       rateAsset: RateAsset.ETH,
     },
@@ -7849,7 +7849,7 @@ export default defineAssetList(Network.ETHEREUM, [
     decimals: 6,
     underlying: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ERC4626,
+      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE,
       aggregator: "0x740ee3b8e79ee324c66b33c227d3cd23f413200d",
       rateAsset: RateAsset.ETH,
     },
@@ -7893,7 +7893,7 @@ export default defineAssetList(Network.ETHEREUM, [
     decimals: 6,
     underlying: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ERC4626,
+      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE,
       aggregator: "0xfba3c30dfcac70eaf60ee01c1c9f3e452c5020f8",
       rateAsset: RateAsset.ETH,
     },

--- a/packages/environment/src/contracts.ts
+++ b/packages/environment/src/contracts.ts
@@ -148,6 +148,7 @@ export interface SuluContracts extends CommonContracts {
   readonly SingleAssetDepositQueueLib: Address;
   readonly SingleAssetDepositQueueFactory: Address;
   readonly SmarDexUsdnNativeRateUsdAggregator: Address;
+  readonly SolvBtcYieldTokenRateUsdAggregatorFactory: Address;
   readonly SolvV2BondBuyerPositionLib: Address;
   readonly SolvV2BondBuyerPositionParser: Address;
   readonly SolvV2BondIssuerPositionLib: Address;

--- a/packages/environment/src/deployments/arbitrum.ts
+++ b/packages/environment/src/deployments/arbitrum.ts
@@ -213,6 +213,7 @@ export default defineDeployment<Deployment.ARBITRUM>({
         SingleAssetRedemptionQueueFactory: "0xb658a26ec9638051a42160bb02319fed12299b25",
         SingleAssetRedemptionQueueLib: "0x137ac14e27de154e6a0a260570259f8cef436ba4",
         SmarDexUsdnNativeRateUsdAggregator: "0x0000000000000000000000000000000000000000",
+        SolvBtcYieldTokenRateUsdAggregatorFactory: "0x0000000000000000000000000000000000000000",
         SolvV2BondBuyerPositionLib: "0x0000000000000000000000000000000000000000",
         SolvV2BondBuyerPositionParser: "0x0000000000000000000000000000000000000000",
         SolvV2BondIssuerPositionLib: "0x0000000000000000000000000000000000000000",

--- a/packages/environment/src/deployments/base.ts
+++ b/packages/environment/src/deployments/base.ts
@@ -209,6 +209,7 @@ export default defineDeployment<Deployment.BASE>({
         SingleAssetRedemptionQueueFactory: "0x785f1779ae48bfa8f8d89ce140c62a603c104f36",
         SingleAssetRedemptionQueueLib: "0x6bf54dc336bacddf2478728b5f7fdec4451a684f",
         SmarDexUsdnNativeRateUsdAggregator: "0x0000000000000000000000000000000000000000",
+        SolvBtcYieldTokenRateUsdAggregatorFactory: "0x0000000000000000000000000000000000000000",
         SolvV2BondBuyerPositionLib: "0x0000000000000000000000000000000000000000",
         SolvV2BondBuyerPositionParser: "0x0000000000000000000000000000000000000000",
         SolvV2BondIssuerPositionLib: "0x0000000000000000000000000000000000000000",

--- a/packages/environment/src/deployments/ethereum.ts
+++ b/packages/environment/src/deployments/ethereum.ts
@@ -236,6 +236,7 @@ export default defineDeployment<Deployment.ETHEREUM>({
         SingleAssetRedemptionQueueFactory: "0xfe84d5209054254389c9d6a754b821f3a297d56a",
         SingleAssetRedemptionQueueLib: "0x0012b7c26b8c081a29a61cd52526cf6305367968",
         SmarDexUsdnNativeRateUsdAggregator: "0xd5004c5d3017862839e83981b110f27ee7b36eaa",
+        SolvBtcYieldTokenRateUsdAggregatorFactory: "0x877f7a1c58ae061cbe6a207fd0379571c45f555a",
         SolvV2BondBuyerPositionLib: "0x0e7d828f9f9a3ce152d39f21f2e2d0ff89448b6b",
         SolvV2BondBuyerPositionParser: "0xa2ed786215d6f4da95338ee7abb84f28134dc19c",
         SolvV2BondIssuerPositionLib: "0x31c30bacb054f5db7f5bc96850b488440abb8991",

--- a/packages/environment/src/deployments/polygon.ts
+++ b/packages/environment/src/deployments/polygon.ts
@@ -218,6 +218,7 @@ export default defineDeployment<Deployment.POLYGON>({
         SingleAssetRedemptionQueueFactory: "0x4b6b342ba8bb29e2d1b542532e6b7be1cae026b9",
         SingleAssetRedemptionQueueLib: "0xe54065f5b303c2843c769fb232b95bb893cf0b87",
         SmarDexUsdnNativeRateUsdAggregator: "0x0000000000000000000000000000000000000000",
+        SolvBtcYieldTokenRateUsdAggregatorFactory: "0x0000000000000000000000000000000000000000",
         SolvV2BondBuyerPositionLib: "0x0000000000000000000000000000000000000000",
         SolvV2BondBuyerPositionParser: "0x0000000000000000000000000000000000000000",
         SolvV2BondIssuerPositionLib: "0x0000000000000000000000000000000000000000",

--- a/packages/environment/src/deployments/testnet.ts
+++ b/packages/environment/src/deployments/testnet.ts
@@ -151,6 +151,7 @@ export default defineDeployment<Deployment.TESTNET>({
         SingleAssetRedemptionQueueFactory: "0xad1980b3301557eae118275e79c2554cb6efbd5a",
         SingleAssetRedemptionQueueLib: "0x78c357627c65c336a64abefa062a0b19ba6fa6f4",
         SmarDexUsdnNativeRateUsdAggregator: "0x0000000000000000000000000000000000000000",
+        SolvBtcYieldTokenRateUsdAggregatorFactory: "0x0000000000000000000000000000000000000000",
         SolvV2BondBuyerPositionLib: "0x0000000000000000000000000000000000000000",
         SolvV2BondBuyerPositionParser: "0x0000000000000000000000000000000000000000",
         SolvV2BondIssuerPositionLib: "0x0000000000000000000000000000000000000000",

--- a/packages/environment/src/price-feeds.ts
+++ b/packages/environment/src/price-feeds.ts
@@ -7,6 +7,7 @@ export enum PriceFeedType {
   PRIMITIVE_CHAINLINK_LIKE_ETHX = "PRIMITIVE_CHAINLINK_LIKE_ETHX",
   PRIMITIVE_CHAINLINK_LIKE_ERC4626 = "PRIMITIVE_CHAINLINK_LIKE_ERC4626",
   PRIMITIVE_CHAINLINK_LIKE_QUOTED = "PRIMITIVE_CHAINLINK_LIKE_QUOTED",
+  PRIMITIVE_CHAINLINK_LIKE_SOLV_BTC_BBN = "PRIMITIVE_CHAINLINK_LIKE_SOLV_BTC_BBN",
   PRIMITIVE_CHAINLINK_LIKE_USDN = "PRIMITIVE_CHAINLINK_LIKE_USDN",
   PRIMITIVE_CHAINLINK_LIKE_WSTETH = "PRIMITIVE_CHAINLINK_LIKE_WSTETH",
   PRIMITIVE_CHAINLINK_LIKE_YNETH = "PRIMITIVE_CHAINLINK_LIKE_YNETH",
@@ -38,6 +39,7 @@ export const primitivePriceFeeds = [
   PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_USDN,
   PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_WSTETH,
   PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_YNETH,
+  PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_SOLV_BTC_BBN,
   PriceFeedType.PRIMITIVE_REDSTONE,
   PriceFeedType.PRIMITIVE_REDSTONE_QUOTED,
   PriceFeedType.PRIMITIVE_REDSTONE_NON_STANDARD_PRECISION,
@@ -78,6 +80,7 @@ export type PriceFeed =
   | PrimitiveRedstonePriceFeed
   | PrimitiveRedstoneQuotedPriceFeed
   | PrimitiveNonStandardPrecisionPriceFeed
+  | PrimitiveChainlinkLikeSolvBtcBbnPriceFeed
   | PrimitivePendleV2PriceFeed
   | DerivativeArrakisV2PriceFeed
   | DerivativeBalancerV2GaugeTokenPriceFeed
@@ -223,6 +226,18 @@ export interface PrimitiveNonStandardPrecisionPriceFeed extends PriceFeedBase {
    * Rate Asset (ETH = 0, USD = 1)
    */
   readonly rateAsset: RateAsset;
+}
+
+export interface PrimitiveChainlinkLikeSolvBtcBbnPriceFeed extends PriceFeedBase {
+  readonly type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_SOLV_BTC_BBN;
+  /**
+   * Aggregator address
+   */
+  readonly aggregator: Address;
+  /**
+   * Rate Asset (ETH = 0, USD = 1)
+   */
+  readonly rateAsset: RateAsset.USD;
 }
 
 export interface PrimitivePendleV2PriceFeed extends PriceFeedBase {

--- a/packages/environment/src/price-feeds.ts
+++ b/packages/environment/src/price-feeds.ts
@@ -4,13 +4,7 @@ export enum PriceFeedType {
   NONE = "NONE",
   WETH = "WETH",
   PRIMITIVE_CHAINLINK = "PRIMITIVE_CHAINLINK",
-  PRIMITIVE_CHAINLINK_LIKE_ETHX = "PRIMITIVE_CHAINLINK_LIKE_ETHX",
-  PRIMITIVE_CHAINLINK_LIKE_ERC4626 = "PRIMITIVE_CHAINLINK_LIKE_ERC4626",
-  PRIMITIVE_CHAINLINK_LIKE_QUOTED = "PRIMITIVE_CHAINLINK_LIKE_QUOTED",
-  PRIMITIVE_CHAINLINK_LIKE_SOLV_BTC_BBN = "PRIMITIVE_CHAINLINK_LIKE_SOLV_BTC_BBN",
-  PRIMITIVE_CHAINLINK_LIKE_USDN = "PRIMITIVE_CHAINLINK_LIKE_USDN",
-  PRIMITIVE_CHAINLINK_LIKE_WSTETH = "PRIMITIVE_CHAINLINK_LIKE_WSTETH",
-  PRIMITIVE_CHAINLINK_LIKE_YNETH = "PRIMITIVE_CHAINLINK_LIKE_YNETH",
+  PRIMITIVE_CHAINLINK_LIKE = "PRIMITIVE_CHAINLINK_LIKE",
   PRIMITIVE_REDSTONE = "PRIMITIVE_REDSTONE",
   PRIMITIVE_REDSTONE_QUOTED = "PRIMITIVE_REDSTONE_QUOTED",
   PRIMITIVE_REDSTONE_NON_STANDARD_PRECISION = "PRIMITIVE_NON_STANDARD_PRECISION",
@@ -33,13 +27,7 @@ export enum PriceFeedType {
 
 export const primitivePriceFeeds = [
   PriceFeedType.PRIMITIVE_CHAINLINK,
-  PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ETHX,
-  PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ERC4626,
-  PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_QUOTED,
-  PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_USDN,
-  PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_WSTETH,
-  PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_YNETH,
-  PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_SOLV_BTC_BBN,
+  PriceFeedType.PRIMITIVE_CHAINLINK_LIKE,
   PriceFeedType.PRIMITIVE_REDSTONE,
   PriceFeedType.PRIMITIVE_REDSTONE_QUOTED,
   PriceFeedType.PRIMITIVE_REDSTONE_NON_STANDARD_PRECISION,
@@ -71,16 +59,10 @@ export type PriceFeed =
   | NoPriceFeed
   | WethPriceFeed
   | PrimitiveChainlinkPriceFeed
-  | PrimitiveChainlinkLikeEthxPriceFeed
-  | PrimitiveChainlinkLikeERC4626PriceFeed
-  | PrimitiveChainlinkLikeQuotedPriceFeed
-  | PrimitiveChainlinkLikeUsdnPriceFeed
-  | PrimitiveChainlinkLikeWstEthPriceFeed
-  | PrimitiveChainlinkLikeYnEthPriceFeed
+  | PrimitiveChainlinkLikePriceFeed
   | PrimitiveRedstonePriceFeed
   | PrimitiveRedstoneQuotedPriceFeed
   | PrimitiveNonStandardPrecisionPriceFeed
-  | PrimitiveChainlinkLikeSolvBtcBbnPriceFeed
   | PrimitivePendleV2PriceFeed
   | DerivativeArrakisV2PriceFeed
   | DerivativeBalancerV2GaugeTokenPriceFeed
@@ -122,43 +104,8 @@ export interface PrimitiveChainlinkPriceFeed extends PriceFeedBase {
   readonly rateAsset: RateAsset;
 }
 
-export interface PrimitiveChainlinkLikeQuotedPriceFeed extends PriceFeedBase {
-  readonly type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_QUOTED;
-  /**
-   * Aggregator address
-   */
-  readonly aggregator: Address;
-  /**
-   * Rate Asset (ETH = 0, USD = 1)
-   */
-  readonly rateAsset: RateAsset.ETH;
-}
-
-export interface PrimitiveChainlinkLikeUsdnPriceFeed extends PriceFeedBase {
-  readonly type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_USDN;
-  /**
-   * Aggregator address
-   */
-  readonly aggregator: Address;
-  /**
-   * Rate Asset (ETH = 0, USD = 1)
-   */
-  readonly rateAsset: RateAsset.USD;
-}
-export interface PrimitiveChainlinkLikeWstEthPriceFeed extends PriceFeedBase {
-  readonly type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_WSTETH;
-  /**
-   * Aggregator address
-   */
-  readonly aggregator: Address;
-  /**
-   * Rate Asset (ETH = 0, USD = 1)
-   */
-  readonly rateAsset: RateAsset.ETH;
-}
-
-export interface PrimitiveChainlinkLikeERC4626PriceFeed extends PriceFeedBase {
-  readonly type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ERC4626;
+export interface PrimitiveChainlinkLikePriceFeed extends PriceFeedBase {
+  readonly type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE;
   /**
    * Aggregator address
    */
@@ -167,29 +114,6 @@ export interface PrimitiveChainlinkLikeERC4626PriceFeed extends PriceFeedBase {
    * Rate Asset (ETH = 0, USD = 1)
    */
   readonly rateAsset: RateAsset;
-}
-
-export interface PrimitiveChainlinkLikeYnEthPriceFeed extends PriceFeedBase {
-  readonly type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_YNETH;
-  /**
-   * Aggregator address
-   */
-  readonly aggregator: Address;
-  /**
-   * Rate Asset (ETH = 0, USD = 1)
-   */
-  readonly rateAsset: RateAsset.ETH;
-}
-export interface PrimitiveChainlinkLikeEthxPriceFeed extends PriceFeedBase {
-  readonly type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ETHX;
-  /**
-   * Aggregator address
-   */
-  readonly aggregator: Address;
-  /**
-   * Rate Asset (ETH = 0, USD = 1)
-   */
-  readonly rateAsset: RateAsset.ETH;
 }
 
 export interface PrimitiveRedstonePriceFeed extends PriceFeedBase {
@@ -226,18 +150,6 @@ export interface PrimitiveNonStandardPrecisionPriceFeed extends PriceFeedBase {
    * Rate Asset (ETH = 0, USD = 1)
    */
   readonly rateAsset: RateAsset;
-}
-
-export interface PrimitiveChainlinkLikeSolvBtcBbnPriceFeed extends PriceFeedBase {
-  readonly type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_SOLV_BTC_BBN;
-  /**
-   * Aggregator address
-   */
-  readonly aggregator: Address;
-  /**
-   * Rate Asset (ETH = 0, USD = 1)
-   */
-  readonly rateAsset: RateAsset.USD;
 }
 
 export interface PrimitivePendleV2PriceFeed extends PriceFeedBase {

--- a/packages/environment/test/assets/price-feed.test.ts
+++ b/packages/environment/test/assets/price-feed.test.ts
@@ -130,6 +130,7 @@ suite.each(assets)("$symbol ($name): $id", (asset) => {
       case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_USDN:
       case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_WSTETH:
       case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_YNETH:
+      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_SOLV_BTC_BBN:
       case PriceFeedType.PRIMITIVE_REDSTONE:
       case PriceFeedType.PRIMITIVE_REDSTONE_QUOTED:
       case PriceFeedType.PRIMITIVE_REDSTONE_NON_STANDARD_PRECISION:
@@ -242,6 +243,7 @@ suite.each(assets)("$symbol ($name): $id", (asset) => {
       case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_USDN:
       case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_WSTETH:
       case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_YNETH:
+      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_SOLV_BTC_BBN:
       case PriceFeedType.PRIMITIVE_REDSTONE:
       case PriceFeedType.PRIMITIVE_REDSTONE_QUOTED:
       case PriceFeedType.PRIMITIVE_REDSTONE_NON_STANDARD_PRECISION:

--- a/packages/environment/test/assets/price-feed.test.ts
+++ b/packages/environment/test/assets/price-feed.test.ts
@@ -78,7 +78,11 @@ suite.each(assets)("$symbol ($name): $id", (asset) => {
         break;
       }
 
-      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_WSTETH: {
+      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE: {
+        const decimals = await aggregatorDecimals(client, { aggregator: asset.priceFeed.aggregator });
+
+        expect(decimals).toBe(asset.priceFeed.rateAsset === 0 ? 18 : 8);
+
         break;
       }
 
@@ -124,13 +128,7 @@ suite.each(assets)("$symbol ($name): $id", (asset) => {
       }
 
       case PriceFeedType.PRIMITIVE_CHAINLINK:
-      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ERC4626:
-      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ETHX:
-      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_QUOTED:
-      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_USDN:
-      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_WSTETH:
-      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_YNETH:
-      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_SOLV_BTC_BBN:
+      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE:
       case PriceFeedType.PRIMITIVE_REDSTONE:
       case PriceFeedType.PRIMITIVE_REDSTONE_QUOTED:
       case PriceFeedType.PRIMITIVE_REDSTONE_NON_STANDARD_PRECISION:
@@ -237,13 +235,7 @@ suite.each(assets)("$symbol ($name): $id", (asset) => {
       case PriceFeedType.NONE:
       case PriceFeedType.WETH:
       case PriceFeedType.PRIMITIVE_CHAINLINK:
-      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ETHX:
-      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_ERC4626:
-      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_QUOTED:
-      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_USDN:
-      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_WSTETH:
-      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_YNETH:
-      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_SOLV_BTC_BBN:
+      case PriceFeedType.PRIMITIVE_CHAINLINK_LIKE:
       case PriceFeedType.PRIMITIVE_REDSTONE:
       case PriceFeedType.PRIMITIVE_REDSTONE_QUOTED:
       case PriceFeedType.PRIMITIVE_REDSTONE_NON_STANDARD_PRECISION:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding support for the `SolvBtcYieldTokenRateUsdAggregatorFactory` in various deployment files and standardizing the `PriceFeedType` enum by consolidating multiple types into a single `PRIMITIVE_CHAINLINK_LIKE` type.

### Detailed summary
- Added `SolvBtcYieldTokenRateUsdAggregatorFactory` to `contracts.ts`.
- Updated deployment files (`base.ts`, `polygon.ts`, `testnet.ts`, `arbitrum.ts`, `ethereum.ts`) with new aggregator addresses.
- Consolidated multiple `PriceFeedType` variants into a single `PRIMITIVE_CHAINLINK_LIKE`.
- Updated references in the `price-feed.test.ts` and `ethereum.ts` files to use the new `PriceFeedType`.
- Removed deprecated `PriceFeedType` variants from the `price-feeds.ts` and related interfaces.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->