### PR TITLE
chore: use correct price feed type for LBTC - v2

### DIFF
--- a/.changeset/fair-mirrors-shave.md
+++ b/.changeset/fair-mirrors-shave.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Use actually correct price feed type

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -715,7 +715,7 @@ export default defineAssetList(Network.ETHEREUM, [
     symbol: "LBTC",
     type: AssetType.PRIMITIVE,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_QUOTED,
+      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE,
       aggregator: "0x677f4b4cd52b2515790f464fe041e261a248f987",
       rateAsset: RateAsset.ETH,
     },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on correcting the price feed type used in the `priceFeed` configuration for an asset in the Ethereum environment.

### Detailed summary
- Updated the `type` of `priceFeed` from `PriceFeedType.PRIMITIVE_CHAINLINK_LIKE_QUOTED` to `PriceFeedType.PRIMITIVE_CHAINLINK_LIKE` in `packages/environment/src/assets/ethereum.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->