### PR TITLE
chore: run evn tests on push to main

### DIFF
--- a/.github/workflows/on-push-to-main.yaml
+++ b/.github/workflows/on-push-to-main.yaml
@@ -15,6 +15,11 @@ jobs:
     uses: ./.github/workflows/reusable-verify.yaml
     secrets: inherit
 
+  verify_environment:
+    name: Verify Environment
+    uses: ./.github/workflows/reusable-verify-environment.yaml
+    secrets: inherit
+
   docs:
     name: Documentation
     uses: ./.github/workflows/reusable-docs.yaml


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new job in the GitHub Actions workflow to verify the environment during the push to the main branch.

### Detailed summary
- Added a new job called `verify_environment` to the workflow in `.github/workflows/on-push-to-main.yaml`.
- Set the name of the job to "Verify Environment".
- Configured the job to use the reusable workflow located at `./.github/workflows/reusable-verify-environment.yaml`.
- Included `secrets: inherit` in the new job configuration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->