### PR TITLE
feat: add accrued performance fee

### DIFF
--- a/.changeset/modern-rice-hear.md
+++ b/.changeset/modern-rice-hear.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Add accrued performance fee


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces an enhancement to the `@enzymefinance/sdk` by adding a new function to calculate accrued performance fees, streamlining the process of obtaining performance fee shares due.

### Detailed summary
- Removed existing logic for calculating `performanceFeeSharesDue`.
- Introduced a new function `getAccruedPerformanceFee` that:
  - Accepts `client` and `args` as parameters.
  - Calculates `gav` using `simulateContract`.
  - Retrieves `sharesDue` from the performance fee contract.
- Updated `performanceFeeSharesDue` assignment to use the new function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->