### PR TITLE
feat: vault of vaults adjustments

### DIFF
--- a/.changeset/silent-dolphins-mate.md
+++ b/.changeset/silent-dolphins-mate.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Vault of vaults adjustments

--- a/packages/sdk/src/Portfolio/Integrations/EnzymeV4Vault.ts
+++ b/packages/sdk/src/Portfolio/Integrations/EnzymeV4Vault.ts
@@ -76,7 +76,6 @@ export function buySharesDecode(encoded: Hex): BuySharesArgs {
 //--------------------------------------------------------------------------------------------
 
 export type RedeemSharesForSpecificAssetsArgs = {
-  actionId: typeof AdapterAction.RedeemSharesForSpecificAssets;
   vaultProxy: Address;
   sharesQuantity: bigint;
   payoutAssets: ReadonlyArray<Address>;
@@ -121,10 +120,12 @@ export function redeemSharesForSpecificAssetsEncode(args: RedeemSharesForSpecifi
     args.minPayoutAssetAmounts,
   ]);
 
-  return encodeAdapterAction({ actionId: args.actionId, encodedActionArgs });
+  return encodeAdapterAction({ actionId: AdapterAction.RedeemSharesForSpecificAssets, encodedActionArgs });
 }
 
-export function redeemSharesForSpecificAssetsDecode(encoded: Hex): RedeemSharesForSpecificAssetsArgs {
+export function redeemSharesForSpecificAssetsDecode(
+  encoded: Hex,
+): RedeemSharesForSpecificAssetsArgs & { actionId: typeof AdapterAction.RedeemSharesForSpecificAssets } {
   const { actionId, encodedActionArgs } = decodeAdapterAction(encoded);
 
   const [vaultProxy, sharesQuantity, payoutAssets, payoutAssetPercentages, minPayoutAssetAmounts] = decodeAbiParameters(

--- a/packages/sdk/src/Portfolio/Integrations/EnzymeV4Vault.ts
+++ b/packages/sdk/src/Portfolio/Integrations/EnzymeV4Vault.ts
@@ -1,5 +1,4 @@
 import { type Address, type Hex, decodeAbiParameters, encodeAbiParameters } from "viem";
-import { Assertion } from "../../Utils.js";
 import * as IntegrationManager from "../../_internal/IntegrationManager.js";
 
 //--------------------------------------------------------------------------------------------
@@ -55,15 +54,12 @@ export function buySharesEncode(args: BuySharesArgs): Hex {
   return encodeAdapterAction({ actionId: AdapterAction.BuyShares, encodedActionArgs });
 }
 
-export function buySharesDecode(encoded: Hex): BuySharesArgs & { actionId: typeof AdapterAction.BuyShares } {
-  const { actionId, encodedActionArgs } = decodeAdapterAction(encoded);
+export function buySharesDecode(encoded: Hex): BuySharesArgs {
+  const { encodedActionArgs } = decodeAdapterAction(encoded);
 
   const [vaultProxy, investmentAmount, minSharesQuantity] = decodeAbiParameters(buySharesEncoding, encodedActionArgs);
 
-  Assertion.invariant(actionId === AdapterAction.BuyShares, "Invalid actionId");
-
   return {
-    actionId,
     vaultProxy,
     investmentAmount,
     minSharesQuantity,
@@ -122,20 +118,15 @@ export function redeemSharesForSpecificAssetsEncode(args: RedeemSharesForSpecifi
   return encodeAdapterAction({ actionId: AdapterAction.RedeemSharesForSpecificAssets, encodedActionArgs });
 }
 
-export function redeemSharesForSpecificAssetsDecode(
-  encoded: Hex,
-): RedeemSharesForSpecificAssetsArgs & { actionId: typeof AdapterAction.RedeemSharesForSpecificAssets } {
-  const { actionId, encodedActionArgs } = decodeAdapterAction(encoded);
+export function redeemSharesForSpecificAssetsDecode(encoded: Hex): RedeemSharesForSpecificAssetsArgs {
+  const { encodedActionArgs } = decodeAdapterAction(encoded);
 
   const [vaultProxy, sharesQuantity, payoutAssets, payoutAssetPercentages, minPayoutAssetAmounts] = decodeAbiParameters(
     redeemSharesForSpecificAssetsEncoding,
     encodedActionArgs,
   );
 
-  Assertion.invariant(actionId === AdapterAction.RedeemSharesForSpecificAssets, "Invalid actionId");
-
   return {
-    actionId,
     vaultProxy,
     sharesQuantity,
     payoutAssets,

--- a/packages/sdk/src/Portfolio/Integrations/EnzymeV4Vault.ts
+++ b/packages/sdk/src/Portfolio/Integrations/EnzymeV4Vault.ts
@@ -23,7 +23,6 @@ export const decodeAdapterAction = IntegrationManager.createDecodeAdapterAction<
 //--------------------------------------------------------------------------------------------
 
 export type BuySharesArgs = {
-  actionId: typeof AdapterAction.BuyShares;
   vaultProxy: Address;
   investmentAmount: bigint;
   minSharesQuantity: bigint;
@@ -53,10 +52,10 @@ export function buySharesEncode(args: BuySharesArgs): Hex {
     args.minSharesQuantity,
   ]);
 
-  return encodeAdapterAction({ actionId: args.actionId, encodedActionArgs });
+  return encodeAdapterAction({ actionId: AdapterAction.BuyShares, encodedActionArgs });
 }
 
-export function buySharesDecode(encoded: Hex): BuySharesArgs {
+export function buySharesDecode(encoded: Hex): BuySharesArgs & { actionId: typeof AdapterAction.BuyShares } {
   const { actionId, encodedActionArgs } = decodeAdapterAction(encoded);
 
   const [vaultProxy, investmentAmount, minSharesQuantity] = decodeAbiParameters(buySharesEncoding, encodedActionArgs);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refactoring the `buySharesEncode` and `redeemSharesForSpecificAssetsEncode` functions in the `EnzymeV4Vault` integration. It simplifies the handling of action IDs by directly using constants instead of passing them as arguments.

### Detailed summary
- Removed `actionId` from `BuySharesArgs` and `RedeemSharesForSpecificAssetsArgs`.
- Updated `buySharesEncode` to use `AdapterAction.BuyShares` directly.
- Updated `redeemSharesForSpecificAssetsEncode` to use `AdapterAction.RedeemSharesForSpecificAssets` directly.
- Removed invariant checks for `actionId` in both decode functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->