### PR TITLE
feat: add usdf and sdex

### DIFF
--- a/.changeset/healthy-paws-care.md
+++ b/.changeset/healthy-paws-care.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Add usdf and sdex

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7855,6 +7855,28 @@ export default defineAssetList(Network.ETHEREUM, [
     },
   },
   {
+    decimals: 18,
+    id: "0x5de8ab7e27f6e7a1fff3e5b337584aa43961beef",
+    name: "SmarDex Token",
+    releases: [],
+    symbol: "SDEX",
+    type: AssetType.PRIMITIVE,
+    priceFeed: {
+      type: PriceFeedType.NONE,
+    },
+  },
+  {
+    decimals: 18,
+    id: "0x5de8ab7e27f6e7a1fff3e5b337584aa43961beef",
+    name: "Falcon USD",
+    releases: [],
+    symbol: "USDf",
+    type: AssetType.PRIMITIVE,
+    priceFeed: {
+      type: PriceFeedType.NONE,
+    },
+  },
+  {
     symbol: "PT-LBTC-26JUN2025",
     name: "PT Lombard LBTC 26JUN2025",
     id: "0x6ca4d5d2ecb72e3bbf17543b3367746b80d22694",

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7867,7 +7867,7 @@ export default defineAssetList(Network.ETHEREUM, [
   },
   {
     decimals: 18,
-    id: "0x5de8ab7e27f6e7a1fff3e5b337584aa43961beef",
+    id: "0xfa2b947eec368f42195f24f36d2af29f7c24cec2",
     name: "Falcon USD",
     releases: [],
     symbol: "USDf",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding two new assets, `SmarDex Token` and `Falcon USD`, to the Ethereum asset list in the `environment` package.

### Detailed summary
- Added `SmarDex Token` with:
  - `decimals`: 18
  - `id`: "0x5de8ab7e27f6e7a1fff3e5b337584aa43961beef"
  - `symbol`: "SDEX"
  - `type`: `AssetType.PRIMITIVE`
  - `priceFeed`: `PriceFeedType.NONE`
  
- Added `Falcon USD` with:
  - `decimals`: 18
  - `id`: "0xfa2b947eec368f42195f24f36d2af29f7c24cec2"
  - `symbol`: "USDf"
  - `type`: `AssetType.PRIMITIVE`
  - `priceFeed`: `PriceFeedType.NONE`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->