### PR TITLE
feat: get aggregator data

### DIFF
--- a/.changeset/fuzzy-socks-invent.md
+++ b/.changeset/fuzzy-socks-invent.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Get aggregator data

--- a/packages/sdk/src/Protocol.ts
+++ b/packages/sdk/src/Protocol.ts
@@ -1,5 +1,5 @@
 import { IDerivativePriceFeed, IValueInterpreter } from "@enzymefinance/abis";
-import type { Address, Client } from "viem";
+import { type Address, type Client, parseAbi } from "viem";
 import { readContract } from "viem/actions";
 import { Viem } from "./Utils.js";
 
@@ -127,4 +127,28 @@ export function getEthUsdAggregator(
     functionName: "getEthUsdAggregator",
     address: args.valueInterpreter,
   });
+}
+
+export async function getLatestRoundData(
+  client: Client,
+  args: Viem.ContractCallParameters<{
+    aggregator: Address;
+  }>,
+) {
+  const [roundId, answer, startedAt, updatedAt, answeredInRound] = await readContract(client, {
+    ...Viem.extractBlockParameters(args),
+    abi: parseAbi([
+      "function latestRoundData() external view returns (uint80 roundId_, int256 answer_, uint256 startedAt_, uint256 updatedAt_, uint80 answeredInRound_)",
+    ]),
+    functionName: "latestRoundData",
+    address: args.aggregator,
+  });
+
+  return {
+    roundId,
+    answer,
+    startedAt,
+    updatedAt,
+    answeredInRound,
+  };
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new function to the `sdk` package that retrieves the latest round data from a specified aggregator, enhancing the functionality of the existing protocol.

### Detailed summary
- Added a new function `getLatestRoundData` in `packages/sdk/src/Protocol.ts`.
- The function takes a `Client` and parameters for the aggregator address.
- It uses `readContract` to fetch `roundId`, `answer`, `startedAt`, `updatedAt`, and `answeredInRound` from the aggregator.
- Utilizes `parseAbi` to define the ABI for the `latestRoundData` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->