### PR TITLE
feat: add vault of vault on base

### DIFF
--- a/.changeset/honest-wolves-breathe.md
+++ b/.changeset/honest-wolves-breathe.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Add vault of vaults on Base

--- a/packages/environment/src/assets/base.ts
+++ b/packages/environment/src/assets/base.ts
@@ -304,7 +304,7 @@ export default defineAssetList(Network.BASE, [
     },
   },
   {
-    symbol: "SAT",
+    symbol: "SATI",
     name: "Sati",
     id: "0xaabe20fbd2c38aaab42aedbe21872bd9964523eb",
     type: AssetType.ENZYME_VAULT,

--- a/packages/environment/src/assets/base.ts
+++ b/packages/environment/src/assets/base.ts
@@ -303,4 +303,40 @@ export default defineAssetList(Network.BASE, [
       nonStandard: true,
     },
   },
+  {
+    symbol: "SAT",
+    name: "Sati",
+    id: "0xaabe20fbd2c38aaab42aedbe21872bd9964523eb",
+    type: AssetType.ENZYME_VAULT,
+    releases: [sulu],
+    decimals: 18,
+    priceFeed: {
+      type: PriceFeedType.DERIVATIVE_ENZYME_VAULT,
+      address: "0xe32792c67d797784ced56f266e92a6611fe5e973",
+    },
+  },
+  {
+    symbol: "SAM",
+    name: "Samadhi",
+    id: "0x0c8be3e93cf0a7a383e54cb34cd471263f24b675",
+    type: AssetType.ENZYME_VAULT,
+    releases: [sulu],
+    decimals: 18,
+    priceFeed: {
+      type: PriceFeedType.DERIVATIVE_ENZYME_VAULT,
+      address: "0xe32792c67d797784ced56f266e92a6611fe5e973",
+    },
+  },
+  {
+    symbol: "VIR",
+    name: "Viriya",
+    id: "0x9362ac7a5e189bf81cc9b09432926a6154537847",
+    type: AssetType.ENZYME_VAULT,
+    releases: [sulu],
+    decimals: 18,
+    priceFeed: {
+      type: PriceFeedType.DERIVATIVE_ENZYME_VAULT,
+      address: "0xe32792c67d797784ced56f266e92a6611fe5e973",
+    },
+  },
 ]);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new feature to the `environment` package by introducing a vault of vaults on Base, which includes multiple assets with their respective details.

### Detailed summary
- Added new asset entries for `SATI`, `SAM`, and `VIR` in the `base.ts` file.
- Each asset includes:
  - `symbol`, `name`, `id`, `type`, `releases`, `decimals`, and `priceFeed` properties.
  - `priceFeed` specifies `type` as `DERIVATIVE_ENZYME_VAULT` and an associated `address`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->