### PR TITLE
feat: add aave v3 1inch

### DIFF
--- a/.changeset/gold-eggs-occur.md
+++ b/.changeset/gold-eggs-occur.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Add Aave V3 1Inch

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -1007,6 +1007,20 @@ export default defineAssetList(Network.ETHEREUM, [
   },
   {
     decimals: 18,
+    id: "0x71aef7b30728b9bb371578f36c5a1f1502a5723e",
+    name: "Aave Ethereum 1INCH",
+    releases: [sulu],
+    symbol: "aEth1INCH",
+    underlying: "0x111111111117dc0aa78b770fa6a738034120c302",
+    type: AssetType.AAVE_V3,
+    priceFeed: {
+      type: PriceFeedType.PRIMITIVE_CHAINLINK,
+      aggregator: "0x72afaecf99c9d9c8215ff44c77b94b99c28741e8",
+      rateAsset: RateAsset.ETH,
+    },
+  },
+  {
+    decimals: 18,
     id: "0x28fac5334c9f7262b3a3fe707e250e01053e07b5",
     name: "IdleUSDT v4 [Risk adjusted]",
     releases: [encore],


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new asset, `Aave Ethereum 1INCH`, to the environment configuration, enhancing the asset offerings for Aave V3.

### Detailed summary
- Added a new asset configuration for `Aave Ethereum 1INCH` with the following properties:
  - `decimals`: 18
  - `id`: "0x71aef7b30728b9bb371578f36c5a1f1502a5723e"
  - `name`: "Aave Ethereum 1INCH"
  - `releases`: [sulu]
  - `symbol`: "aEth1INCH"
  - `underlying`: "0x111111111117dc0aa78b770fa6a738034120c302"
  - `type`: `AssetType.AAVE_V3`
  - `priceFeed` configuration with:
    - `type`: `PriceFeedType.PRIMITIVE_CHAINLINK`
    - `aggregator`: "0x72afaecf99c9d9c8215ff44c77b94b99c28741e8"
    - `rateAsset`: `RateAsset.ETH`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->