### PR TITLE
feat: add pendle usds 14 aug 2025

### DIFF
--- a/.changeset/tricky-trees-leave.md
+++ b/.changeset/tricky-trees-leave.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Add Pendle USDS 14AUG2025

--- a/packages/environment/scripts/deploy-pendle-oracles/consts.ts
+++ b/packages/environment/scripts/deploy-pendle-oracles/consts.ts
@@ -19,4 +19,7 @@ export const underlyingToAggregatorInfo = {
   "0xd9a442856c234a39a81a089c06451ebaa4306a72": {
     aggregator: "0x114e286b85aacd4032a8b399cd288944fc5b7a90",
   },
+  "0xdc035d45d973e3ec169d2276ddab16f1e407384f": {
+    aggregator: "0x6c966976008c37BF60e019E3A4a802DD798d3b4b", // USDS/ETH
+  },
 } as const;

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -8050,4 +8050,19 @@ export default defineAssetList(Network.ETHEREUM, [
       rateAsset: RateAsset.ETH,
     },
   },
+  {
+    symbol: "PT-USDS-14AUG2025",
+    name: "PT USDS Stablecoin 14AUG2025",
+    id: "0xffec096c087c13cc268497b89a613cace4df9a48",
+    type: AssetType.PENDLE_V2_PT,
+    releases: [sulu],
+    decimals: 18,
+    underlying: "0xdc035d45d973e3ec169d2276ddab16f1e407384f",
+    markets: ["0xdace1121e10500e9e29d071f01593fd76b000f08"],
+    priceFeed: {
+      type: PriceFeedType.PRIMITIVE_PENDLE_V2,
+      aggregator: "0x6359564ede3cc6a0aa5052b20988e04dd6773abe",
+      rateAsset: RateAsset.ETH,
+    },
+  },
 ]);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a new asset, the `PT-USDS-14AUG2025`, to the environment for Pendle oracles, including its associated properties and price feed details.

### Detailed summary
- Updated `.changeset/tricky-trees-leave.md` with a patch for `@enzymefinance/environment`.
- Added `PT-USDS-14AUG2025` asset in `packages/environment/src/assets/ethereum.ts` with details like `symbol`, `name`, `id`, `type`, `releases`, `decimals`, `underlying`, `markets`, and `priceFeed`. 
- Introduced a new aggregator for the USDS/ETH market in `packages/environment/scripts/deploy-pendle-oracles/consts.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->