### PR TITLE
test: fix enzyme vault names

### DIFF
--- a/packages/environment/test/assets/token.test.ts
+++ b/packages/environment/test/assets/token.test.ts
@@ -33,7 +33,7 @@ suite.each(assets)("$symbol ($name): $id", (asset) => {
         break;
       }
       case AssetType.ENZYME_VAULT: {
-        // We don't validate Enzyme Vaults names, as they can change.
+        // We don't validate Enzyme Vaults symbol, as they can change.
         // For example when Cointerminal update Vaults campaigns
         break;
       }
@@ -103,6 +103,12 @@ suite.each(assets)("$symbol ($name): $id", (asset) => {
 
         const onChainVersion = await getApiVersion(client, { yearnVault: asset.id });
         expect(partsYearn?.[2]).toEqual(onChainVersion);
+        break;
+      }
+
+      case AssetType.ENZYME_VAULT: {
+        // We don't validate Enzyme Vaults names, as they can change.
+        // For example when Cointerminal update Vaults campaigns
         break;
       }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating comments related to the validation of `Enzyme Vaults` in the test file `token.test.ts`, clarifying that the validation pertains to symbols rather than names.

### Detailed summary
- Updated comment in the `AssetType.ENZYME_VAULT` case to specify that the validation is for symbols, not names.
- Added a new `case AssetType.ENZYME_VAULT` block in the test suite, reiterating the same clarification in the comment.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->