### PR TITLE
feat: add pt susude 25 sep 2025

### DIFF
--- a/.changeset/tasty-ghosts-count.md
+++ b/.changeset/tasty-ghosts-count.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+add PT-sUSDE-25SEP2025

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -8081,4 +8081,19 @@ export default defineAssetList(Network.ETHEREUM, [
       rateAsset: RateAsset.USD,
     },
   },
+  {
+    symbol: "PT-sUSDE-25SEP2025",
+    name: "PT Ethena sUSDE 25SEP2025",
+    id: "0x9f56094c450763769ba0ea9fe2876070c0fd5f77",
+    type: AssetType.PENDLE_V2_PT,
+    releases: [sulu],
+    decimals: 18,
+    underlying: "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
+    markets: ["0xa36b60a14a1a5247912584768c6e53e1a269a9f7"],
+    priceFeed: {
+      type: PriceFeedType.PRIMITIVE_PENDLE_V2,
+      aggregator: "0xcc7ff5845ad4f48c4dd49a41bae058a376a425fb",
+      rateAsset: RateAsset.ETH,
+    },
+  },
 ]);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new asset configuration for `PT-sUSDE-25SEP2025` in the Ethereum environment.

### Detailed summary
- Added a new asset with the following properties:
  - `symbol`: "PT-sUSDE-25SEP2025"
  - `name`: "PT Ethena sUSDE 25SEP2025"
  - `id`: "0x9f56094c450763769ba0ea9fe2876070c0fd5f77"
  - `type`: `AssetType.PENDLE_V2_PT`
  - `releases`: [sulu]
  - `decimals`: 18
  - `underlying`: "0x9d39a5de30e57443bff2a8307a4256c8797a3497"
  - `markets`: ["0xa36b60a14a1a5247912584768c6e53e1a269a9f7"]
  - `priceFeed` configuration with:
    - `type`: `PriceFeedType.PRIMITIVE_PENDLE_V2`
    - `aggregator`: "0xcc7ff5845ad4f48c4dd49a41bae058a376a425fb"
    - `rateAsset`: `RateAsset.ETH`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->