### PR TITLE
feat: add pt susude 27 nov 2025

### DIFF
--- a/.changeset/itchy-moles-juggle.md
+++ b/.changeset/itchy-moles-juggle.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Add PT sUSDe 27 Nov 2025

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -8096,4 +8096,19 @@ export default defineAssetList(Network.ETHEREUM, [
       rateAsset: RateAsset.ETH,
     },
   },
+  {
+    symbol: "PT-sUSDE-27NOV2025",
+    name: "PT Ethena sUSDE 27NOV2025",
+    id: "0xe6a934089bbee34f832060ce98848359883749b3",
+    type: AssetType.PENDLE_V2_PT,
+    releases: [sulu],
+    decimals: 18,
+    underlying: "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
+    markets: ["0xb6ac3d5da138918ac4e84441e924a20daa60dbdd"],
+    priceFeed: {
+      type: PriceFeedType.PRIMITIVE_PENDLE_V2,
+      aggregator: "0xb04820ba8c7d08f37c75cddc42ec8145bfffb1c4",
+      rateAsset: RateAsset.ETH,
+    },
+  },
 ]);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new asset to the Ethereum environment, specifically a PT sUSDe with a maturity date of November 27, 2025. 

### Detailed summary
- Added a new asset with the following details:
  - `symbol`: "PT-sUSDE-27NOV2025"
  - `name`: "PT Ethena sUSDE 27NOV2025"
  - `id`: "0xe6a934089bbee34f832060ce98848359883749b3"
  - `type`: `AssetType.PENDLE_V2_PT`
  - `releases`: [sulu]
  - `decimals`: 18
  - `underlying`: "0x9d39a5de30e57443bff2a8307a4256c8797a3497"
  - `markets`: ["0xb6ac3d5da138918ac4e84441e924a20daa60dbdd"]
  - `priceFeed`:
    - `type`: `PriceFeedType.PRIMITIVE_PENDLE_V2`
    - `aggregator`: "0xb04820ba8c7d08f37c75cddc42ec8145bfffb1c4"
    - `rateAsset`: `RateAsset.ETH`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->