### PR TITLE
chore: add ETHFI on ethereum

### DIFF
--- a/.changeset/eight-pigs-peel.md
+++ b/.changeset/eight-pigs-peel.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Add ETHFI on Ethereum

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7621,10 +7621,12 @@ export default defineAssetList(Network.ETHEREUM, [
     name: "ether.fi governance token",
     symbol: "ETHFI",
     decimals: 18,
-    releases: [],
+    releases: [sulu],
     type: AssetType.PRIMITIVE,
     priceFeed: {
-      type: PriceFeedType.NONE,
+      type: PriceFeedType.PRIMITIVE_CHAINLINK,
+      aggregator: "0x19678515847d8de85034dad0390e09c3048d31cd",
+      rateAsset: RateAsset.USD,
     },
   },
   {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces the `ETHFI` asset on the Ethereum network, updating its properties and price feed configuration.

### Detailed summary
- Added `ETHFI` asset with symbol `ETHFI` and `decimals` set to 18.
- Changed `releases` from an empty array to include `sulu`.
- Updated `priceFeed` type from `PriceFeedType.NONE` to `PriceFeedType.PRIMITIVE_CHAINLINK`.
- Added `aggregator` address `0x19678515847d8de85034dad0390e09c3048d31cd`.
- Set `rateAsset` to `RateAsset.USD`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->