### PR TITLE
chore: add aBascbBTC on Base

### DIFF
--- a/.changeset/plenty-kangaroos-confess.md
+++ b/.changeset/plenty-kangaroos-confess.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Add aBascbBTC on Base

--- a/packages/environment/src/assets/base.ts
+++ b/packages/environment/src/assets/base.ts
@@ -339,4 +339,18 @@ export default defineAssetList(Network.BASE, [
       address: "0xe32792c67d797784ced56f266e92a6611fe5e973",
     },
   },
+  {
+    decimals: 8,
+    id: "0xbdb9300b7cde636d9cd4aff00f6f009ffbbc8ee6",
+    name: "Aave Base cbBTC",
+    releases: [sulu],
+    symbol: "aBascbBTC",
+    type: AssetType.AAVE_V3,
+    underlying: "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf",
+    priceFeed: {
+      type: PriceFeedType.PRIMITIVE_CHAINLINK,
+      aggregator: "0x07da0e54543a844a80abe69c8a12f22b3aa59f9d",
+      rateAsset: RateAsset.USD,
+    },
+  },
 ]);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new asset, `aBascbBTC`, to the `Base` environment. It specifies various attributes for the asset including its `id`, `decimals`, and `priceFeed` details.

### Detailed summary
- Added `aBascbBTC` asset with the following attributes:
  - `decimals`: 8
  - `id`: "0xbdb9300b7cde636d9cd4aff00f6f009ffbbc8ee6"
  - `name`: "Aave Base cbBTC"
  - `symbol`: "aBascbBTC"
  - `type`: `AssetType.AAVE_V3`
  - `underlying`: "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf"
  - `priceFeed`:
    - `type`: `PriceFeedType.PRIMITIVE_CHAINLINK`
    - `aggregator`: "0x07da0e54543a844a80abe69c8a12f22b3aa59f9d"
    - `rateAsset`: `RateAsset.USD`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->