### PR TITLE
feat: unregister expired pendle assets

### DIFF
--- a/.changeset/nasty-candles-kiss.md
+++ b/.changeset/nasty-candles-kiss.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Unregister expired pendle assets

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7436,19 +7436,6 @@ export default defineAssetList(Network.ETHEREUM, [
     },
   },
   {
-    symbol: "PT-sUSDE-29MAY2025",
-    name: "PT Ethena sUSDE 29MAY2025",
-    id: "0xb7de5dfcb74d25c2f21841fbd6230355c50d9308",
-    type: AssetType.PENDLE_V2_PT,
-    releases: [],
-    decimals: 18,
-    underlying: "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
-    markets: ["0xb162b764044697cf03617c2efbcb1f42e31e4766"],
-    priceFeed: {
-      type: PriceFeedType.NONE
-    },
-  },
-  {
     decimals: 18,
     id: "0x691ad41906e3fe78c3fe1328ecddc9bd7c0e5eb8",
     name: "ZeroLend PT Ethena USDe 27MAR2025",
@@ -7520,7 +7507,7 @@ export default defineAssetList(Network.ETHEREUM, [
     decimals: 18,
     underlying: "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
     priceFeed: {
-      type: PriceFeedType.NONE
+      type: PriceFeedType.NONE,
     },
   },
   {
@@ -7581,7 +7568,7 @@ export default defineAssetList(Network.ETHEREUM, [
     underlying: "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
     markets: ["0xb162b764044697cf03617c2efbcb1f42e31e4766"],
     priceFeed: {
-      type: PriceFeedType.NONE
+      type: PriceFeedType.NONE,
     },
   },
   {
@@ -7689,7 +7676,7 @@ export default defineAssetList(Network.ETHEREUM, [
     underlying: "0xd11c452fc99cf405034ee446803b6f6c1f6d5ed8",
     markets: ["0xbdb8f9729d3194f75fd1a3d9bc4ffe0dde3a404c"],
     priceFeed: {
-      type: PriceFeedType.NONE
+      type: PriceFeedType.NONE,
     },
   },
   {
@@ -7702,7 +7689,7 @@ export default defineAssetList(Network.ETHEREUM, [
     underlying: "0xcd5fe23c85820f7b72d0926fc9b05b43e359b7ee",
     markets: ["0xf4cf59259d007a96c641b41621ab52c93b9691b1"],
     priceFeed: {
-      type: PriceFeedType.NONE
+      type: PriceFeedType.NONE,
     },
   },
   {
@@ -7895,7 +7882,7 @@ export default defineAssetList(Network.ETHEREUM, [
     underlying: "0x8236a87084f8b84306f72007f36f2618a5634494",
     markets: ["0x931f7ea0c31c14914a452d341bc5cb5d996be71d"],
     priceFeed: {
-      type: PriceFeedType.NONE
+      type: PriceFeedType.NONE,
     },
   },
   {
@@ -7908,7 +7895,7 @@ export default defineAssetList(Network.ETHEREUM, [
     underlying: "0x657e8c867d8b37dcc18fa4caead9c45eb088c642",
     markets: ["0x523f9441853467477b4dde653c554942f8e17162"],
     priceFeed: {
-      type: PriceFeedType.NONE
+      type: PriceFeedType.NONE,
     },
   },
   {
@@ -7921,7 +7908,7 @@ export default defineAssetList(Network.ETHEREUM, [
     underlying: "0xd9d920aa40f578ab794426f5c90f6c731d159def",
     markets: ["0xb6b2cf977c512bcd195b58e2ccfb3fb15535cb19"],
     priceFeed: {
-      type: PriceFeedType.NONE
+      type: PriceFeedType.NONE,
     },
   },
   {
@@ -7948,7 +7935,7 @@ export default defineAssetList(Network.ETHEREUM, [
     underlying: "0x80ac24aa929eaf5013f6436cda2a7ba190f5cc0b",
     markets: ["0x9a63fa80b5ddfd3cab23803fdb93ad2c18f3d5aa"],
     priceFeed: {
-      type: PriceFeedType.NONE
+      type: PriceFeedType.NONE,
     },
   },
   {
@@ -7961,7 +7948,7 @@ export default defineAssetList(Network.ETHEREUM, [
     underlying: "0x4c9edd5852cd905f086c759e8383e09bff1e68b3",
     markets: ["0x9df192d13d61609d1852461c4850595e1f56e714"],
     priceFeed: {
-      type: PriceFeedType.NONE
+      type: PriceFeedType.NONE,
     },
   },
   {
@@ -8015,7 +8002,7 @@ export default defineAssetList(Network.ETHEREUM, [
     underlying: "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
     markets: ["0x4339ffe2b7592dc783ed13cce310531ab366deac"],
     priceFeed: {
-      type: PriceFeedType.NONE
+      type: PriceFeedType.NONE,
     },
   },
   {
@@ -8028,7 +8015,7 @@ export default defineAssetList(Network.ETHEREUM, [
     underlying: "0xd9a442856c234a39a81a089c06451ebaa4306a72",
     markets: ["0x58612beb0e8a126735b19bb222cbc7fc2c162d2a"],
     priceFeed: {
-      type: PriceFeedType.NONE
+      type: PriceFeedType.NONE,
     },
   },
   {
@@ -8041,7 +8028,7 @@ export default defineAssetList(Network.ETHEREUM, [
     underlying: "0xdc035d45d973e3ec169d2276ddab16f1e407384f",
     markets: ["0xdace1121e10500e9e29d071f01593fd76b000f08"],
     priceFeed: {
-      type: PriceFeedType.NONE
+      type: PriceFeedType.NONE,
     },
   },
   {

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -6025,17 +6025,6 @@ export default defineAssetList(Network.ETHEREUM, [
     },
   },
   {
-    decimals: 18,
-    id: "0x45804880de22913dafe09f4980848ece6ecbaf78",
-    name: "Paxos Gold",
-    releases: [],
-    symbol: "PAXG",
-    type: AssetType.PRIMITIVE,
-    priceFeed: {
-      type: PriceFeedType.NONE,
-    },
-  },
-  {
     decimals: 9,
     id: "0xd31a59c85ae9d8edefec411d448f90841571b89c",
     name: "Wrapped SOL",
@@ -6678,18 +6667,6 @@ export default defineAssetList(Network.ETHEREUM, [
       type: PriceFeedType.PRIMITIVE_CHAINLINK,
       aggregator: "0x8fffffd4afb6115b954bd326cbe7b4ba576818f6",
       rateAsset: RateAsset.USD,
-    },
-  },
-  {
-    decimals: 18,
-    id: "0xa17581a9e3356d9a858b789d68b4d866e593ae94",
-    name: "Compound WETH",
-    releases: [sulu],
-    symbol: "cWETHv3",
-    type: AssetType.COMPOUND_V3,
-    underlying: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-    priceFeed: {
-      type: PriceFeedType.NONE,
     },
   },
   {
@@ -7582,19 +7559,6 @@ export default defineAssetList(Network.ETHEREUM, [
     markets: ["0xb451a36c8b6b2eac77ad0737ba732818143a0e25"],
     priceFeed: {
       type: PriceFeedType.NONE,
-    },
-  },
-  {
-    decimals: 8,
-    id: "0x657e8c867d8b37dcc18fa4caead9c45eb088c642",
-    name: "ether.fi BTC",
-    releases: [sulu],
-    symbol: "eBTC",
-    type: AssetType.PRIMITIVE,
-    priceFeed: {
-      type: PriceFeedType.PRIMITIVE_REDSTONE_QUOTED,
-      aggregator: "0xb04f255f21bc7a45ef4790deb007926e01b1f1f5",
-      rateAsset: RateAsset.ETH,
     },
   },
   {

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7440,14 +7440,12 @@ export default defineAssetList(Network.ETHEREUM, [
     name: "PT Ethena sUSDE 29MAY2025",
     id: "0xb7de5dfcb74d25c2f21841fbd6230355c50d9308",
     type: AssetType.PENDLE_V2_PT,
-    releases: [sulu],
+    releases: [],
     decimals: 18,
     underlying: "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
     markets: ["0xb162b764044697cf03617c2efbcb1f42e31e4766"],
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_PENDLE_V2,
-      aggregator: "0x52325958f2da217886e3c49e3cdbdbcf1c058a9c",
-      rateAsset: RateAsset.ETH,
+      type: PriceFeedType.NONE
     },
   },
   {
@@ -7518,13 +7516,11 @@ export default defineAssetList(Network.ETHEREUM, [
     name: "LP Ethena sUSDE 29MAY2025",
     id: "0xb162b764044697cf03617c2efbcb1f42e31e4766",
     type: AssetType.PENDLE_V2_LP,
-    releases: [sulu],
+    releases: [],
     decimals: 18,
     underlying: "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_PENDLE_V2,
-      aggregator: "0x0998a52dbf3851c8b97012cfc2acba234a413e86",
-      rateAsset: RateAsset.USD,
+      type: PriceFeedType.NONE
     },
   },
   {
@@ -7580,14 +7576,12 @@ export default defineAssetList(Network.ETHEREUM, [
     name: "PT Ethena sUSDE 29MAY2025",
     id: "0xb7de5dfcb74d25c2f21841fbd6230355c50d9308",
     type: AssetType.PENDLE_V2_PT,
-    releases: [sulu],
+    releases: [],
     decimals: 18,
     underlying: "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
     markets: ["0xb162b764044697cf03617c2efbcb1f42e31e4766"],
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_PENDLE_V2,
-      aggregator: "0x52325958f2da217886e3c49e3cdbdbcf1c058a9c",
-      rateAsset: RateAsset.ETH,
+      type: PriceFeedType.NONE
     },
   },
   {
@@ -7690,14 +7684,12 @@ export default defineAssetList(Network.ETHEREUM, [
     name: "PT Treehouse ETH 29MAY2025",
     id: "0x84d17ef6bec165484c320b852eeb294203e191be",
     type: AssetType.PENDLE_V2_PT,
-    releases: [sulu],
+    releases: [],
     decimals: 18,
     underlying: "0xd11c452fc99cf405034ee446803b6f6c1f6d5ed8",
     markets: ["0xbdb8f9729d3194f75fd1a3d9bc4ffe0dde3a404c"],
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_PENDLE_V2,
-      aggregator: "0x8cbdd4e6b5e79578f23f8216ab67777d788407d5",
-      rateAsset: RateAsset.ETH,
+      type: PriceFeedType.NONE
     },
   },
   {
@@ -7705,14 +7697,12 @@ export default defineAssetList(Network.ETHEREUM, [
     name: "PT ether.fi weETH 26JUN2025",
     id: "0xef6122835a2bbf575d0117d394fda24ab7d09d4e",
     type: AssetType.PENDLE_V2_PT,
-    releases: [sulu],
+    releases: [],
     decimals: 18,
     underlying: "0xcd5fe23c85820f7b72d0926fc9b05b43e359b7ee",
     markets: ["0xf4cf59259d007a96c641b41621ab52c93b9691b1"],
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_PENDLE_V2,
-      aggregator: "0x8dda8b784d288a8a7f073a8e20617139fca02801",
-      rateAsset: RateAsset.ETH,
+      type: PriceFeedType.NONE
     },
   },
   {
@@ -7900,14 +7890,12 @@ export default defineAssetList(Network.ETHEREUM, [
     name: "PT Lombard LBTC 26JUN2025",
     id: "0x6ca4d5d2ecb72e3bbf17543b3367746b80d22694",
     type: AssetType.PENDLE_V2_PT,
-    releases: [sulu],
+    releases: [],
     decimals: 8,
     underlying: "0x8236a87084f8b84306f72007f36f2618a5634494",
     markets: ["0x931f7ea0c31c14914a452d341bc5cb5d996be71d"],
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_PENDLE_V2,
-      aggregator: "0x0db642561beeed68b84cb7da288c03ffeea40bd0",
-      rateAsset: RateAsset.ETH,
+      type: PriceFeedType.NONE
     },
   },
   {
@@ -7915,14 +7903,12 @@ export default defineAssetList(Network.ETHEREUM, [
     name: "PT ether.fi eBTC 26JUN2025",
     id: "0xc653f79de1274ee65674befda54986020d6f8fc1",
     type: AssetType.PENDLE_V2_PT,
-    releases: [sulu],
+    releases: [],
     decimals: 8,
     underlying: "0x657e8c867d8b37dcc18fa4caead9c45eb088c642",
     markets: ["0x523f9441853467477b4dde653c554942f8e17162"],
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_PENDLE_V2,
-      aggregator: "0x5f02260dc0e6566aff2e73c7f8d293e5c6804945",
-      rateAsset: RateAsset.ETH,
+      type: PriceFeedType.NONE
     },
   },
   {
@@ -7930,14 +7916,12 @@ export default defineAssetList(Network.ETHEREUM, [
     name: "PT SolvBTC Babylon 26JUN2025",
     id: "0x4f62a7a25a4fd6ae386e957284afb5fbf1e1f32c",
     type: AssetType.PENDLE_V2_PT,
-    releases: [sulu],
+    releases: [],
     decimals: 8,
     underlying: "0xd9d920aa40f578ab794426f5c90f6c731d159def",
     markets: ["0xb6b2cf977c512bcd195b58e2ccfb3fb15535cb19"],
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_PENDLE_V2,
-      aggregator: "0x2587fb3b40e76957c73f19f258faefcc61fa18a2",
-      rateAsset: RateAsset.ETH,
+      type: PriceFeedType.NONE
     },
   },
   {
@@ -7959,14 +7943,12 @@ export default defineAssetList(Network.ETHEREUM, [
     name: "PT Syrup USDC 28AUG2025",
     id: "0xcce7d12f683c6dae700154f0badf779c0ba1f89a",
     type: AssetType.PENDLE_V2_PT,
-    releases: [sulu],
+    releases: [],
     decimals: 6,
     underlying: "0x80ac24aa929eaf5013f6436cda2a7ba190f5cc0b",
     markets: ["0x9a63fa80b5ddfd3cab23803fdb93ad2c18f3d5aa"],
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_PENDLE_V2,
-      aggregator: "0x36cd1957d93918b6f7436d33b74b958604c3d35a",
-      rateAsset: RateAsset.ETH,
+      type: PriceFeedType.NONE
     },
   },
   {
@@ -7974,14 +7956,12 @@ export default defineAssetList(Network.ETHEREUM, [
     name: "PT Ethena USDe 31JUL2025",
     id: "0x917459337caac939d41d7493b3999f571d20d667",
     type: AssetType.PENDLE_V2_PT,
-    releases: [sulu],
+    releases: [],
     decimals: 18,
     underlying: "0x4c9edd5852cd905f086c759e8383e09bff1e68b3",
     markets: ["0x9df192d13d61609d1852461c4850595e1f56e714"],
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_PENDLE_V2,
-      aggregator: "0xbdbb726d6fd1cbeec085f97d0ceeb9282e482b86",
-      rateAsset: RateAsset.ETH,
+      type: PriceFeedType.NONE
     },
   },
   {
@@ -8030,14 +8010,12 @@ export default defineAssetList(Network.ETHEREUM, [
     name: "PT Ethena sUSDE 31JUL2025",
     id: "0x3b3fb9c57858ef816833dc91565efcd85d96f634",
     type: AssetType.PENDLE_V2_PT,
-    releases: [sulu],
+    releases: [],
     decimals: 18,
     underlying: "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
     markets: ["0x4339ffe2b7592dc783ed13cce310531ab366deac"],
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_PENDLE_V2,
-      aggregator: "0x391115569cc95b788e159d287b03c13239a94276",
-      rateAsset: RateAsset.ETH,
+      type: PriceFeedType.NONE
     },
   },
   {
@@ -8045,14 +8023,12 @@ export default defineAssetList(Network.ETHEREUM, [
     name: "PT Puffer ETH 26JUN2025",
     id: "0x9cfc9917c171a384c7168d3529fc7e851a2e0d6d",
     type: AssetType.PENDLE_V2_PT,
-    releases: [sulu],
+    releases: [],
     decimals: 18,
     underlying: "0xd9a442856c234a39a81a089c06451ebaa4306a72",
     markets: ["0x58612beb0e8a126735b19bb222cbc7fc2c162d2a"],
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_PENDLE_V2,
-      aggregator: "0x08d9d0372b586096bb0d757c5af1cf1a80359661",
-      rateAsset: RateAsset.ETH,
+      type: PriceFeedType.NONE
     },
   },
   {
@@ -8060,14 +8036,12 @@ export default defineAssetList(Network.ETHEREUM, [
     name: "PT USDS Stablecoin 14AUG2025",
     id: "0xffec096c087c13cc268497b89a613cace4df9a48",
     type: AssetType.PENDLE_V2_PT,
-    releases: [sulu],
+    releases: [],
     decimals: 18,
     underlying: "0xdc035d45d973e3ec169d2276ddab16f1e407384f",
     markets: ["0xdace1121e10500e9e29d071f01593fd76b000f08"],
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_PENDLE_V2,
-      aggregator: "0x6359564ede3cc6a0aa5052b20988e04dd6773abe",
-      rateAsset: RateAsset.ETH,
+      type: PriceFeedType.NONE
     },
   },
   {

--- a/packages/environment/src/environment.ts
+++ b/packages/environment/src/environment.ts
@@ -1,6 +1,6 @@
 import type { AdapterDefinition } from "./adapters.js";
 import { getAdaptersForRelease } from "./adapters.js";
-import type { Asset } from "./assets.js";
+import type { Asset, AssetDefinition } from "./assets.js";
 import { AssetType } from "./assets.js";
 import type { VersionContracts } from "./contracts.js";
 import { Version, isVersion } from "./contracts.js";
@@ -99,6 +99,7 @@ export class Environment<TVersion extends Version = Version, TDeployment extends
   public readonly knownAddressLists: KnownAddressListIdMapping<TDeployment>;
   public readonly knownUintLists: KnownUintListIdMapping<TDeployment>;
   public readonly assets: Record<Address, Asset> = {};
+  public readonly assetsDefinition: Array<AssetDefinition> = [];
   public readonly adapters: Record<string, AdapterDefinition> = {};
   public readonly namedTokens: DeploymentNamedAssetsTokens<TDeployment>;
 
@@ -149,6 +150,8 @@ export class Environment<TVersion extends Version = Version, TDeployment extends
 
     const network = deployment.network;
     const assets = deployment.assets.filter((asset) => asset.network === network);
+
+    this.assetsDefinition = assets;
 
     this.release = release;
     this.contracts = release.contracts;

--- a/packages/environment/test/assets/token.test.ts
+++ b/packages/environment/test/assets/token.test.ts
@@ -9,7 +9,7 @@ import { environment } from "../utils/fixtures.js";
 
 const client = getClient(environment.network.id);
 
-const assets = environment.getAssets();
+const assets = environment.assetsDefinition;
 
 suite.each(assets)("$symbol ($name): $id", (asset) => {
   test("defined decimals matches on-chain decimals", async () => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on unregistering expired Pendle assets and restructuring the `environment` package to use `assetsDefinition` instead of `getAssets`. It also updates asset definitions to remove outdated Pendle asset entries.

### Detailed summary
- Added `assetsDefinition` property to the `Environment` class.
- Updated `token.test.ts` to use `assetsDefinition`.
- Removed multiple expired Pendle asset definitions from `ethereum.ts`.
- Updated price feeds for some assets to `PriceFeedType.NONE`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->