### PR TITLE
feat: add reUSD asset to Ethereum for Votium

### DIFF
--- a/.changeset/fair-cougars-pay.md
+++ b/.changeset/fair-cougars-pay.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+add reUSD asset to ethereum for votium

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -8018,4 +8018,15 @@ export default defineAssetList(Network.ETHEREUM, [
       address: "0x66aa5b2fdfb453f8a27f9bd1d9124947ef3886bb",
     },
   },
+  {
+    symbol: "reUSD",
+    name: "Resupply USD",
+    id: "0x57ab1e0003f623289cd798b1824be09a793e4bec",
+    type: AssetType.PRIMITIVE,
+    releases: [],
+    decimals: 18,
+    priceFeed: {
+      type: PriceFeedType.NONE,
+    },
+  },
 ]);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new asset, `reUSD`, to the Ethereum environment for use in the Votium platform.

### Detailed summary
- Added `reUSD` asset with the following properties:
  - `symbol`: "reUSD"
  - `name`: "Resupply USD"
  - `id`: "0x57ab1e0003f623289cd798b1824be09a793e4bec"
  - `type`: `AssetType.PRIMITIVE`
  - `releases`: []
  - `decimals`: 18
  - `priceFeed`: `PriceFeedType.NONE`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->