### PR TITLE
feat: deregister USR and wstUSR assets on Ethereum

### DIFF
--- a/.changeset/fast-llamas-dream.md
+++ b/.changeset/fast-llamas-dream.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+deregister USR and wstUSR assets on ethereum

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7467,13 +7467,11 @@ export default defineAssetList(Network.ETHEREUM, [
     decimals: 18,
     id: "0x66a1e37c9b0eaddca17d3662d6c05f4decf3e110",
     name: "Resolv USD",
-    releases: [sulu],
+    releases: [],
     symbol: "USR",
     type: AssetType.PRIMITIVE,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_REDSTONE,
-      aggregator: "0x107dd3391a6357248f2093698014e7c6130779ee",
-      rateAsset: RateAsset.USD,
+      type: PriceFeedType.NONE,
     },
   },
   {
@@ -7482,13 +7480,11 @@ export default defineAssetList(Network.ETHEREUM, [
     id: "0x1202f5c7b4b9e47a1a484e8b270be34dbbc75055",
     type: AssetType.ERC_4626,
     protocol: Erc4626Protocol.RESOLV,
-    releases: [sulu],
+    releases: [],
     decimals: 18,
     underlying: "0x66a1e37c9b0eaddca17d3662d6c05f4decf3e110",
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE,
-      aggregator: "0xe825080d444aa2772ece2648b48c320f8ddfbe62",
-      rateAsset: RateAsset.ETH,
+      type: PriceFeedType.NONE,
     },
   },
   {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on deregistering the `USR` and `wstUSR` assets on the Ethereum network and updating their associated properties in the asset definitions.

### Detailed summary
- Removed `releases` array for the `USR` asset and set it to an empty array.
- Changed `priceFeed` type for the `USR` asset from `PriceFeedType.PRIMITIVE_REDSTONE` to `PriceFeedType.NONE`.
- Removed `releases` array for the `wstUSR` asset and set it to an empty array.
- Changed `priceFeed` type for the `wstUSR` asset from `PriceFeedType.PRIMITIVE_CHAINLINK_LIKE` to `PriceFeedType.NONE`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->