### PR TITLE
chore: update GatedRedemptionQueueSharesWrapperLib

### DIFF
--- a/.changeset/blue-rocks-run.md
+++ b/.changeset/blue-rocks-run.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Update GatedRedemptionQueueSharesWrapper

--- a/packages/environment/src/deployments/ethereum.ts
+++ b/packages/environment/src/deployments/ethereum.ts
@@ -175,7 +175,7 @@ export default defineDeployment<Deployment.ETHEREUM>({
         GasRelayPaymasterFactory: "0x846bbe1925047023651de7ec289f329c24ded3a8",
         GasRelayPaymasterLib: "0x131c220c18874e32abbe945eb8aa998b84f63625",
         GatedRedemptionQueueSharesWrapperFactory: "0x73b9c40530311b49b526f230d01bdf5725b3290d",
-        GatedRedemptionQueueSharesWrapperLib: "0xe971375e3e8af54232f9b7c88cce143edf95c272",
+        GatedRedemptionQueueSharesWrapperLib: "0xbb8401cbdd96174762ae451039595d934cb61357",
         GenericAdapter: "0x0000000000000000000000000000000000000000",
         GlobalConfigLib: "0x6682e70860d48a039f52daccda917250349a3fb3",
         GlobalConfigProxy: "0x5611df74a77efd198de5fc7f83a482dcfe0c7a7a",

--- a/packages/environment/src/deployments/polygon.ts
+++ b/packages/environment/src/deployments/polygon.ts
@@ -159,7 +159,7 @@ export default defineDeployment<Deployment.POLYGON>({
         GasRelayPaymasterFactory: "0xed05786ef7b5e5bf909512f0ad46eb8f22cdc4ca",
         GasRelayPaymasterLib: "0x190e7045caeb09459bba12bced1d133e10d63715",
         GatedRedemptionQueueSharesWrapperFactory: "0x7a68d541af898c14fbd5ecbda3b402b18d8c17d4",
-        GatedRedemptionQueueSharesWrapperLib: "0x9932120518b25e35d4653a8b8d316c58c8b6d7c9",
+        GatedRedemptionQueueSharesWrapperLib: "0xe6ae7ba4224a40adb10d2eac2fa7b1e5a069586f",
         GenericAdapter: "0x0000000000000000000000000000000000000000",
         GlobalConfigLib: "0xcbbd50255cf49797badb28ce625a4ea217c67a64",
         GlobalConfigProxy: "0x905448cb27f51d9a663fb18d57d76c49d19be837",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the deployment configurations for the `GatedRedemptionQueueSharesWrapperLib` in both the `polygon.ts` and `ethereum.ts` files, reflecting new contract addresses.

### Detailed summary
- Updated `GatedRedemptionQueueSharesWrapperLib` address in `packages/environment/src/deployments/polygon.ts` from `0x9932120518b25e35d4653a8b8d316c58c8b6d7c9` to `0xe6ae7ba4224a40adb10d2eac2fa7b1e5a069586f`.
- Updated `GatedRedemptionQueueSharesWrapperLib` address in `packages/environment/src/deployments/ethereum.ts` from `0xe971375e3e8af54232f9b7c88cce143edf95c272` to `0xbb8401cbdd96174762ae451039595d934cb61357`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->