### PR TITLE
chore: remove bCOIN

### DIFF
--- a/.changeset/sharp-insects-care.md
+++ b/.changeset/sharp-insects-care.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Remove bCOIN

--- a/packages/environment/src/assets/base.ts
+++ b/packages/environment/src/assets/base.ts
@@ -295,25 +295,18 @@ export default defineAssetList(Network.BASE, [
     releases: [sulu],
     type: AssetType.PRIMITIVE,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0xfb2487ee6e6a1f51d31e64d969c9f437235633f0",
-      rateAsset: RateAsset.USD,
-      nonStandard: true,
+      type: PriceFeedType.NONE,
     },
   },
   {
     symbol: "wbCOIN",
     name: "Wrapped Backed Coinbase Global",
     id: "0xdec933e2392ad908263e70a386fbf34e703ffe8f",
-    type: AssetType.ERC_4626,
-    protocol: Erc4626Protocol.BCOIN,
+    type: AssetType.PRIMITIVE,
     releases: [sulu],
     decimals: 18,
-    underlying: "0xbbcb0356bb9e6b3faa5cbf9e5f36185d53403ac9",
     priceFeed: {
-      type: PriceFeedType.DERIVATIVE_ERC4626,
-      address: "0x6889790fb10a03bbf9dc86f1bed3219b509f5367",
-      nonStandard: true,
+      type: PriceFeedType.NONE,
     },
   },
   {

--- a/packages/environment/src/assets/base.ts
+++ b/packages/environment/src/assets/base.ts
@@ -292,7 +292,7 @@ export default defineAssetList(Network.BASE, [
     name: "Backed Coinbase Global",
     symbol: "bCOIN",
     decimals: 18,
-    releases: [sulu],
+    releases: [],
     type: AssetType.PRIMITIVE,
     priceFeed: {
       type: PriceFeedType.NONE,
@@ -303,7 +303,7 @@ export default defineAssetList(Network.BASE, [
     name: "Wrapped Backed Coinbase Global",
     id: "0xdec933e2392ad908263e70a386fbf34e703ffe8f",
     type: AssetType.PRIMITIVE,
-    releases: [sulu],
+    releases: [],
     decimals: 18,
     priceFeed: {
       type: PriceFeedType.NONE,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on the removal of the `bCOIN` asset and updates related to the `wbCOIN` asset, simplifying the asset definitions and their associated properties.

### Detailed summary
- Removed the `bCOIN` asset definition.
- Updated `wbCOIN` asset:
  - Changed `type` from `AssetType.ERC_4626` to `AssetType.PRIMITIVE`.
  - Cleared the `releases` array.
  - Changed `priceFeed` type from `PriceFeedType.DERIVATIVE_ERC4626` to `PriceFeedType.NONE`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->