### PR TITLE
chore: de-register rsETH

### DIFF
--- a/.changeset/sixty-rice-listen.md
+++ b/.changeset/sixty-rice-listen.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+De-register rsETH

--- a/packages/environment/src/assets/arbitrum.ts
+++ b/packages/environment/src/assets/arbitrum.ts
@@ -151,13 +151,11 @@ export default defineAssetList(Network.ARBITRUM, [
     decimals: 18,
     id: "0x4186bfc76e2e237523cbc30fd220fe055156b41f",
     name: "KelpDao Restaked ETH",
-    releases: [sulu],
+    releases: [],
     symbol: "rsETH",
     type: AssetType.PRIMITIVE,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0xb0ea543f9f8d4b818550365d13f66da747e1476a",
-      rateAsset: RateAsset.ETH,
+      type: PriceFeedType.NONE,
     },
   },
   {

--- a/packages/environment/src/assets/base.ts
+++ b/packages/environment/src/assets/base.ts
@@ -208,13 +208,11 @@ export default defineAssetList(Network.BASE, [
     decimals: 18,
     id: "0x1bc71130a0e39942a7658878169764bbd8a45993",
     name: "KelpDao Restaked ETH",
-    releases: [sulu],
+    releases: [],
     symbol: "rsETH",
     type: AssetType.PRIMITIVE,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0xd7221b10fbbc1e1ba95fd0b4d031c15f7f365296",
-      rateAsset: RateAsset.ETH,
+      type: PriceFeedType.NONE,
     },
   },
   {

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -3348,13 +3348,11 @@ export default defineAssetList(Network.ETHEREUM, [
     decimals: 18,
     id: "0xa1290d69c65a6fe4df752f95823fae25cb99e5a7",
     name: "rsETH",
-    releases: [sulu],
+    releases: [],
     symbol: "rsETH",
     type: AssetType.PRIMITIVE,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_REDSTONE_NON_STANDARD_PRECISION,
-      aggregator: "0xf387707bc4df894607a93f83d58a835cacd370f1",
-      rateAsset: RateAsset.ETH,
+      type: PriceFeedType.NONE,
     },
   },
   {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on de-registering `rsETH` across different asset files in the environment package by updating the `releases` field to an empty array and changing the `priceFeed` type to `PriceFeedType.NONE`.

### Detailed summary
- Removed `rsETH` from the `releases` array in:
  - `packages/environment/src/assets/base.ts`
  - `packages/environment/src/assets/arbitrum.ts`
  - `packages/environment/src/assets/ethereum.ts`
- Changed `priceFeed` type to `PriceFeedType.NONE` in all mentioned files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->