### PR TITLE
feat: udpate tx decode of bebop tx

### DIFF
--- a/.changeset/spicy-mice-cough.md
+++ b/.changeset/spicy-mice-cough.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/sdk": patch
+---
+
+Update decoding args of bebop tx data

--- a/biome.json
+++ b/biome.json
@@ -4,6 +4,7 @@
   },
   "files": {
     "ignore": [
+      ".zed",
       ".direnv",
       "dist",
       "build",

--- a/packages/sdk/src/Portfolio/Integrations/BebopBlend.ts
+++ b/packages/sdk/src/Portfolio/Integrations/BebopBlend.ts
@@ -142,6 +142,7 @@ const bebopSwapSingleAbi = [
   {
     name: "swapSingle",
     type: "function",
+    stateMutability: "nonpayable",
     inputs: [
       {
         name: "order",
@@ -175,28 +176,15 @@ const bebopSwapSingleAbi = [
 ] as const;
 
 /**
- * Decode the maker's signature from the Bebop settlement contract calldata.
- * Uses proper ABI decoding to extract the signature struct.
+ * Decode the args from the Bebop settlement contract calldata.
  * Reference: https://docs.bebop.xyz/bebop/smart-contracts/pmm-rfq-smart-contract
  */
-export function decodeMakerSignatureFromTxData(txData: Hex): { signatureBytes: Hex; flags: bigint } {
-  const decoded = decodeFunctionData({
-    abi: bebopSwapSingleAbi,
-    data: txData,
-  });
+ export function decodeSwapSingleFromTxData(txData: Hex) {
+   const { args } = decodeFunctionData({
+     abi: bebopSwapSingleAbi,
+     data: txData,
+   });
 
-  if (decoded.functionName !== "swapSingle") {
-    throw new Error(`Unexpected function: ${decoded.functionName}`);
-  }
-
-  if (!decoded.args || decoded.args.length < 2) {
-    throw new Error("Missing args in decoded function data");
-  }
-
-  const makerSignature = decoded.args[1] as { signatureBytes: Hex; flags: bigint };
-
-  return {
-    signatureBytes: makerSignature.signatureBytes,
-    flags: makerSignature.flags,
-  };
-}
+   const [order, makerSignature, filledTakerAmount] = args;
+   return { order, makerSignature, filledTakerAmount };
+ }

--- a/packages/sdk/src/Portfolio/Integrations/BebopBlend.ts
+++ b/packages/sdk/src/Portfolio/Integrations/BebopBlend.ts
@@ -179,12 +179,12 @@ const bebopSwapSingleAbi = [
  * Decode the args from the Bebop settlement contract calldata.
  * Reference: https://docs.bebop.xyz/bebop/smart-contracts/pmm-rfq-smart-contract
  */
- export function decodeSwapSingleFromTxData(txData: Hex) {
-   const { args } = decodeFunctionData({
-     abi: bebopSwapSingleAbi,
-     data: txData,
-   });
+export function decodeSwapSingleFromTxData(txData: Hex) {
+  const { args } = decodeFunctionData({
+    abi: bebopSwapSingleAbi,
+    data: txData,
+  });
 
-   const [order, makerSignature, filledTakerAmount] = args;
-   return { order, makerSignature, filledTakerAmount };
- }
+  const [order, makerSignature, filledTakerAmount] = args;
+  return { order, makerSignature, filledTakerAmount };
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the decoding function for Bebop transaction data by renaming it and modifying its implementation to handle new arguments. It enhances clarity and functionality in processing transaction data.

### Detailed summary
- Updated `decodeMakerSignatureFromTxData` to `decodeSwapSingleFromTxData`.
- Changed the function to decode arguments from the Bebop settlement contract calldata.
- Modified the return structure to include `order`, `makerSignature`, and `filledTakerAmount`.
- Removed checks for function name and argument length.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->