### PR TITLE
feat: deregister solvBTC, xSolvBTC on Ethereum and FXS, KNC, BAT on Polygon

### DIFF
--- a/.changeset/shaggy-adults-shave.md
+++ b/.changeset/shaggy-adults-shave.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+deregister solvBTC, xSolvBTC on ethereum, FXS, KNC and BAT on polygon

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -7145,12 +7145,10 @@ export default defineAssetList(Network.ETHEREUM, [
     name: "Solv BTC",
     id: "0x7a56e1c57c7475ccf742a1832b028f0456652f97",
     type: AssetType.PRIMITIVE,
-    releases: [sulu],
+    releases: [],
     decimals: 18,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_REDSTONE,
-      aggregator: "0x24c8964338deb5204b096039147b8e8c3aea42cc",
-      rateAsset: RateAsset.USD,
+      type: PriceFeedType.NONE,
     },
   },
   {
@@ -7158,12 +7156,10 @@ export default defineAssetList(Network.ETHEREUM, [
     name: "xSolvBTC",
     id: "0xd9d920aa40f578ab794426f5c90f6c731d159def",
     type: AssetType.PRIMITIVE,
-    releases: [sulu],
+    releases: [],
     decimals: 18,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK_LIKE,
-      aggregator: "0xe16a36e1ae4538a579b5a249d042943b90878ef1",
-      rateAsset: RateAsset.USD,
+      type: PriceFeedType.NONE,
     },
   },
   {

--- a/packages/environment/src/assets/polygon.ts
+++ b/packages/environment/src/assets/polygon.ts
@@ -297,13 +297,11 @@ export default defineAssetList(Network.POLYGON, [
     decimals: 18,
     id: "0x1a3acf6d19267e2d3e7f898f42803e90c9219062",
     name: "Frax Share",
-    releases: [polygon.sulu, testnet.sulu],
+    releases: [testnet.sulu],
     symbol: "FXS",
     type: AssetType.PRIMITIVE,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0x6c0fe985d3cacbcde428b84fc9431792694d0f51",
-      rateAsset: RateAsset.USD,
+      type: PriceFeedType.NONE,
     },
   },
   {
@@ -323,13 +321,11 @@ export default defineAssetList(Network.POLYGON, [
     decimals: 18,
     id: "0x1c954e8fe737f99f68fa1ccda3e51ebdb291948c",
     name: "Kyber Network Crystal v2 (PoS)",
-    releases: [polygon.sulu, testnet.sulu],
+    releases: [testnet.sulu],
     symbol: "KNC",
     type: AssetType.PRIMITIVE,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0x10e5f3dfc81b3e5ef4e648c4454d04e79e1e41e2",
-      rateAsset: RateAsset.USD,
+      type: PriceFeedType.NONE,
     },
   },
   {
@@ -575,13 +571,11 @@ export default defineAssetList(Network.POLYGON, [
     decimals: 18,
     id: "0x3cef98bb43d732e2f285ee605a8158cde967d219",
     name: "Basic Attention Token (PoS)",
-    releases: [polygon.sulu, testnet.sulu],
+    releases: [testnet.sulu],
     symbol: "BAT",
     type: AssetType.PRIMITIVE,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0x2346ce62bd732c62618944e51cbfa09d985d86d2",
-      rateAsset: RateAsset.USD,
+      type: PriceFeedType.NONE,
     },
   },
   {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the asset definitions for `solvBTC`, `xSolvBTC`, `Frax Share`, `Kyber Network Crystal v2`, and `Basic Attention Token` by removing the `releases` array and changing the `priceFeed` type to `PriceFeedType.NONE`.

### Detailed summary
- Removed `releases` from `solvBTC` and `xSolvBTC`.
- Changed `priceFeed` type to `PriceFeedType.NONE` for `solvBTC` and `xSolvBTC`.
- Updated `releases` for `Frax Share`, `Kyber Network Crystal v2`, and `Basic Attention Token` to only include `testnet.sulu`.
- Changed `priceFeed` type to `PriceFeedType.NONE` for `Frax Share`, `Kyber Network Crystal v2`, and `Basic Attention Token`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Solv BTC and xSolv BTC support on Ethereum
  * Removed FXS, KNC, and BAT support on Polygon
  * Disabled price feed support for deregistered assets

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enzymefinance/sdk/pull/892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->