### PR TITLE
chore: change sUSD token name

### DIFF
--- a/.changeset/eighty-pandas-impress.md
+++ b/.changeset/eighty-pandas-impress.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+Change token name

--- a/packages/environment/src/assets/ethereum.ts
+++ b/packages/environment/src/assets/ethereum.ts
@@ -1958,7 +1958,7 @@ export default defineAssetList(Network.ETHEREUM, [
   {
     decimals: 18,
     id: "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
-    name: "Synth sUSD",
+    name: "Synth sUSD (retired)",
     releases: [sulu, encore],
     symbol: "sUSD",
     type: AssetType.PRIMITIVE,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the token name associated with a specific asset in the Ethereum environment configuration.

### Detailed summary
- Updated the `name` of the asset from `"Synth sUSD"` to `"Synth sUSD (retired)"` in the `packages/environment/src/assets/ethereum.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the displayed name of the Ethereum asset “Synth sUSD” to “Synth sUSD (retired)” for clearer labeling.
* **Chores**
  * Added a patch release note to capture the asset name change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->