### PR TITLE
chore: deregister FRAX asset on Polygon

### DIFF
--- a/.changeset/fifty-games-sell.md
+++ b/.changeset/fifty-games-sell.md
@@ -1,0 +1,5 @@
+---
+"@enzymefinance/environment": patch
+---
+
+deregister FRAX on polygon

--- a/.github/workflows/reusable-verify.yaml
+++ b/.github/workflows/reusable-verify.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Install foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
       - name: Run tests

--- a/.github/workflows/reusable-verify.yaml
+++ b/.github/workflows/reusable-verify.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Install foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: nightly
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
       - name: Run tests

--- a/packages/environment/src/assets/polygon.ts
+++ b/packages/environment/src/assets/polygon.ts
@@ -658,13 +658,11 @@ export default defineAssetList(Network.POLYGON, [
     decimals: 18,
     id: "0x45c32fa6df82ead1e2ef74d17b76547eddfaff89",
     name: "Frax",
-    releases: [polygon.sulu, testnet.sulu],
+    releases: [testnet.sulu],
     symbol: "FRAX",
     type: AssetType.PRIMITIVE,
     priceFeed: {
-      type: PriceFeedType.PRIMITIVE_CHAINLINK,
-      aggregator: "0x00dbeb1e45485d53df7c2f0df1aa0b6dc30311d3",
-      rateAsset: RateAsset.USD,
+      type: PriceFeedType.NONE,
     },
   },
   {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deregistered FRAX from the Polygon production environment.
  * Removed FRAX’s Polygon production price feed support while retaining FRAX support on the Polygon testnet.
* **Chores**
  * Updated the verification workflow to use the stable toolchain for running checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->